### PR TITLE
[v2.1.3][Bug] Data-driven reporting month selector

### DIFF
--- a/finance-core.js
+++ b/finance-core.js
@@ -20,6 +20,20 @@ export function createId(prefix = 'item') {
   return `${prefix}-${id}`;
 }
 
+export function availableReportingMonths(state = {}, fallbackMonth = state.settings?.selectedMonth || currentMonth()) {
+  const months = new Set();
+  for (const transaction of state.transactions || []) {
+    const month = reportingMonth(transaction.budgetMonth) || reportingMonth(transaction.date);
+    if (month) months.add(month);
+  }
+  for (const payslip of state.payslips || []) {
+    const month = reportingMonth(payslip.period) || reportingMonth(payslip.payDate);
+    if (month) months.add(month);
+  }
+  if (months.size) return [...months].sort().reverse();
+  return [reportingMonth(fallbackMonth) || currentMonth()];
+}
+
 export function periodTransactions(transactions, month) {
   return (transactions || []).filter((transaction) => String(transaction.budgetMonth || transaction.date || '').slice(0, 7) === month);
 }
@@ -238,6 +252,11 @@ function isBlankState(state) {
 
 function currentMonth() {
   return new Date().toISOString().slice(0, 7);
+}
+
+function reportingMonth(value) {
+  const month = String(value || '').slice(0, 7);
+  return /^\d{4}-(0[1-9]|1[0-2])$/.test(month) ? month : '';
 }
 
 function exactTransactionKey(item) {

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -1,5 +1,5 @@
 import {
-  buildFallbackAnswer, buildFinancialChecks, buildNextAction, calculateBudgetRows,
+  availableReportingMonths, buildFallbackAnswer, buildFinancialChecks, buildNextAction, calculateBudgetRows,
   calculatePeriodSummary, calculateStreak, createId, debtPlan, exportTransactionsCsv,
   findDuplicateCandidates, findSavingsOpportunities, formatCurrency, formatDate
 } from './finance-core.js';
@@ -93,6 +93,7 @@ function selectView(name) {
 }
 
 function render() {
+  populateMonthOptions();
   const month = state.settings.selectedMonth;
   const summary = calculatePeriodSummary(state, month);
   pendingAction = buildNextAction(state);
@@ -641,13 +642,22 @@ async function deleteDiagnostics() {
 }
 
 async function saveAndRender() { await saveState(); render(); }
-async function saveState() { state = await window.financeAPI.saveState(state); }
+async function saveState() {
+  synchroniseSelectedMonth();
+  state = await window.financeAPI.saveState(state);
+}
 
 function populateMonthOptions() {
-  const months = [...new Set([...state.transactions.map((item) => String(item.budgetMonth || item.date).slice(0, 7)), ...state.payslips.map((item) => item.period), state.settings.selectedMonth].filter(Boolean))].sort().reverse();
+  const months = synchroniseSelectedMonth();
   const select = byId('monthSelect'); clear(select);
   for (const month of months) { const option = document.createElement('option'); option.value = month; option.textContent = monthLabel(month); select.append(option); }
   select.value = state.settings.selectedMonth;
+}
+
+function synchroniseSelectedMonth() {
+  const months = availableReportingMonths(state);
+  if (!months.includes(state.settings.selectedMonth)) state.settings.selectedMonth = months[0];
+  return months;
 }
 
 function populateAccountOptions() {

--- a/tests/finance-core.test.js
+++ b/tests/finance-core.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  buildFinancialChecks, buildNextAction, calculateBudgetRows, calculatePeriodSummary, debtPlan, exportTransactionsCsv,
+  availableReportingMonths, buildFinancialChecks, buildNextAction, calculateBudgetRows, calculatePeriodSummary, debtPlan, exportTransactionsCsv,
   findDuplicateCandidates, formatCurrency, matchInternalTransfers
 } from '../finance-core.js';
 
@@ -13,6 +13,26 @@ const baseState = () => ({
 
 test('currency uses UK pounds', () => {
   assert.equal(formatCurrency(1234.56), '£1,234.56');
+});
+
+test('reporting months come only from dated financial records and leave gaps missing', () => {
+  const state = baseState();
+  state.settings.selectedMonth = '2025-08';
+  state.transactions = [
+    { date: '2025-04-03' },
+    { budgetMonth: '2025-06', date: '2025-05-31' },
+    { budgetMonth: 'not-a-month', date: '2025-03-20' },
+    { date: 'not-a-date' }
+  ];
+  state.payslips = [{ period: '2025-01' }, { period: '2025-13', payDate: '2025-02-28' }];
+
+  assert.deepEqual(availableReportingMonths(state), ['2025-06', '2025-04', '2025-03', '2025-02', '2025-01']);
+});
+
+test('reporting months retain a usable selected-month fallback when there is no dated data', () => {
+  const state = baseState();
+  state.settings.selectedMonth = '2025-08';
+  assert.deepEqual(availableReportingMonths(state), ['2025-08']);
 });
 
 test('a blank installation gives one onboarding action without example finance data', () => {


### PR DESCRIPTION
### Purpose

Fix the reporting month selector so it reflects months that actually contain dated transaction or payslip data. This addresses the case where an April statement was imported but only the previously selected August remained available, and ensures skipped months are not invented.

### Work completed

- Added one shared reporting-month calculation based on valid transaction `budgetMonth`/date values and payslip period/pay-date values.
- Made reporting months unique, sorted newest first, and restricted to valid `YYYY-MM` values.
- Ensured missing months stay absent; the selector does not generate a continuous range between dated records.
- Removed the behaviour that forced a previously selected month into the options when that month had no dated financial records.
- Preserved a single usable fallback month only when the application contains no dated transaction or payslip data at all.
- Rebuilt the selector during every render, including immediately after confirming an import.
- Synchronised an unavailable selected month to the newest available data month before state saves.
- Added regression tests covering April data, deliberately skipped months, invalid dates, payslip dates, sorting, and the empty-data fallback.

### Files changed

- `finance-core.js` — added `availableReportingMonths` and strict reporting-month normalisation so the selector has one tested source of truth.
- `renderer-app.js` — now refreshes month options on render and synchronises `settings.selectedMonth` to an available data month before saving.
- `tests/finance-core.test.js` — added regression coverage proving dated months appear, gaps remain absent, invalid values are ignored, and an empty installation remains usable.

### User-facing changes

- April becomes selectable as soon as April-dated statement transactions or payslip data are imported.
- If the data contains January, April, and June, only January, April, and June are offered; February, March, and May are not fabricated.
- If the previously selected month has no data, the app moves to the newest month that does.
- A completely empty installation still shows one fallback reporting month so the interface remains usable.

### Technical changes

- Month discovery is now centralised in a pure finance-core helper rather than assembled directly in the renderer.
- Transaction `budgetMonth` is used when valid, with the transaction date as a fallback.
- Payslip period is used when valid, with pay date as a fallback.
- No dependencies were added, removed, or updated.
- No database schema, storage format, import format, document-vault, logging, networking, analytics, or privacy behaviour changed.

### Testing and verification

- `npm ci` — passed; installed the exact locked dependency set.
- `npm test` — passed: 23 tests, 0 failures.
- New reporting-month regression tests — passed.
- `npm run check` — passed, including the project structure and privacy checks.
- `node --check finance-core.js && node --check renderer-app.js` — passed.
- Electron desktop capture/start attempt — could not complete because this container has no graphical display; Electron stopped at GTK display initialisation.
- `npm run dist:win` — application packaging reached `dist/win-unpacked`; the final NSIS installer step could not run because Wine is not installed in this Linux environment.

### Data and migration impact

No schema or migration is required. Existing transactions, payslips, accounts, documents, databases, and imported files are unchanged. Only `settings.selectedMonth` may be corrected to an actually available reporting month on the next save when its previous value has no dated data. Existing financial records are not rewritten.

### Known limitations

- A manual Electron desktop interaction check could not be completed in this headless container.
- The final Windows NSIS installer could not be produced here because Wine is unavailable; Windows application files were packaged successfully before that environment dependency was reached.
- When there are no dated transactions or payslips anywhere, one fallback month remains visible so the rest of the interface has a valid reporting period.

### Excluded work

- No continuous calendar range or empty-month options were added.
- No changes were made to statement or payslip parsing.
- No broader budget, transaction, debt, overdraft, document, or UI redesign work was included.
- No version bump or release was created.

### Branch details

* Branch: `fix/data-driven-month-selector`
* Commit SHA: `20488edc1fc0a40e9f0f5f150e74d3a8c831d2a9`
* Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/4
* Target branch: `main`

### Confirmations

* No changes were committed or pushed directly to `main`.
* The pull request has not been merged.
* No personal financial data, imported documents, credentials, secrets, or sensitive logs were committed.
* Only files relevant to the requested work were changed.