### PR TITLE
[v2.1.2][Bug] Packaged PDF import repair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "onestep-money",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
+        "@napi-rs/canvas": "^1.0.3",
         "electron-updater": "^6.8.9",
         "pdfjs-dist": "^6.2.108"
       },
@@ -173,7 +174,6 @@
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.3.tgz",
       "integrity": "sha512-OlI657a5XXvKGFX7kNeIzJ8rO7IXt87Mqu2H8rXE46viAuOfum/JA7ysX7+eBhxNKznT+RCZh418mndlcFX3+w==",
       "license": "MIT",
-      "optional": true,
       "workspaces": [
         "e2e/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",
@@ -26,6 +26,7 @@
     "release:win": "electron-builder --win nsis --publish always"
   },
   "dependencies": {
+    "@napi-rs/canvas": "^1.0.3",
     "electron-updater": "^6.8.9",
     "pdfjs-dist": "^6.2.108"
   },

--- a/pdf-service.js
+++ b/pdf-service.js
@@ -1,6 +1,24 @@
 import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export function installPdfCompatibilityGlobals() {
+  if (typeof globalThis.DOMMatrix === 'function') return;
+
+  // PDF.js creates a DOMMatrix while its Node bundle is loading, even when we
+  // only extract text. Loading the pure-JavaScript geometry module directly
+  // keeps PDF imports working if the optional native canvas binding cannot be
+  // loaded in a packaged Electron app.
+  const { DOMMatrix } = require('@napi-rs/canvas/geometry');
+  if (typeof DOMMatrix !== 'function') {
+    throw new Error('The PDF compatibility layer is unavailable. Reinstall OneStep Money.');
+  }
+  globalThis.DOMMatrix = DOMMatrix;
+}
 
 export async function extractPdfDocument(filePath) {
+  installPdfCompatibilityGlobals();
   const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
   const bytes = await fs.readFile(filePath);
   const loadingTask = pdfjs.getDocument({

--- a/tests/pdf-service.test.js
+++ b/tests/pdf-service.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { installPdfCompatibilityGlobals } from '../pdf-service.js';
+
+test('PDF compatibility installs DOMMatrix without loading the native canvas binding', () => {
+  const original = globalThis.DOMMatrix;
+  try {
+    delete globalThis.DOMMatrix;
+    installPdfCompatibilityGlobals();
+    assert.equal(typeof globalThis.DOMMatrix, 'function');
+    const matrix = new globalThis.DOMMatrix([1, 0, 0, 1, 12, 34]);
+    assert.equal(matrix.e, 12);
+    assert.equal(matrix.f, 34);
+  } finally {
+    if (original) globalThis.DOMMatrix = original;
+    else delete globalThis.DOMMatrix;
+  }
+});


### PR DESCRIPTION
## What changed

- install a `DOMMatrix` compatibility global before loading PDF.js in Electron's Node process
- make `@napi-rs/canvas` a required packaged dependency and use its pure-JavaScript geometry module
- add a regression test that proves the compatibility layer works without loading the native canvas binding
- bump the application version from 2.1.1 to 2.1.2

## Why

All PDF imports failed in the packaged Windows app with `DOMMatrix is not defined`. PDF.js referenced the browser API while loading inside Electron's Node process, and its optional compatibility package was not guaranteed to survive packaging.

## User impact

Bank statements and payslips can be imported again without installing extra software. The change is local-only and does not add telemetry, network access, or changes to stored financial data.

## Validation

- `npm test`: 17/17 passed
- `npm run check`: project and privacy checks passed
- four existing PDF fixtures imported successfully through the exact branch source
- Windows Electron packaging completed and the generated `app.asar` was verified to contain and execute the compatibility module
- NSIS installer wrapping could not complete in this Linux runtime because Wine is unavailable
- graphical Electron launch could not be repeated in this runtime because its D-Bus/display access is restricted