### PR TITLE
[Superseded][Feature] Automated financial imports and UI refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ New installations start completely blank. This repository contains no personal a
 
 - Gives one small immediate action instead of a crowded to-do list.
 - Imports bank statements with a review step before saving records.
+- Synchronises reconciled statement balances and keeps linked overdraft usage up to date automatically.
+- Imports PDF credit reports, updates matched borrowing and adds newly reported debts or overdrafts without duplicating tracked accounts.
 - Separates debts from overdrafts while comparing both safely in payoff forecasts.
 - Tracks gross pay, PAYE, National Insurance, other deductions and net pay from supported payslips.
 - Stores imported originals in an encrypted local document vault.
@@ -26,17 +28,24 @@ New installations start completely blank. This repository contains no personal a
 
 Bank statements:
 
-- CSV with signed amounts or separate debit and credit columns
+- CSV, TSV and semicolon-delimited exports, including common UK-bank headings and optional preamble rows
 - QIF
-- OFX
+- OFX and QFX
 - JSON transaction arrays
-- PDF layouts currently recognised for Nationwide, Halifax and Monzo
+- PDF layouts recognised for Nationwide, Halifax, Lloyds, Bank of Scotland and Monzo
+- Conservative fallback for accessible PDFs with labelled Date, Description and Amount or Money In/Money Out columns
 
 Payslips:
 
 - JPA E017 PDF payslips
 
-Unrecognised layouts are rejected visibly. Invalid dates and amounts are never silently replaced with zero or today's date.
+Credit reports:
+
+- PDF reports from Experian, ClearScore, Credit Karma, TransUnion, Equifax and TotallyMoney
+- Clearly labelled provider, report date, score, lender, balance, limit, payment, APR, status and account-date fields are extracted when present
+- Positive unmatched balances are added automatically after the import review; matched debts are updated and zero-balance untracked accounts are not created
+
+Unrecognised layouts are rejected visibly. Invalid dates and amounts are never silently replaced with zero or today's date, and PDF imports that do not reconcile are marked for review.
 
 ## Privacy model
 

--- a/data-store.js
+++ b/data-store.js
@@ -182,9 +182,17 @@ export class FinanceDataStore {
       restoredIds.set(previousId, stored.document.id);
     }
     backup.state.documents = backup.documents.map((entry) => entry.metadata);
-    for (const collectionName of ['transactions', 'payslips', 'taxDocuments']) {
+    for (const collectionName of ['transactions', 'payslips', 'taxDocuments', 'creditReports']) {
       for (const record of backup.state[collectionName] || []) {
         if (restoredIds.has(record.sourceDocumentId)) record.sourceDocumentId = restoredIds.get(record.sourceDocumentId);
+        for (const account of record.accounts || []) {
+          if (restoredIds.has(account.sourceDocumentId)) account.sourceDocumentId = restoredIds.get(account.sourceDocumentId);
+        }
+      }
+    }
+    for (const collectionName of ['debts', 'overdrafts']) {
+      for (const record of backup.state[collectionName] || []) {
+        if (restoredIds.has(record.sourceStatementDocumentId)) record.sourceStatementDocumentId = restoredIds.get(record.sourceStatementDocumentId);
       }
     }
     for (const batch of backup.state.importBatches || []) {
@@ -224,13 +232,14 @@ export class FinanceDataStore {
 function migrateState(input) {
   const state = input && typeof input === 'object' ? input : {};
   return {
-    schemaVersion: 4,
+    schemaVersion: 5,
     meta: { createdAt: state.meta?.createdAt || new Date().toISOString(), updatedAt: state.meta?.updatedAt || new Date().toISOString() },
     profile: state.profile || { name: '', locale: 'en-GB', currency: 'GBP', dependableIncome: 0, paydayDay: 30 },
     accounts: Array.isArray(state.accounts) ? state.accounts : [],
     transactions: Array.isArray(state.transactions) ? state.transactions : [],
     payslips: Array.isArray(state.payslips) ? state.payslips : [],
     taxDocuments: Array.isArray(state.taxDocuments) ? state.taxDocuments : [],
+    creditReports: Array.isArray(state.creditReports) ? state.creditReports : [],
     debts: Array.isArray(state.debts) ? state.debts : [],
     overdrafts: Array.isArray(state.overdrafts) ? state.overdrafts : [],
     budgets: Array.isArray(state.budgets) ? state.budgets : [],
@@ -263,7 +272,7 @@ async function atomicWrite(destination, contents) {
 
 function mimeFromName(fileName) {
   const extension = path.extname(fileName).toLowerCase();
-  return ({ '.pdf': 'application/pdf', '.csv': 'text/csv', '.qif': 'application/qif', '.ofx': 'application/x-ofx', '.txt': 'text/plain', '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg' })[extension] || 'application/octet-stream';
+  return ({ '.pdf': 'application/pdf', '.csv': 'text/csv', '.tsv': 'text/tab-separated-values', '.qif': 'application/qif', '.ofx': 'application/x-ofx', '.qfx': 'application/x-ofx', '.txt': 'text/plain', '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg' })[extension] || 'application/octet-stream';
 }
 
 function requirePassphrase(passphrase) {

--- a/document-import.js
+++ b/document-import.js
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import path from 'node:path';
 
-const MONEY_PATTERN = /^[-+]?£?-?[\d,]+\.\d{2}$/;
+const MONEY_PATTERN = /^(?:[-+]?\s*(?:£|GBP)?\s*[\d,]+\.\d{2}|\((?:£|GBP)?\s*[\d,]+\.\d{2}\))(?:\s*(?:CR|DR))?$/i;
 const MONTHS = { jan: '01', feb: '02', mar: '03', apr: '04', may: '05', jun: '06', jul: '07', aug: '08', sep: '09', oct: '10', nov: '11', dec: '12' };
 
 export function parseImportedDocument(fileName, payload, requestedKind = 'auto', accountHint = '') {
@@ -12,16 +12,21 @@ export function parseImportedDocument(fileName, payload, requestedKind = 'auto',
     return parsePayslipText(payload.text || String(payload || ''), fileName);
   }
 
+  if (kind === 'credit-report') {
+    if (extension !== '.pdf') return rejectedImport('Credit reports must be imported as PDF files.');
+    return parseCreditReportText(payload.text || String(payload || ''), fileName);
+  }
+
   if (extension === '.pdf') {
     return parsePdfStatement(payload, fileName, accountHint);
   }
 
   const text = String(payload || '');
-  if (extension === '.csv') return parseCsvStatement(text, fileName, accountHint);
+  if (['.csv', '.tsv', '.txt'].includes(extension)) return parseCsvStatement(text, fileName, accountHint);
   if (extension === '.qif') return parseQifStatement(text, fileName, accountHint);
-  if (extension === '.ofx') return parseOfxStatement(text, fileName, accountHint);
+  if (['.ofx', '.qfx'].includes(extension)) return parseOfxStatement(text, fileName, accountHint);
   if (extension === '.json') return parseJsonStatement(text, fileName, accountHint);
-  return rejectedImport('Unsupported file type. Use PDF, CSV, QIF, OFX or JSON.');
+  return rejectedImport('Unsupported file type. Use PDF, CSV, TSV, QIF, OFX, QFX or JSON.');
 }
 
 export function parsePayslipText(text, fileName = 'Payslip.pdf') {
@@ -78,45 +83,183 @@ export function parsePayslipText(text, fileName = 'Payslip.pdf') {
   };
 }
 
-export function parseCsvStatement(text, fileName = 'statement.csv', accountHint = '') {
-  const rows = parseCsvRows(text);
-  if (rows.length < 2) return rejectedImport('The CSV contains no transaction rows.');
-  const headers = rows[0].map((value) => normaliseHeader(value));
-  const indices = {
-    date: findHeader(headers, ['date', 'transaction date', 'posted date', 'effective date']),
-    description: findHeader(headers, ['description', 'details', 'merchant', 'payee', 'transaction']),
-    debit: findHeader(headers, ['debit', 'money out', 'withdrawal', 'paid out']),
-    credit: findHeader(headers, ['credit', 'money in', 'deposit', 'paid in']),
-    amount: findHeader(headers, ['amount', 'value']),
-    balance: findHeader(headers, ['balance', 'running balance']),
-    type: findHeader(headers, ['type', 'transaction type'])
+export function parseCreditReportText(text, fileName = 'credit-report.pdf') {
+  const sourceText = String(text || '');
+  const provider = detectCreditReportProvider(sourceText);
+  const reportDate = findLabelledDate(sourceText, /(?:report date|date of report|generated (?:on|at)|report generated)/i);
+  const scoreMatch = sourceText.match(/(?:credit\s+score|your\s+score)(?:\s+is|\s*:)?\s*(\d{1,4})(?:\s*(?:\/|out of)\s*(\d{2,4}))?/i);
+  const score = scoreMatch ? Number(scoreMatch[1]) : null;
+  const scoreMaximum = scoreMatch?.[2] ? Number(scoreMatch[2]) : null;
+  const accounts = parseCreditReportAccounts(sourceText, fileName);
+  const warnings = [];
+  if (!provider) warnings.push('The credit-report provider was not identified automatically.');
+  if (!reportDate) warnings.push('The report date was not identified automatically.');
+  if (!accounts.length) warnings.push('No structured account entries were detected. The encrypted report is still available for manual review.');
+
+  const report = {
+    id: stableId('credit-report', fileName, provider, reportDate, score, accounts.map((account) => account.id).join(',')),
+    provider: provider || 'Unknown provider',
+    reportDate,
+    score,
+    scoreMaximum,
+    accounts,
+    notes: '',
+    source: fileName
   };
-  if (indices.date < 0 || indices.description < 0 || (indices.amount < 0 && indices.debit < 0 && indices.credit < 0)) {
-    return rejectedImport('Required CSV columns are missing. Map Date, Description and either Amount or Debit/Credit.');
+  return {
+    kind: 'credit-report',
+    records: [report],
+    rejected: [],
+    warnings,
+    summary: { provider: report.provider, reportDate, score, scoreMaximum, accountCount: accounts.length },
+    reconciled: Boolean(provider && reportDate && accounts.length)
+  };
+}
+
+function detectCreditReportProvider(text) {
+  if (/\bExperian\b/i.test(text)) return 'Experian';
+  if (/\bClearScore\b/i.test(text)) return 'ClearScore';
+  if (/\bCredit Karma\b/i.test(text)) return 'Credit Karma';
+  if (/\bTransUnion\b/i.test(text)) return 'TransUnion';
+  if (/\bEquifax\b/i.test(text)) return 'Equifax';
+  if (/\bTotallyMoney\b/i.test(text)) return 'TotallyMoney';
+  return '';
+}
+
+function findLabelledDate(text, labelPattern) {
+  const datePattern = '(\\d{1,2}[/-]\\d{1,2}[/-](?:\\d{4}|\\d{2})|\\d{1,2}\\s+[A-Za-z]{3,9}\\s+(?:\\d{4}|\\d{2})|\\d{4}[-/]\\d{1,2}[-/]\\d{1,2})';
+  const match = String(text || '').match(new RegExp(`${labelPattern.source}[\\s:.-]{0,12}${datePattern}`, 'i'));
+  return match ? parseDate(match[1]) : '';
+}
+
+function parseCreditReportAccounts(text, fileName) {
+  const lines = String(text || '').split(/\r?\n/).map((line) => normaliseWhitespace(line).trim()).filter(Boolean);
+  const lenderPattern = /^(?:lender|creditor|account provider|provider|company|organisation|organization|account name|name of organisation)\s*:?\s*(.*)$/i;
+  const starts = [];
+  lines.forEach((line, index) => {
+    const match = line.match(lenderPattern);
+    if (match) starts.push({ index, inlineValue: match[1].trim() });
+  });
+
+  const accounts = [];
+  starts.forEach((start, position) => {
+    const end = starts[position + 1]?.index ?? Math.min(lines.length, start.index + 50);
+    const block = lines.slice(start.index, end);
+    const lender = start.inlineValue || nextUnlabelledValue(lines, start.index);
+    const accountType = labelledText(block, /^(?:account type|type of account|product type)\s*:?\s*(.*)$/i);
+    const balanceText = labelledText(block, /^(?:current balance|outstanding balance|amount owed|balance)\s*:?\s*(.*)$/i);
+    const limitText = labelledText(block, /^(?:credit limit|account limit)\s*:?\s*(.*)$/i);
+    const status = labelledText(block, /^(?:account status|payment status|status)\s*:?\s*(.*)$/i);
+    const openedText = labelledText(block, /^(?:opened|opening date|start date|account opened)\s*:?\s*(.*)$/i);
+    const referenceText = labelledText(block, /^(?:account number|account reference|reference number|reference)\s*:?\s*(.*)$/i);
+    const paymentText = labelledText(block, /^(?:monthly payment|regular payment|minimum payment|payment amount)\s*:?\s*(.*)$/i);
+    const aprText = labelledText(block, /^(?:apr|annual percentage rate|interest rate)\s*:?\s*(.*)$/i);
+    const originalBalanceText = labelledText(block, /^(?:original balance|opening balance|original amount|loan amount)\s*:?\s*(.*)$/i);
+    const defaultDateText = labelledText(block, /^(?:default date|date defaulted)\s*:?\s*(.*)$/i);
+    const updatedText = labelledText(block, /^(?:last updated|updated on|balance updated|reported on)\s*:?\s*(.*)$/i);
+    const currentBalance = moneyFromText(balanceText);
+    const creditLimit = moneyFromText(limitText);
+    const contractualPayment = moneyFromText(paymentText);
+    const originalBalance = moneyFromText(originalBalanceText);
+    const apr = percentageFromText(aprText);
+    const openedDate = dateFromText(openedText);
+    const defaultDate = dateFromText(defaultDateText);
+    const updatedDate = dateFromText(updatedText);
+    const accountReference = accountReferenceFromText(referenceText);
+    if (!lender || (!accountType && currentBalance === null && creditLimit === null && contractualPayment === null && originalBalance === null && apr === null && !status && !openedDate && !defaultDate)) return;
+    accounts.push({
+      id: stableId('credit-report-account', fileName, lender, accountType, currentBalance, creditLimit, contractualPayment, originalBalance, apr, status, openedDate, defaultDate, accountReference),
+      lender,
+      accountType,
+      currentBalance,
+      creditLimit,
+      contractualPayment,
+      originalBalance,
+      apr,
+      status,
+      openedDate,
+      defaultDate,
+      updatedDate,
+      accountReference,
+      notes: ''
+    });
+  });
+  return accounts;
+}
+
+function labelledText(lines, pattern) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(pattern);
+    if (!match) continue;
+    return match[1]?.trim() || nextUnlabelledValue(lines, index);
   }
+  return '';
+}
+
+function nextUnlabelledValue(lines, index) {
+  const next = String(lines[index + 1] || '').trim();
+  return next && !/^[A-Za-z][A-Za-z ]{1,30}\s*:/.test(next) ? next : '';
+}
+
+function moneyFromText(value) {
+  const match = String(value || '').match(/(?:£|GBP)?\s*-?[\d,]+(?:\.\d{2})?(?:\s*(?:CR|DR))?/i);
+  return match ? parseMoney(match[0]) : null;
+}
+
+function percentageFromText(value) {
+  const match = String(value || '').match(/(\d{1,3}(?:\.\d{1,3})?)\s*%/);
+  return match ? Number(match[1]) / 100 : null;
+}
+
+function dateFromText(value) {
+  const text = String(value || '');
+  const match = text.match(/\d{1,2}[/-]\d{1,2}[/-](?:\d{4}|\d{2})|\d{1,2}\s+[A-Za-z]{3,9}\s+(?:\d{4}|\d{2})|\d{4}[-/]\d{1,2}[-/]\d{1,2}/);
+  return match ? parseDate(match[0]) : '';
+}
+
+function accountReferenceFromText(value) {
+  const compact = String(value || '').replace(/\s/g, '');
+  const visible = compact.match(/([A-Za-z0-9]{4})$/)?.[1] || '';
+  return visible ? `••••${visible.toUpperCase()}` : '';
+}
+
+export function parseCsvStatement(text, fileName = 'statement.csv', accountHint = '') {
+  const rows = parseDelimitedRows(text);
+  if (rows.length < 2) return rejectedImport('The CSV contains no transaction rows.');
+  const headerIndex = findStatementHeaderRow(rows);
+  if (headerIndex < 0) return rejectedImport('Required columns are missing. Include Date, Description and either Amount or Money In/Money Out.');
+  const headers = rows[headerIndex].map((value) => normaliseHeader(value));
+  const indices = {
+    date: findHeader(headers, ['date', 'transaction date', 'posted date', 'posting date', 'booking date', 'completed date', 'effective date', 'value date']),
+    description: findHeader(headers, ['description', 'transaction description', 'details', 'merchant', 'payee', 'counter party', 'counterparty', 'narrative', 'reference', 'memo', 'name']),
+    debit: findHeader(headers, ['debit', 'debit amount', 'money out', 'withdrawal', 'paid out', 'spent']),
+    credit: findHeader(headers, ['credit', 'credit amount', 'money in', 'deposit', 'paid in', 'received']),
+    amount: findHeader(headers, ['amount', 'transaction amount', 'value']),
+    balance: findHeader(headers, ['balance', 'running balance', 'account balance']),
+    type: findHeader(headers, ['type', 'transaction type', 'debit credit', 'credit debit indicator', 'dr cr'])
+  };
 
   const rejected = [];
   const records = [];
-  rows.slice(1).forEach((row, offset) => {
+  rows.slice(headerIndex + 1).forEach((row, offset) => {
     if (!row.some((cell) => String(cell).trim())) return;
     const date = parseDate(row[indices.date]);
     const description = String(row[indices.description] || '').trim();
     const debit = indices.debit >= 0 ? parseMoney(row[indices.debit]) : null;
     const credit = indices.credit >= 0 ? parseMoney(row[indices.credit]) : null;
     const signedAmount = indices.amount >= 0 ? parseMoney(row[indices.amount]) : null;
-    if (!date) return rejected.push({ row: offset + 2, reason: 'Invalid or ambiguous date.' });
-    if (!description) return rejected.push({ row: offset + 2, reason: 'Missing description.' });
-
     let incoming = credit && credit > 0 ? credit : 0;
     let outgoing = debit && debit > 0 ? debit : 0;
     if (!incoming && !outgoing && signedAmount !== null && signedAmount !== 0) {
-      const rawType = normaliseHeader(indices.type >= 0 ? row[indices.type] : '');
-      const positiveIsDebit = rawType.includes('debit') || rawType.includes('withdrawal');
-      if (signedAmount < 0 || positiveIsDebit) outgoing = Math.abs(signedAmount);
-      else incoming = signedAmount;
+      const direction = transactionDirection(indices.type >= 0 ? row[indices.type] : '');
+      if (signedAmount < 0 || direction === 'outgoing') outgoing = Math.abs(signedAmount);
+      else incoming = Math.abs(signedAmount);
     }
-    if (!incoming && !outgoing) return rejected.push({ row: offset + 2, reason: 'Missing or zero amount.' });
-    records.push(makeTransaction({ accountHint, date, description, incoming, outgoing, balance: indices.balance >= 0 ? parseMoney(row[indices.balance]) : null, source: fileName, sourceRow: offset + 2 }));
+    const sourceRow = headerIndex + offset + 2;
+    if (!date) return rejected.push({ row: sourceRow, reason: 'Invalid or ambiguous date.' });
+    if (!description) return rejected.push({ row: sourceRow, reason: 'Missing description.' });
+    if (!incoming && !outgoing) return rejected.push({ row: sourceRow, reason: 'Missing or zero amount.' });
+    records.push(makeTransaction({ accountHint, date, description, incoming, outgoing, balance: indices.balance >= 0 ? parseMoney(row[indices.balance]) : null, bankType: indices.type >= 0 ? String(row[indices.type] || '').trim() : '', source: fileName, sourceRow }));
   });
   return statementResult(records, rejected, [], accountHint, fileName);
 }
@@ -170,12 +313,33 @@ function parseJsonStatement(text, fileName, accountHint) {
   }
 }
 
-function parsePdfStatement(document, fileName, accountHint) {
+export function parsePdfStatement(document, fileName, accountHint) {
   const institution = detectInstitution(document.text);
-  if (institution === 'monzo') return parseMonzoPdf(document, fileName, accountHint || 'Monzo');
-  if (institution === 'halifax') return parseHalifaxPdf(document, fileName, accountHint || 'Halifax');
-  if (institution === 'nationwide') return parseNationwidePdf(document, fileName, accountHint || 'Nationwide');
-  return rejectedImport('This PDF layout is not recognised. Export CSV, QIF or OFX, or choose the account manually.');
+  const knownParsers = {
+    monzo: [parseMonzoPdf, 'Monzo'],
+    halifax: [parseLbgPdf, 'Halifax'],
+    lloyds: [parseLbgPdf, 'Lloyds'],
+    'bank-of-scotland': [parseLbgPdf, 'Bank of Scotland'],
+    nationwide: [parseNationwidePdf, 'Nationwide']
+  };
+  if (knownParsers[institution]) {
+    const [parser, provider] = knownParsers[institution];
+    const parsed = parser(document, fileName, accountHint || provider);
+    if (parsed.records.length) return enrichPdfStatement(parsed, document.text, provider);
+  }
+  const generic = parseGenericPdfTable(document, fileName, accountHint || knownParsers[institution]?.[1] || '');
+  if (generic.records.length) return enrichPdfStatement(generic, document.text, knownParsers[institution]?.[1] || '');
+  return rejectedImport('This PDF layout is not recognised. Try the bank\'s CSV, QIF, OFX or QFX export; the encrypted original has still been kept for review.');
+}
+
+function enrichPdfStatement(result, text, institution) {
+  const overdraftLimit = findMoney(text, /(?:arranged|agreed)?\s*overdraft\s*(?:limit|facility|amount)?[\s:£]{0,20}([\d,]+\.\d{2})/i)
+    ?? findMoney(text, /(?:overdraft limit|overdraft facility)[\s\S]{0,40}?£?([\d,]+\.\d{2})/i);
+  const overdraftRateText = String(text || '').match(/(?:arranged overdraft|overdraft interest)[\s\S]{0,180}?(?:EAR|APR|annual interest rate)[\s:]*(\d{1,3}(?:\.\d{1,3})?)\s*%/i)?.[0] || '';
+  const overdraftApr = percentageFromText(overdraftRateText);
+  result.institution = institution;
+  result.summary = { ...result.summary, institution, overdraftLimit, overdraftApr };
+  return result;
 }
 
 function parseMonzoPdf(document, fileName, accountHint) {
@@ -197,17 +361,17 @@ function parseMonzoPdf(document, fileName, accountHint) {
   });
 }
 
-function parseHalifaxPdf(document, fileName, accountHint) {
+function parseLbgPdf(document, fileName, accountHint) {
   const records = [];
   for (const page of document.pages) {
     for (const line of page.lines) {
-      const dateItem = line.items.find((item) => /^\d{2} [A-Z][a-z]{2} \d{2}$/.test(item.text));
-      const typeItem = line.items.find((item) => /^(FPI|FPO|TFR|CHG|DEB|DEP|DD|SO|BGC|ATM|CD|BP)$/i.test(item.text));
+      const dateItem = line.items.find((item) => /^\d{1,2} [A-Z][a-z]{2} \d{2}$/.test(item.text));
+      const typeItem = line.items.find((item) => /^(FPI|FPO|TFR|CHG|DEB|DEP|DD|SO|BGC|ATM|CD|BP|COR|CHQ|CPT|FEE|MPI|MPO|PAY)$/i.test(item.text));
       const moneyItems = line.items.filter((item) => MONEY_PATTERN.test(item.text.replace(/\s/g, '')));
       if (!dateItem || !typeItem || moneyItems.length < 2) continue;
       const balanceItem = moneyItems[moneyItems.length - 1];
       const amountItem = moneyItems[moneyItems.length - 2];
-      const isIncome = /^(FPI|BGC|DEP)$/i.test(typeItem.text);
+      const isIncome = /^(FPI|BGC|DEP|MPI)$/i.test(typeItem.text);
       const description = line.items.filter((item) => item.x > dateItem.x && item.x < typeItem.x && item.text !== '.').map((item) => item.text).join(' ');
       records.push(makeTransaction({ accountHint, date: parseDate(dateItem.text), description, incoming: isIncome ? Math.abs(parseMoney(amountItem.text)) : 0, outgoing: isIncome ? 0 : Math.abs(parseMoney(amountItem.text)), balance: parseMoney(balanceItem.text), bankType: typeItem.text, source: fileName, sourceRow: records.length + 1 }));
     }
@@ -264,6 +428,122 @@ function parseNationwidePdf(document, fileName, accountHint) {
   });
 }
 
+function parseGenericPdfTable(document, fileName, accountHint) {
+  const records = [];
+  for (const page of document.pages || []) {
+    let columns = null;
+    let currentDate = '';
+    for (const line of page.lines || []) {
+      const detectedColumns = detectPdfTableColumns(line);
+      if (detectedColumns) {
+        columns = detectedColumns;
+        currentDate = '';
+        continue;
+      }
+      if (!columns) continue;
+      if (/terms and conditions|important information|how to complain|financial services compensation|summary box/i.test(line.text)) {
+        columns = null;
+        continue;
+      }
+
+      const dateItem = line.items.find((item) => parseDate(item.text));
+      if (dateItem) currentDate = parseDate(dateItem.text);
+      const money = {};
+      for (const item of line.items) {
+        if (!MONEY_PATTERN.test(String(item.text).replace(/\u00a0/g, ' ').trim())) continue;
+        const column = nearestPdfColumn(item.x, columns, ['outgoing', 'incoming', 'amount', 'balance']);
+        if (column && money[column] === undefined) money[column] = parseMoney(item.text);
+      }
+
+      const description = pdfColumnText(line, columns, 'description', dateItem);
+      const bankType = pdfColumnText(line, columns, 'type', dateItem);
+      const hasSplitAmount = money.outgoing !== undefined || money.incoming !== undefined;
+      const hasSignedAmount = money.amount !== undefined;
+      if (!hasSplitAmount && !hasSignedAmount) {
+        if (!dateItem && description && records.length && !/continued|carried forward|brought forward/i.test(description)) {
+          records[records.length - 1].description = `${records[records.length - 1].description} | ${description}`;
+        }
+        continue;
+      }
+      if (!currentDate || !description || /opening balance|closing balance|balance brought forward/i.test(description)) continue;
+
+      let incoming = Math.abs(money.incoming || 0);
+      let outgoing = Math.abs(money.outgoing || 0);
+      if (!incoming && !outgoing && hasSignedAmount && money.amount) {
+        const direction = transactionDirection(bankType);
+        if (money.amount < 0 || direction === 'outgoing') outgoing = Math.abs(money.amount);
+        else incoming = Math.abs(money.amount);
+      }
+      if (!incoming && !outgoing) continue;
+      records.push(makeTransaction({
+        accountHint,
+        date: currentDate,
+        description,
+        incoming,
+        outgoing,
+        balance: money.balance ?? null,
+        bankType,
+        source: fileName,
+        sourceRow: records.length + 1
+      }));
+    }
+  }
+  return reconcilePdf(records, document.text || '', accountHint, fileName, {
+    opening: /(?:Opening|Start|Previous) balance\s*(?:£|GBP)?\s*(-?[\d,]+\.\d{2})/i,
+    closing: /(?:Closing|End|New) balance\s*(?:£|GBP)?\s*(-?[\d,]+\.\d{2})/i
+  });
+}
+
+function detectPdfTableColumns(line) {
+  const spans = pdfHeaderSpans(line.items || []);
+  const columns = {
+    date: pdfHeaderPosition(spans, [/^(?:transaction |posting |value )?date$/]),
+    description: pdfHeaderPosition(spans, [/^(?:transaction )?(?:description|details|narrative)$/, /^counter ?party$/]),
+    type: pdfHeaderPosition(spans, [/^(?:transaction )?type$/, /^dr cr$/, /^debit credit$/]),
+    outgoing: pdfHeaderPosition(spans, [/^(?:money|paid) out$/, /^debit(?: amount)?$/, /^withdrawals?$/]),
+    incoming: pdfHeaderPosition(spans, [/^(?:money|paid) in$/, /^credit(?: amount)?$/, /^deposits?$/]),
+    amount: pdfHeaderPosition(spans, [/^(?:transaction )?amount$/, /^value$/]),
+    balance: pdfHeaderPosition(spans, [/^(?:running |account )?balance$/])
+  };
+  const hasAmount = (columns.outgoing !== null && columns.incoming !== null) || columns.amount !== null;
+  return columns.date !== null && columns.description !== null && hasAmount ? columns : null;
+}
+
+function pdfHeaderSpans(items) {
+  const spans = [];
+  for (let start = 0; start < items.length; start += 1) {
+    for (let size = 1; size <= 3 && start + size <= items.length; size += 1) {
+      const selected = items.slice(start, start + size);
+      spans.push({ text: normalisePdfHeader(selected.map((item) => item.text).join(' ')), x: selected[0].x });
+    }
+  }
+  return spans;
+}
+
+function pdfHeaderPosition(spans, patterns) {
+  const match = spans.find((span) => patterns.some((pattern) => pattern.test(span.text)));
+  return match ? match.x : null;
+}
+
+function normalisePdfHeader(value) {
+  return String(value || '').toLowerCase().replace(/£|gbp/g, ' ').replace(/[^a-z0-9]+/g, ' ').trim().replace(/\s+/g, ' ');
+}
+
+function nearestPdfColumn(x, columns, allowed = Object.keys(columns)) {
+  const choices = allowed.filter((name) => columns[name] !== null && columns[name] !== undefined);
+  return choices.sort((left, right) => Math.abs(columns[left] - x) - Math.abs(columns[right] - x))[0] || '';
+}
+
+function pdfColumnText(line, columns, target, dateItem) {
+  if (columns[target] === null || columns[target] === undefined) return '';
+  return line.items
+    .filter((item) => item !== dateItem && !MONEY_PATTERN.test(String(item.text).replace(/\u00a0/g, ' ').trim()))
+    .filter((item) => nearestPdfColumn(item.x, columns) === target)
+    .map((item) => item.text)
+    .join(' ')
+    .trim();
+}
+
 function reconcilePdf(records, text, accountHint, fileName, patterns) {
   records.sort((left, right) => left.date.localeCompare(right.date) || Number(left.sourceRow || 0) - Number(right.sourceRow || 0));
   const warnings = [];
@@ -290,15 +570,54 @@ function reconcilePdf(records, text, accountHint, fileName, patterns) {
 }
 
 function statementResult(records, rejected, warnings, accountHint, fileName) {
+  const ordered = chronologicalStatementRecords(records);
+  const first = ordered.find((item) => Number.isFinite(item.runningBalance));
+  const last = [...ordered].reverse().find((item) => Number.isFinite(item.runningBalance));
+  const openingBalance = first ? roundMoney(first.runningBalance - first.incoming + first.outgoing) : null;
+  const closingBalance = last?.runningBalance ?? null;
+  const balanceChainValid = statementBalanceChainValid(ordered);
   return {
     kind: 'statement', records, rejected, warnings, accountHint, source: fileName,
     summary: {
       incoming: roundMoney(records.reduce((sum, item) => sum + item.incoming, 0)),
       outgoing: roundMoney(records.reduce((sum, item) => sum + item.outgoing, 0)),
-      count: records.length
+      count: records.length,
+      openingBalance,
+      closingBalance
     },
-    reconciled: rejected.length === 0 && records.length > 0
+    reconciled: rejected.length === 0 && records.length > 0 && balanceChainValid
   };
+}
+
+function chronologicalStatementRecords(records) {
+  if (records.length < 2) return [...records];
+  const firstDate = records[0].date || '';
+  const lastDate = records[records.length - 1].date || '';
+  if (firstDate && lastDate && firstDate !== lastDate) return firstDate < lastDate ? [...records] : [...records].reverse();
+
+  let ascendingScore = 0;
+  let descendingScore = 0;
+  for (let index = 1; index < records.length; index += 1) {
+    const previous = records[index - 1];
+    const current = records[index];
+    if (!Number.isFinite(previous.runningBalance) || !Number.isFinite(current.runningBalance)) continue;
+    const ascendingExpected = roundMoney(previous.runningBalance + current.incoming - current.outgoing);
+    const descendingExpected = roundMoney(current.runningBalance + previous.incoming - previous.outgoing);
+    if (Math.abs(ascendingExpected - current.runningBalance) <= 0.02) ascendingScore += 1;
+    if (Math.abs(descendingExpected - previous.runningBalance) <= 0.02) descendingScore += 1;
+  }
+  return descendingScore > ascendingScore ? [...records].reverse() : [...records];
+}
+
+function statementBalanceChainValid(records) {
+  for (let index = 1; index < records.length; index += 1) {
+    const previous = records[index - 1];
+    const current = records[index];
+    if (!Number.isFinite(previous.runningBalance) || !Number.isFinite(current.runningBalance)) continue;
+    const expected = roundMoney(previous.runningBalance + current.incoming - current.outgoing);
+    if (Math.abs(expected - current.runningBalance) > 0.02) return false;
+  }
+  return true;
 }
 
 function makeTransaction(input) {
@@ -354,6 +673,8 @@ function inferDocumentKind(fileName, text) {
 function detectInstitution(text) {
   if (/Monzo Bank Limited|Personal Account statement/i.test(text)) return 'monzo';
   if (/logo, Halifax|Halifax plc|www\.halifax\.co\.uk/i.test(text)) return 'halifax';
+  if (/Lloyds Bank plc|www\.lloydsbank\.com|logo, Lloyds/i.test(text)) return 'lloyds';
+  if (/Bank of Scotland plc|www\.bankofscotland\.co\.uk|logo, Bank of Scotland/i.test(text)) return 'bank-of-scotland';
   if (/Nationwide Building Society|Your FlexAccount/i.test(text)) return 'nationwide';
   return '';
 }
@@ -378,12 +699,12 @@ export function parseDate(value) {
   const text = String(value).trim();
   let match = text.match(/^(\d{4})(\d{2})(\d{2})/);
   if (match) return validIso(match[1], match[2], match[3]);
-  match = text.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/);
+  match = text.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})(?:[ T].*)?$/);
   if (match) return validIso(match[1], match[2], match[3]);
-  match = text.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{2}|\d{4})$/);
+  match = text.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{2}|\d{4})(?:[ T].*)?$/);
   if (match) return validIso(match[3].length === 2 ? `20${match[3]}` : match[3], match[2], match[1]);
-  match = text.match(/^(\d{1,2})\s+([A-Za-z]{3})\s+(\d{2}|\d{4})$/);
-  if (match) return validIso(match[3].length === 2 ? `20${match[3]}` : match[3], MONTHS[match[2].toLowerCase()], match[1]);
+  match = text.match(/^(\d{1,2})\s+([A-Za-z]{3,9})\s+(\d{2}|\d{4})(?:[ T].*)?$/);
+  if (match) return validIso(match[3].length === 2 ? `20${match[3]}` : match[3], MONTHS[match[2].slice(0, 3).toLowerCase()], match[1]);
   return '';
 }
 
@@ -396,12 +717,14 @@ function validIso(year, month, day) {
 export function parseMoney(value) {
   if (value === null || value === undefined || value === '') return null;
   if (typeof value === 'number') return Number.isFinite(value) ? value : null;
-  let text = String(value).trim().replace(/\s/g, '').replace(/£/g, '').replace(/,/g, '');
+  let text = String(value).trim().replace(/\u00a0/g, ' ');
+  const trailingDebit = /\bDR$/i.test(text);
+  text = text.replace(/\b(?:CR|DR)$/i, '').replace(/\s/g, '').replace(/£|GBP/gi, '').replace(/,/g, '');
   const parenthesised = /^\(.+\)$/.test(text);
   text = text.replace(/[()]/g, '').replace(/^\+/, '');
   const number = Number(text);
   if (!Number.isFinite(number)) return null;
-  return parenthesised ? -number : number;
+  return parenthesised || trailingDebit ? -Math.abs(number) : number;
 }
 
 function tag(block, name) {
@@ -409,7 +732,17 @@ function tag(block, name) {
 }
 
 function findHeader(headers, candidates) {
-  return headers.findIndex((header) => candidates.some((candidate) => header === candidate || header.includes(candidate)));
+  for (const candidate of candidates) {
+    const exact = headers.indexOf(candidate);
+    if (exact >= 0) return exact;
+  }
+  const exactOnly = new Set(['date', 'type', 'value', 'name', 'reference']);
+  for (const candidate of candidates) {
+    if (exactOnly.has(candidate)) continue;
+    const partial = headers.findIndex((header) => header.includes(candidate));
+    if (partial >= 0) return partial;
+  }
+  return -1;
 }
 
 function normaliseHeader(value) {
@@ -420,7 +753,39 @@ function normaliseWhitespace(value) {
   return String(value || '').replace(/\u00a0/g, ' ').replace(/[ \t]+/g, ' ').replace(/\r/g, '');
 }
 
-function parseCsvRows(text) {
+function findStatementHeaderRow(rows) {
+  return rows.slice(0, 30).findIndex((row) => {
+    const headers = row.map((value) => normaliseHeader(value));
+    const date = findHeader(headers, ['date', 'transaction date', 'posted date', 'posting date', 'booking date', 'completed date', 'effective date', 'value date']);
+    const description = findHeader(headers, ['description', 'transaction description', 'details', 'merchant', 'payee', 'counter party', 'counterparty', 'narrative', 'reference', 'memo', 'name']);
+    const amount = findHeader(headers, ['amount', 'transaction amount', 'value']);
+    const debit = findHeader(headers, ['debit', 'debit amount', 'money out', 'withdrawal', 'paid out', 'spent']);
+    const credit = findHeader(headers, ['credit', 'credit amount', 'money in', 'deposit', 'paid in', 'received']);
+    return date >= 0 && description >= 0 && (amount >= 0 || debit >= 0 || credit >= 0);
+  });
+}
+
+function transactionDirection(value) {
+  const text = normaliseHeader(value).replace(/[_/-]+/g, ' ');
+  if (!text) return '';
+  if (/\b(credit|cr|fpi|bgc|deposit|money in|paid in|refund|salary|interest received)\b/.test(text)) return 'incoming';
+  if (/\b(debit|dr|deb|fpo|dd|direct debit|so|standing order|chg|charge|atm|cpt|cash withdrawal|card payment|cash|purchase|money out|paid out|withdrawal)\b/.test(text)) return 'outgoing';
+  return '';
+}
+
+function parseDelimitedRows(text) {
+  const source = String(text || '').replace(/^\uFEFF/, '');
+  const candidates = [',', '\t', ';'].map((delimiter) => {
+    const rows = parseSeparatedRows(source, delimiter);
+    const headerIndex = findStatementHeaderRow(rows);
+    const populated = rows.slice(0, 30).filter((row) => row.some((cell) => String(cell).trim()));
+    const width = Math.max(0, ...populated.map((row) => row.length));
+    return { delimiter, rows, score: (headerIndex >= 0 ? 10000 : 0) + width * populated.length };
+  });
+  return candidates.sort((left, right) => right.score - left.score)[0].rows;
+}
+
+function parseSeparatedRows(text, delimiter) {
   const rows = [];
   let row = [];
   let field = '';
@@ -430,7 +795,7 @@ function parseCsvRows(text) {
     if (character === '"') {
       if (quoted && text[index + 1] === '"') { field += '"'; index += 1; }
       else quoted = !quoted;
-    } else if (character === ',' && !quoted) { row.push(field); field = ''; }
+    } else if (character === delimiter && !quoted) { row.push(field); field = ''; }
     else if ((character === '\n' || character === '\r') && !quoted) {
       if (character === '\r' && text[index + 1] === '\n') index += 1;
       row.push(field); rows.push(row); row = []; field = '';

--- a/finance-core.js
+++ b/finance-core.js
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 4;
+export const SCHEMA_VERSION = 5;
 
 export function formatCurrency(value, options = {}) {
   return new Intl.NumberFormat('en-GB', {
@@ -56,20 +56,34 @@ export function calculateBudgetRows(state, month = state.settings?.selectedMonth
 }
 
 export function buildNextAction(state, now = new Date()) {
-  const today = now.toISOString().slice(0, 10);
+  const today = localDateKey(now);
+  const isSnoozed = (id) => String(state.settings?.snoozedActions?.[id] || '') > today;
   const task = (state.tasks || [])
     .filter((entry) => !entry.completedAt && (!entry.snoozedUntil || entry.snoozedUntil <= today))
     .sort((left, right) => Number(left.order || 999) - Number(right.order || 999))[0];
   if (task) return task;
 
-  if (!(state.accounts || []).length) return { id: 'generated-first-account', title: 'Add your first account', detail: 'Open Settings, add one bank account, then stop. No balances need to be perfect yet.', timeframe: '5 min', stage: 'today' };
-  if (!(state.transactions || []).length) return { id: 'generated-first-import', title: 'Import one recent statement', detail: 'Choose one account and review the preview before accepting any payments.', timeframe: '10 min', stage: 'today' };
+  const checkIn = { id: 'generated-checkin', title: 'Complete a five-minute check-in', detail: 'Update one balance, then stop. Consistency matters more than perfection.', timeframe: '5 min', stage: 'today' };
+  if (!(state.accounts || []).length) {
+    const firstAccount = { id: 'generated-first-account', title: 'Add your first account', detail: 'Open Settings, add one bank account, then stop. No balances need to be perfect yet.', timeframe: '5 min', stage: 'today' };
+    return isSnoozed(firstAccount.id) ? checkIn : firstAccount;
+  }
+  if (!(state.transactions || []).length) {
+    const firstImport = { id: 'generated-first-import', title: 'Import one recent statement', detail: 'Choose one account and review the preview before accepting any payments.', timeframe: '10 min', stage: 'today' };
+    return isSnoozed(firstImport.id) ? checkIn : firstImport;
+  }
 
   const overLimit = (state.overdrafts || []).find((item) => item.status === 'over_limit');
-  if (overLimit) return { id: 'generated-overlimit', title: `Check ${overLimit.name}`, detail: 'Confirm the balance and ask about an affordable plan before making an extra debt payment.', timeframe: '10 min', stage: 'today' };
+  if (overLimit && !isSnoozed('generated-overlimit')) return { id: 'generated-overlimit', title: `Check ${overLimit.name}`, detail: 'Confirm the balance and ask about an affordable plan before making an extra debt payment.', timeframe: '10 min', stage: 'today' };
   const arrears = [...(state.overdrafts || []), ...(state.debts || [])].find((item) => ['arrears', 'defaulted'].includes(item.status));
-  if (arrears) return { id: 'generated-arrears', title: `Confirm the plan for ${arrears.name}`, detail: 'Record the agreed payment and whether interest or charges are frozen.', timeframe: '10 min', stage: 'this week' };
-  return { id: 'generated-checkin', title: 'Complete a five-minute check-in', detail: 'Update one balance, then stop. Consistency matters more than perfection.', timeframe: '5 min', stage: 'today' };
+  if (arrears && !isSnoozed('generated-arrears')) return { id: 'generated-arrears', title: `Confirm the plan for ${arrears.name}`, detail: 'Record the agreed payment and whether interest or charges are frozen.', timeframe: '10 min', stage: 'this week' };
+  if (!isSnoozed(checkIn.id)) return checkIn;
+  return { id: 'generated-paused', title: 'Nothing else needs your attention today', detail: 'Your available steps are snoozed. Come back tomorrow, or use another page if you choose to update something now.', timeframe: 'Done', stage: 'today', passive: true };
+}
+
+export function hasCompletedCheckIn(checkIns = [], now = new Date()) {
+  const today = localDateKey(now);
+  return checkIns.some((entry) => entry.completed !== false && localDateKey(new Date(entry.date)) === today);
 }
 
 export function calculateStreak(checkIns = [], now = new Date()) {
@@ -186,6 +200,76 @@ export function findDuplicateCandidates(existing, incoming) {
   return { exact, possible };
 }
 
+export function planCreditReportAccounts(debts = [], overdrafts = [], accounts = []) {
+  const usedMatches = new Set();
+  return accounts.map((account) => {
+    const balance = Number(account.currentBalance);
+    const kind = reportedAccountKind(account);
+    const collection = kind === 'overdraft' ? overdrafts : debts;
+    const existing = collection.find((item) => !usedMatches.has(item.id) && reportedAccountMatches(item, account));
+    if (existing) {
+      usedMatches.add(existing.id);
+      return { account, action: 'existing', kind, existingId: existing.id };
+    }
+    if (!Number.isFinite(balance) || balance <= 0) return { account, action: 'no-balance', kind };
+    return { account, action: kind === 'overdraft' ? 'add-overdraft' : 'add-debt', kind };
+  });
+}
+
+export function creditReportDebtStatus(value) {
+  const text = String(value || '').toLowerCase();
+  if (/default/.test(text)) return 'defaulted';
+  if (/over limit/.test(text)) return 'over_limit';
+  if (/arrears|late|missed|delinquent/.test(text)) return 'arrears';
+  return 'current';
+}
+
+export function syncStatementAccount(state, account, preview, documentId = '') {
+  const closingBalance = Number(preview?.summary?.closingBalance);
+  if (!account || !preview?.reconciled || !Number.isFinite(closingBalance)) return '';
+  account.currentBalance = closingBalance;
+  account.statementDate = (preview.records || []).map((item) => item.date).filter(Boolean).sort().at(-1) || account.statementDate;
+  if (!Number.isFinite(account.openingBalance) && Number.isFinite(preview.summary.openingBalance)) account.openingBalance = preview.summary.openingBalance;
+  if (!account.institution && preview.institution) account.institution = preview.institution;
+
+  const used = Math.max(0, -closingBalance);
+  let overdraft = (state.overdrafts || []).find((item) => item.accountId === account.id);
+  if (!overdraft && used > 0) overdraft = findUnlinkedOverdraftForAccount(state.overdrafts || [], account);
+  let action = 'account-updated';
+  if (!overdraft && used > 0) {
+    overdraft = {
+      id: createId('overdraft'),
+      accountId: account.id,
+      name: `${account.name || account.institution || 'Account'} overdraft`,
+      type: 'overdraft',
+      currentBalance: used,
+      limit: preview.summary.overdraftLimit ?? null,
+      apr: null,
+      contractualPayment: null,
+      status: Number.isFinite(preview.summary.overdraftLimit) && used > preview.summary.overdraftLimit ? 'over_limit' : 'current',
+      includeInPlan: true,
+      arrangementConfirmed: false,
+      interestFrozen: false,
+      planPriority: 999,
+      description: 'Automatically kept in sync with the linked bank statement balance.',
+      notes: 'Confirm the arranged limit and APR if they are not shown on the statement.'
+    };
+    state.overdrafts.push(overdraft);
+    action = 'overdraft-created';
+  }
+  if (!overdraft) return action;
+  overdraft.accountId = account.id;
+  overdraft.currentBalance = used;
+  if (Number.isFinite(preview.summary.overdraftLimit)) overdraft.limit = preview.summary.overdraftLimit;
+  if (Number.isFinite(preview.summary.overdraftApr)) overdraft.apr = preview.summary.overdraftApr;
+  if (overdraft.status === 'over_limit' && (!Number.isFinite(overdraft.limit) || used <= overdraft.limit)) overdraft.status = 'current';
+  if (Number.isFinite(overdraft.limit) && used > overdraft.limit) overdraft.status = 'over_limit';
+  overdraft.statementDate = account.statementDate;
+  overdraft.sourceStatementDocumentId = documentId;
+  overdraft.updatedAt = new Date().toISOString();
+  return action === 'overdraft-created' ? action : 'overdraft-updated';
+}
+
 export function matchInternalTransfers(transactions) {
   const credits = transactions.filter((item) => item.incoming > 0 && item.transferStatus !== 'confirmed');
   const matches = [];
@@ -233,7 +317,62 @@ function priorityOrder(items, balances, strategy) {
 }
 
 function isBlankState(state) {
-  return ['accounts', 'transactions', 'payslips', 'debts', 'overdrafts', 'budgets'].every((key) => !(state[key] || []).length);
+  return ['accounts', 'transactions', 'payslips', 'creditReports', 'debts', 'overdrafts', 'budgets'].every((key) => !(state[key] || []).length);
+}
+
+function reportedAccountMatches(existing, reported) {
+  const existingLender = creditorKey(existing.name);
+  const reportedLender = creditorKey(reported.lender);
+  if (!existingLender || existingLender !== reportedLender) return false;
+  const existingReference = referenceKey(existing.accountReference);
+  const reportedReference = referenceKey(reported.accountReference);
+  if (existingReference && reportedReference && existingReference !== reportedReference) return false;
+  const existingType = reportedTypeKey(existing.type);
+  const reportedType = reportedTypeKey(reported.accountType);
+  return !existingType || !reportedType || existingType === reportedType;
+}
+
+function creditorKey(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/\b(?:the|plc|limited|ltd|llp|incorporated|inc|company|co)\b/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function referenceKey(value) {
+  return String(value || '').replace(/[^a-z0-9]/gi, '').slice(-4).toLowerCase();
+}
+
+function reportedTypeKey(value) {
+  const text = String(value || '').toLowerCase();
+  if (/overdraft|current account/.test(text)) return 'overdraft';
+  if (/credit card|store card|charge card/.test(text)) return 'card';
+  if (/hire purchase|vehicle|motor finance/.test(text)) return 'vehicle-finance';
+  if (/mortgage/.test(text)) return 'mortgage';
+  if (/loan/.test(text)) return 'loan';
+  if (/mobile|communications|telecom/.test(text)) return 'communications';
+  if (/catalogue|mail order/.test(text)) return 'catalogue';
+  return text.replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function reportedAccountKind(account) {
+  return reportedTypeKey(account.accountType) === 'overdraft' ? 'overdraft' : 'debt';
+}
+
+function findUnlinkedOverdraftForAccount(overdrafts, account) {
+  const accountNames = [account.name, account.institution].map(accountMatchKey).filter(Boolean);
+  const candidates = overdrafts.filter((item) => !item.accountId && accountNames.some((name) => {
+    const overdraftName = accountMatchKey(item.name);
+    return overdraftName && (overdraftName === name || overdraftName.includes(name) || name.includes(overdraftName));
+  }));
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+function accountMatchKey(value) {
+  return String(value || '').toLowerCase().replace(/\b(?:bank|current|account|overdraft|plc|limited|ltd|the)\b/g, ' ').replace(/[^a-z0-9]+/g, ' ').trim().replace(/\s+/g, ' ');
 }
 
 function currentMonth() {
@@ -270,4 +409,13 @@ function weekKey(date) {
   const value = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
   value.setUTCDate(value.getUTCDate() - ((value.getUTCDay() + 6) % 7));
   return value.toISOString().slice(0, 10);
+}
+
+function localDateKey(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
   </head>
   <body>
     <div id="desktopRequired" class="desktop-required" hidden>
+      <img src="assets/onestep-money-wordmark.png" alt="OneStep Money — One clear move at a time." />
+      <p class="eyebrow">PRIVATE BY DESIGN</p>
       <h1>Open the desktop app</h1>
       <p>Your private data and document vault are available only in Electron desktop mode.</p>
     </div>
@@ -17,37 +19,41 @@
       <aside class="sidebar">
         <div class="brand">
           <img class="brand-mark" src="assets/onestep-money-icon.png" alt="" aria-hidden="true" />
-          <div><strong>OneStep Money</strong><span>One clear move at a time.</span></div>
+          <div class="brand-copy"><strong><span>OneStep</span> <span>Money</span></strong><span>One clear move at a time.</span></div>
         </div>
         <nav aria-label="Main navigation">
-          <button class="nav-button active" data-view="today"><span aria-hidden="true">●</span>Today</button>
-          <button class="nav-button" data-view="transactions"><span aria-hidden="true">↕</span>Payments</button>
-          <button class="nav-button" data-view="pay"><span aria-hidden="true">£</span>Pay</button>
-          <button class="nav-button" data-view="debts"><span aria-hidden="true">D</span>Debts</button>
-          <button class="nav-button" data-view="overdrafts"><span aria-hidden="true">O</span>Overdrafts</button>
-          <button class="nav-button" data-view="budget"><span aria-hidden="true">◎</span>Budget</button>
-          <button class="nav-button" data-view="guide"><span aria-hidden="true">✦</span>Guide</button>
-          <button class="nav-button" data-view="documents"><span aria-hidden="true">▤</span>Documents</button>
-          <button class="nav-button" data-view="settings"><span aria-hidden="true">⚙</span>Settings</button>
+          <button class="nav-button active" data-view="today"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 11.5 12 4l9 7.5"/><path d="M5.5 10.5V20h13v-9.5"/><path d="M9.5 20v-6h5v6"/></svg><span class="nav-label">Today</span></button>
+          <button class="nav-button" data-view="transactions"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 4v16M3.5 7.5 7 4l3.5 3.5M17 20V4m-3.5 12.5L17 20l3.5-3.5"/></svg><span class="nav-label">Payments</span></button>
+          <button class="nav-button" data-view="pay"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6.5 8.5a5.5 5.5 0 1 1 0 7"/><path d="M4 12h9M4 16h9"/></svg><span class="nav-label">Pay</span></button>
+          <button class="nav-button" data-view="debts"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="6" width="18" height="13" rx="2"/><path d="M3 10h18M7 15h3"/></svg><span class="nav-label">Debts</span></button>
+          <button class="nav-button" data-view="overdrafts"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M8 12h8M12 8v8"/></svg><span class="nav-label">Overdrafts</span></button>
+          <button class="nav-button" data-view="budget"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 19V9m5 10V5m6 14v-7m5 7V8"/><path d="M3 19.5h18"/></svg><span class="nav-label">Budget</span></button>
+          <button class="nav-button" data-view="guide"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 3 1.2 4.1L17 9l-3.8 1.9L12 15l-1.2-4.1L7 9l3.8-1.9L12 3Z"/><path d="m18.5 14 .7 2.3 2.1 1.2-2.1 1.1-.7 2.4-.7-2.4-2.1-1.1 2.1-1.2.7-2.3Z"/></svg><span class="nav-label">Guide</span></button>
+          <button class="nav-button" data-view="documents"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3h8l4 4v14H6z"/><path d="M14 3v5h4M9 12h6M9 16h6"/></svg><span class="nav-label">Documents</span></button>
+          <button class="nav-button" data-view="settings"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1-2.8 2.8-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.6v.2h-4V21a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1L4.2 17l.1-.1a1.7 1.7 0 0 0 .3-1.9A1.7 1.7 0 0 0 3 14H2.8v-4H3a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9L4.2 7 7 4.2l.1.1a1.7 1.7 0 0 0 1.9.3 1.7 1.7 0 0 0 1-1.6v-.2h4V3a1.7 1.7 0 0 0 1 1.6 1.7 1.7 0 0 0 1.9-.3l.1-.1L19.8 7l-.1.1a1.7 1.7 0 0 0-.3 1.9 1.7 1.7 0 0 0 1.6 1h.2v4H21a1.7 1.7 0 0 0-1.6 1Z"/></svg><span class="nav-label">Settings</span></button>
         </nav>
-        <div class="privacy-status"><span id="encryptionDot" class="status-dot"></span><span id="encryptionText">Checking secure storage…</span></div>
+        <div class="privacy-status"><span id="encryptionDot" class="status-dot"></span><span class="privacy-copy"><strong>Private on this device</strong><span id="encryptionText">Checking secure storage…</span></span></div>
       </aside>
 
       <main class="main-content">
         <header class="topbar">
-          <div><p class="eyebrow" id="viewEyebrow">ONE CLEAR MOVE</p><h1 id="viewTitle">Today</h1></div>
+          <div class="title-stack"><p class="eyebrow" id="viewEyebrow">ONE CLEAR MOVE</p><h1 id="viewTitle">Today</h1></div>
           <div class="topbar-actions">
             <label class="compact-field">Month<select id="monthSelect" aria-label="Reporting month"></select></label>
-            <div class="streak-chip" title="Weeks with a completed check-in"><span aria-hidden="true">◆</span><strong id="streakValue">0</strong> week streak</div>
+            <div class="streak-chip" title="Weeks with a completed check-in"><span class="streak-icon" aria-hidden="true">◆</span><span><strong id="streakValue">0</strong> week streak</span></div>
           </div>
         </header>
 
         <section id="view-today" class="view active" aria-labelledby="viewTitle">
           <article class="focus-panel">
-            <div><p class="eyebrow">IMMEDIATE ACTION</p><h2 id="nextActionTitle">Loading your next action…</h2><p id="nextActionDetail"></p></div>
+            <div class="focus-copy"><div class="step-emblem" aria-hidden="true"><span>1</span></div><div><p class="eyebrow">IMMEDIATE ACTION</p><h2 id="nextActionTitle">Loading your next action…</h2><p id="nextActionDetail"></p></div></div>
             <div class="focus-actions"><span id="nextActionTime" class="time-chip">10 min</span><button id="completeActionButton" class="primary-button">Done for today</button><button id="snoozeActionButton" class="secondary-button">Snooze 1 day</button></div>
           </article>
-          <p class="permission-slip">No catching up. No perfect spreadsheet. Finish this one step, then close the app.</p>
+          <div id="dailyCompleteState" class="daily-complete" hidden>
+            <span class="daily-complete-icon" aria-hidden="true">✓</span>
+            <div><strong>Today’s check-in is complete</strong><p>You have done enough for today. Your next clear move will be waiting tomorrow.</p></div>
+          </div>
+          <p class="permission-slip"><span aria-hidden="true">✓</span>No catching up. No perfect spreadsheet. Finish this one step, then close the app.</p>
 
           <div class="metric-grid">
             <article class="metric-card"><span>Planned safety margin</span><strong id="marginValue">£0.00</strong><small id="marginHint">From entered items</small></article>
@@ -58,7 +64,7 @@
 
           <div class="two-column">
             <article class="panel"><div class="panel-heading"><div><p class="eyebrow">QUICK READ</p><h2>What needs attention</h2></div></div><div id="checksList" class="checks-list"></div></article>
-            <article class="panel encouragement-panel"><p class="eyebrow">MOMENTUM</p><h2 id="momentumTitle">Showing up counts</h2><div class="progress-track"><span id="bufferProgress"></span></div><p id="momentumText"></p><button id="quickCheckInButton" class="secondary-button">Log a five-minute check-in</button></article>
+            <article class="panel encouragement-panel"><p class="eyebrow">MOMENTUM</p><h2 id="momentumTitle">Showing up counts</h2><div class="progress-track"><span id="bufferProgress"></span></div><p id="momentumText"></p><button id="quickCheckInButton" class="secondary-button">Complete five-minute check-in</button><p id="checkInStatus" class="check-in-status">Use this when you reviewed your money but did not finish the action above.</p></article>
           </div>
         </section>
 
@@ -86,6 +92,7 @@
           <div class="section-actions"><div><h2>Debts</h2><p>Loans, cards, finance agreements and defaults. Overdrafts have their own page.</p></div><button class="primary-button" data-add="debt">Add debt</button></div>
           <div class="metric-grid three"><article class="metric-card"><span>Total debt</span><strong id="debtTotalValue">£0.00</strong></article><article class="metric-card"><span>Known monthly payments</span><strong id="debtPaymentsValue">£0.00</strong></article><article class="metric-card"><span>Unknown APRs</span><strong id="unknownAprValue">0</strong></article></div>
           <div id="debtCards" class="card-list"></div>
+          <article class="panel"><div class="panel-heading"><div><h2>Credit reports</h2><p class="muted">Import a PDF to securely store it and add newly reported balances without duplicating debts you already track.</p></div><button id="importCreditReportButton" class="secondary-button">Import credit report</button></div><div id="creditReportCards" class="compact-card-list"></div></article>
         </section>
 
         <section id="view-overdrafts" class="view" hidden>
@@ -109,7 +116,7 @@
         </section>
 
         <section id="view-documents" class="view" hidden>
-          <div class="section-actions"><div><h2>Secure documents</h2><p>Encrypted copies of every imported statement and payslip. Open them only inside the app.</p></div></div>
+          <div class="section-actions"><div><h2>Secure documents</h2><p>Encrypted copies of every imported statement, payslip and credit report. Open them only inside the app.</p></div></div>
           <div id="documentCards" class="card-list"></div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         <section id="view-today" class="view active" aria-labelledby="viewTitle">
           <article class="focus-panel">
             <div class="focus-copy"><div class="step-emblem" aria-hidden="true"><span>1</span></div><div><p class="eyebrow">IMMEDIATE ACTION</p><h2 id="nextActionTitle">Loading your next action…</h2><p id="nextActionDetail"></p></div></div>
-            <div class="focus-actions"><span id="nextActionTime" class="time-chip">10 min</span><button id="completeActionButton" class="primary-button">Done for today</button><button id="snoozeActionButton" class="secondary-button">Snooze 1 day</button></div>
+            <div class="focus-actions"><span id="nextActionTime" class="time-chip">10 min</span><button id="completeActionButton" class="primary-button">Complete &amp; finish</button><button id="snoozeActionButton" class="secondary-button">Snooze 1 day</button></div>
           </article>
           <div id="dailyCompleteState" class="daily-complete" hidden>
             <span class="daily-complete-icon" aria-hidden="true">✓</span>

--- a/main-process.js
+++ b/main-process.js
@@ -106,13 +106,15 @@ function registerIpcHandlers() {
   });
 
   ipcMain.handle('import:choose', async (_event, options = {}) => {
-    const kind = options.kind === 'payslip' ? 'payslip' : 'statement';
+    const kind = ['payslip', 'credit-report'].includes(options.kind) ? options.kind : 'statement';
     const selection = await dialog.showOpenDialog(mainWindow, {
-      title: kind === 'payslip' ? 'Import payslip' : 'Import bank statement',
+      title: kind === 'payslip' ? 'Import payslip' : kind === 'credit-report' ? 'Import credit report' : 'Import bank statement',
       properties: ['openFile', 'multiSelections'],
       filters: kind === 'payslip'
         ? [{ name: 'Payslips', extensions: ['pdf'] }]
-        : [{ name: 'Statements', extensions: ['pdf', 'csv', 'qif', 'ofx', 'json'] }]
+        : kind === 'credit-report'
+          ? [{ name: 'Credit reports', extensions: ['pdf'] }]
+        : [{ name: 'Statements', extensions: ['pdf', 'csv', 'tsv', 'txt', 'qif', 'ofx', 'qfx', 'json'] }]
     });
     if (selection.canceled) return [];
     await store.createAutomaticBackup('before-import');
@@ -124,10 +126,14 @@ function registerIpcHandlers() {
         const extension = path.extname(filePath).toLowerCase();
         const payload = extension === '.pdf' ? await extractPdfDocument(filePath) : await fs.readFile(filePath, 'utf8');
         const preview = parseImportedDocument(path.basename(filePath), payload, kind, options.accountId || '');
-        preview.records = preview.records.map((record) => ({ ...record, sourceDocumentId: document.id }));
+        preview.records = preview.records.map((record) => ({
+          ...record,
+          sourceDocumentId: document.id,
+          accounts: Array.isArray(record.accounts) ? record.accounts.map((account) => ({ ...account, sourceDocumentId: document.id })) : record.accounts
+        }));
         document.displayName = canonicalDocumentName(document, preview, options.accountId, currentState);
         document.parseStatus = preview.records.length ? (preview.reconciled ? 'ready' : 'review') : 'needs_review';
-        document.linkedRecordIds = preview.records.map((record) => record.id);
+        document.linkedRecordIds = preview.records.flatMap((record) => [record.id, ...(record.accounts || []).map((account) => account.id)]);
         results.push({ document, duplicateDocument: stored.duplicate, preview });
       } catch (error) {
         document.parseStatus = 'needs_review';
@@ -231,11 +237,15 @@ function canonicalDocumentName(document, preview, accountId, state) {
   const record = preview.records?.[0];
   const date = preview.kind === 'payslip'
     ? record?.payDate || `${record?.period || new Date().toISOString().slice(0, 7)}-01`
-    : [...(preview.records || [])].map((item) => item.date).filter(Boolean).sort().at(-1) || new Date().toISOString().slice(0, 10);
-  const type = preview.kind === 'payslip' ? 'payslip' : 'bank-statement';
+    : preview.kind === 'credit-report'
+      ? record?.reportDate || new Date().toISOString().slice(0, 10)
+      : [...(preview.records || [])].map((item) => item.date).filter(Boolean).sort().at(-1) || new Date().toISOString().slice(0, 10);
+  const type = preview.kind === 'payslip' ? 'payslip' : preview.kind === 'credit-report' ? 'credit-report' : 'bank-statement';
   const provider = preview.kind === 'payslip'
     ? 'jpa'
-    : slugName(state.accounts.find((account) => account.id === accountId)?.institution || 'unassigned');
+    : preview.kind === 'credit-report'
+      ? slugName(record?.provider || 'unknown-provider')
+      : slugName(state.accounts.find((account) => account.id === accountId)?.institution || 'unassigned');
   const base = `${date}__${type}__${provider}`;
   const used = new Set((state.documents || []).map((item) => item.displayName).filter(Boolean));
   let candidate = `${base}${extension}`;

--- a/main-process.js
+++ b/main-process.js
@@ -46,7 +46,7 @@ function createWindow() {
     height: 940,
     minWidth: 980,
     minHeight: 680,
-    backgroundColor: '#0d1117',
+    backgroundColor: '#061a38',
     show: !process.argv.includes('--capture-ui'),
     webPreferences: {
       preload: path.join(__dirname, 'preload-bridge.cjs'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onestep-money",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -533,6 +533,17 @@ function creditPlanLabel(item) {
 
 async function completeNextAction() {
   if (hasCompletedCheckIn(state.checkIns)) return;
+  const blocker = actionCompletionBlocker(pendingAction);
+  if (blocker) {
+    byId('nextActionDetail').textContent = blocker;
+    const panel = document.querySelector('.focus-panel');
+    panel.classList.remove('is-blocked');
+    void panel.offsetWidth;
+    panel.classList.add('is-blocked');
+    window.setTimeout(() => panel.classList.remove('is-blocked'), 460);
+    showToast('This action is still open. Complete it, or use the five-minute check-in below.');
+    return;
+  }
   const task = state.tasks.find((item) => item.id === pendingAction.id);
   if (task) task.completedAt = new Date().toISOString();
   state.checkIns.push({ id: createId('checkin'), date: new Date().toISOString(), completed: true, kind: 'action', actionId: pendingAction.id, note: pendingAction.title });
@@ -540,6 +551,12 @@ async function completeNextAction() {
   await animateFocusPanel('is-completing', 360);
   render();
   showToast('Today is complete. You can close the app now.');
+}
+
+function actionCompletionBlocker(action) {
+  if (action.id === 'generated-first-account' && !state.accounts.length) return 'This step is still open: add an account in Settings first. If you only reviewed your money today, use the five-minute check-in below instead.';
+  if (action.id === 'generated-first-import' && !state.transactions.length) return 'This step is still open: import and confirm at least one payment first. If you only reviewed your money today, use the five-minute check-in below instead.';
+  return '';
 }
 
 async function snoozeNextAction() {

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -1,7 +1,8 @@
 import {
   buildFallbackAnswer, buildFinancialChecks, buildNextAction, calculateBudgetRows,
   calculatePeriodSummary, calculateStreak, createId, debtPlan, exportTransactionsCsv,
-  findDuplicateCandidates, findSavingsOpportunities, formatCurrency, formatDate
+  creditReportDebtStatus, findDuplicateCandidates, findSavingsOpportunities, formatCurrency, formatDate,
+  hasCompletedCheckIn, planCreditReportAccounts, syncStatementAccount
 } from './finance-core.js';
 
 let state;
@@ -50,6 +51,7 @@ function bindEvents() {
   byId('quickCheckInButton').addEventListener('click', logCheckIn);
   byId('importStatementButton').addEventListener('click', () => importDocuments('statement'));
   byId('importPayslipButton').addEventListener('click', () => importDocuments('payslip'));
+  byId('importCreditReportButton').addEventListener('click', () => importDocuments('credit-report'));
   byId('exportCsvButton').addEventListener('click', async () => {
     const saved = await window.financeAPI.exportCsv(exportTransactionsCsv(state.transactions));
     if (saved) showToast('Payments exported safely.');
@@ -92,6 +94,9 @@ function render() {
   byId('nextActionTitle').textContent = pendingAction.title;
   byId('nextActionDetail').textContent = pendingAction.detail || '';
   byId('nextActionTime').textContent = pendingAction.timeframe || '10 min';
+  byId('completeActionButton').hidden = Boolean(pendingAction.passive);
+  byId('snoozeActionButton').hidden = Boolean(pendingAction.passive);
+  renderDailyCompletion();
   byId('marginValue').textContent = formatCurrency(summary.plannedMargin);
   byId('cashFlowValue').textContent = formatCurrency(summary.netCashFlow);
   byId('todayDebtValue').textContent = formatCurrency(summary.debts);
@@ -105,6 +110,7 @@ function render() {
   renderTransactions();
   renderPay();
   renderDebts();
+  renderCreditReports();
   renderOverdrafts();
   renderBudget();
   renderDocuments();
@@ -127,9 +133,22 @@ function renderMomentum() {
   const current = Number(state.settings.emergencyBufferBalance || 0);
   const target = Math.max(1, Number(state.settings.emergencyBufferTarget || 500));
   const percent = Math.min(100, Math.round((current / target) * 100));
+  const completedToday = hasCompletedCheckIn(state.checkIns);
   byId('bufferProgress').style.width = `${percent}%`;
   byId('momentumTitle').textContent = current ? `${percent}% of your starter buffer` : 'Showing up counts';
   byId('momentumText').textContent = current ? `${formatCurrency(current)} saved toward ${formatCurrency(target)}. Keep the target small while payments are being stabilised.` : 'Your first win is a completed check-in. The buffer can grow after essential payments are secure.';
+  byId('quickCheckInButton').disabled = completedToday;
+  byId('quickCheckInButton').textContent = completedToday ? 'Check-in complete today' : 'Complete five-minute check-in';
+  byId('checkInStatus').textContent = completedToday
+    ? 'Recorded for today. There is nothing else you need to tick off.'
+    : 'Use this when you reviewed your money but did not finish the action above.';
+}
+
+function renderDailyCompletion() {
+  const completedToday = hasCompletedCheckIn(state.checkIns);
+  document.querySelector('.focus-panel').hidden = completedToday;
+  document.querySelector('.permission-slip').hidden = completedToday;
+  byId('dailyCompleteState').hidden = !completedToday;
 }
 
 function renderTransactions() {
@@ -219,6 +238,20 @@ function renderDebts() {
   for (const item of state.debts) container.append(entityCard('debt', item, [stat('Balance', formatCurrency(item.currentBalance)), stat('APR', item.apr == null ? 'Unknown' : `${(item.apr * 100).toFixed(2)}%`), stat('Payment', item.contractualPayment ? formatCurrency(item.contractualPayment) : 'Unknown', true)]));
 }
 
+function renderCreditReports() {
+  const container = byId('creditReportCards'); clear(container);
+  const reports = [...(state.creditReports || [])].sort((left, right) => String(right.reportDate || '').localeCompare(String(left.reportDate || '')));
+  if (!reports.length) {
+    container.append(element('p', 'muted', 'No credit reports imported yet.'));
+    return;
+  }
+  for (const report of reports) {
+    const score = report.score == null ? 'Score not detected' : `Score ${report.score}${report.scoreMaximum ? ` / ${report.scoreMaximum}` : ''}`;
+    const detail = `${report.reportDate ? formatDate(report.reportDate) : 'Date not detected'} · ${score} · ${(report.accounts || []).length} reported account${(report.accounts || []).length === 1 ? '' : 's'}`;
+    container.append(entityCard('credit report', { ...report, name: report.provider, description: detail }, [], false));
+  }
+}
+
 function renderOverdrafts() {
   const total = state.overdrafts.reduce((sum, item) => sum + Number(item.currentBalance || 0), 0);
   byId('overdraftTotalValue').textContent = formatCurrency(total);
@@ -262,7 +295,7 @@ function renderDocuments() {
   const container = byId('documentCards'); clear(container);
   const documents = [...state.documents].sort((left, right) => right.importedAt.localeCompare(left.importedAt));
   if (!documents.length) {
-    const empty = element('article', 'panel'); append(empty, element('h2', '', 'No secure documents yet'), element('p', 'muted', 'Import a bank statement or payslip. The encrypted original will appear here automatically.')); container.append(empty); return;
+    const empty = element('article', 'panel'); append(empty, element('h2', '', 'No secure documents yet'), element('p', 'muted', 'Import a bank statement, payslip or credit report. The encrypted original will appear here automatically.')); container.append(empty); return;
   }
   for (const documentItem of documents) {
     const card = entityCard('document', documentItem, [stat('Type', titleCase(documentItem.kind)), stat('Imported', formatDate(documentItem.importedAt)), stat('Status', titleCase(documentItem.parseStatus), true)], false);
@@ -330,7 +363,14 @@ function showNextImport() {
   const preview = currentImport.preview;
   byId('importTitle').textContent = currentImport.document.originalName;
   const summary = byId('importSummary'); clear(summary);
-  if (preview.kind === 'payslip') {
+  if (preview.kind === 'credit-report') {
+    const report = preview.records[0];
+    currentImport.creditPlan = report ? creditReportAdditionPlan(report) : [];
+    const newBalances = currentImport.creditPlan.filter((item) => item.action === 'add-debt' || item.action === 'add-overdraft').length;
+    const updates = currentImport.creditPlan.filter((item) => item.action === 'existing').length;
+    const score = preview.summary.score == null ? 'Not detected' : `${preview.summary.score}${preview.summary.scoreMaximum ? ` / ${preview.summary.scoreMaximum}` : ''}`;
+    append(summary, summaryTile('Provider', preview.summary.provider || 'Unknown'), summaryTile('Report date', preview.summary.reportDate ? formatDate(preview.summary.reportDate) : 'Not detected'), summaryTile('Score', score), summaryTile('Debt sync', `${newBalances} new · ${updates} update${updates === 1 ? '' : 's'}`));
+  } else if (preview.kind === 'payslip') {
     append(summary, summaryTile('Period', monthLabel(preview.summary.period)), summaryTile('Gross', formatCurrency(preview.summary.gross)), summaryTile('Deductions', formatCurrency(preview.summary.deductions)), summaryTile('Net', formatCurrency(preview.summary.net)));
   } else {
     append(summary, summaryTile('Records', preview.records.length), summaryTile('Money in', formatCurrency(preview.summary.incoming)), summaryTile('Money out', formatCurrency(preview.summary.outgoing)), summaryTile('Reconciled', preview.reconciled ? 'Yes' : 'Needs review'));
@@ -340,14 +380,30 @@ function showNextImport() {
   warning.hidden = !messages.length; warning.textContent = messages.join('\n');
   renderImportPreview(preview);
   byId('confirmImportButton').disabled = !preview.records.length;
+  byId('confirmImportButton').textContent = preview.kind === 'credit-report' ? 'Save report and sync debts' : 'Import reviewed records';
   byId('importDialog').showModal();
 }
 
 function renderImportPreview(preview) {
   const head = byId('importPreviewHead'); const body = byId('importPreviewRows'); clear(head); clear(body);
   const headerRow = document.createElement('tr');
-  const headers = preview.kind === 'payslip' ? ['Period', 'Gross', 'Deductions', 'Net'] : ['Date', 'Description', 'Incoming', 'Outgoing', 'Balance'];
+  const headers = preview.kind === 'credit-report'
+    ? ['Lender', 'Type', 'Balance', 'Limit', 'Action']
+    : preview.kind === 'payslip' ? ['Period', 'Gross', 'Deductions', 'Net'] : ['Date', 'Description', 'Incoming', 'Outgoing', 'Balance'];
   headers.forEach((label) => headerRow.append(element('th', '', label))); head.append(headerRow);
+  if (preview.kind === 'credit-report') {
+    const plan = currentImport?.creditPlan || [];
+    if (!plan.length) {
+      const row = document.createElement('tr'); const empty = cell('No structured account rows detected. The PDF can still be stored securely.'); empty.colSpan = 5; row.append(empty); body.append(row);
+      return;
+    }
+    for (const item of plan) {
+      const row = document.createElement('tr');
+      append(row, cell(item.account.lender), cell(item.account.accountType || 'Unknown'), amountCell(item.account.currentBalance), amountCell(item.account.creditLimit), cell(creditPlanLabel(item)));
+      body.append(row);
+    }
+    return;
+  }
   for (const record of preview.records.slice(0, 100)) {
     const row = document.createElement('tr');
     if (preview.kind === 'payslip') append(row, cell(monthLabel(record.period)), amountCell(record.grossPay), amountCell(record.totalDeductions), amountCell(record.netPay));
@@ -360,7 +416,14 @@ async function confirmCurrentImport(event) {
   event.preventDefault();
   if (!currentImport) return;
   const preview = currentImport.preview;
-  if (preview.kind === 'payslip') {
+  let completionMessage = 'Reviewed records imported.';
+  if (preview.kind === 'credit-report') {
+    const report = preview.records[0];
+    state.creditReports ||= [];
+    if (report && !state.creditReports.some((item) => item.id === report.id || item.sourceDocumentId === report.sourceDocumentId)) state.creditReports.push(report);
+    const added = applyCreditReportPlan(report, currentImport.creditPlan || []);
+    completionMessage = `Credit report saved. ${added.debts} debt${added.debts === 1 ? '' : 's'} and ${added.overdrafts} overdraft${added.overdrafts === 1 ? '' : 's'} added; ${added.updated} tracked balance${added.updated === 1 ? '' : 's'} updated.`;
+  } else if (preview.kind === 'payslip') {
     for (const record of preview.records) if (!state.payslips.some((item) => item.id === record.id)) state.payslips.push(record);
   } else {
     const duplicates = findDuplicateCandidates(state.transactions, preview.records);
@@ -368,40 +431,154 @@ async function confirmCurrentImport(event) {
     const possibleIds = new Set(duplicates.possible.map((item) => item.incoming.id));
     state.transactions.push(...preview.records.filter((item) => !exactIds.has(item.id)).map((item) => ({ ...item, duplicateStatus: possibleIds.has(item.id) ? 'possible' : 'none' })));
     const account = state.accounts.find((item) => item.id === preview.accountHint);
-    if (account && preview.reconciled && Number.isFinite(preview.summary.closingBalance)) {
-      account.currentBalance = preview.summary.closingBalance;
-      account.statementDate = preview.records.map((item) => item.date).filter(Boolean).sort().at(-1) || account.statementDate;
+    if (account) {
+      const overdraftSync = syncStatementAccount(state, account, preview, currentImport.document.id);
+      completionMessage = overdraftSync === 'overdraft-created'
+        ? 'Statement imported. Account balance updated and its overdraft added.'
+        : overdraftSync === 'overdraft-updated' ? 'Statement imported. Account and overdraft balances updated.'
+          : overdraftSync === 'account-updated' ? 'Statement imported and account balance updated.' : completionMessage;
     }
     if (exactIds.size) showToast(`${exactIds.size} exact duplicate${exactIds.size === 1 ? '' : 's'} skipped.`);
   }
-  state.importBatches.push({ id: createId('import'), documentId: currentImport.document.id, kind: preview.kind, importedAt: new Date().toISOString(), recordCount: preview.records.length, reconciled: preview.reconciled });
+  const recordCount = preview.kind === 'credit-report' ? (preview.records[0]?.accounts || []).length : preview.records.length;
+  state.importBatches.push({ id: createId('import'), documentId: currentImport.document.id, kind: preview.kind, importedAt: new Date().toISOString(), recordCount, reconciled: preview.reconciled });
   await saveState();
   byId('importDialog').close('confirmed');
   currentImport = null;
   render();
-  showToast('Reviewed records imported.');
+  showToast(completionMessage);
   showNextImport();
 }
 
+function creditReportAdditionPlan(report) {
+  return planCreditReportAccounts(state.debts, state.overdrafts, report?.accounts || []);
+}
+
+function applyCreditReportPlan(report, plan) {
+  const added = { debts: 0, overdrafts: 0, updated: 0 };
+  for (const item of plan) {
+    const account = item.account;
+    if (item.action === 'existing') {
+      const collection = item.kind === 'overdraft' ? state.overdrafts : state.debts;
+      const existing = collection.find((entry) => entry.id === item.existingId);
+      if (existing) {
+        applyReportedAccountFields(existing, account, report);
+        added.updated += 1;
+      }
+      continue;
+    }
+    if (!['add-debt', 'add-overdraft'].includes(item.action)) continue;
+    const common = {
+      name: account.lender || 'Reported account',
+      currentBalance: Number(account.currentBalance || 0),
+      apr: account.apr ?? null,
+      contractualPayment: account.contractualPayment ?? null,
+      creditLimit: account.creditLimit ?? null,
+      originalBalance: account.originalBalance ?? null,
+      openedDate: account.openedDate || '',
+      defaultDate: account.defaultDate || '',
+      lastReportedAt: account.updatedDate || report.reportDate || '',
+      reportedStatus: account.status || '',
+      status: creditReportDebtStatus(account.status),
+      includeInPlan: true,
+      arrangementConfirmed: false,
+      interestFrozen: false,
+      planPriority: 999,
+      accountReference: account.accountReference || '',
+      sourceCreditReportId: report.id,
+      sourceCreditAccountId: account.id,
+      description: `Imported from ${report.provider} credit report${report.reportDate ? ` dated ${formatDate(report.reportDate)}` : ''}.`,
+      notes: 'Confirm the APR, minimum payment and current balance against the lender before planning overpayments.',
+      updatedAt: new Date().toISOString()
+    };
+    if (item.action === 'add-overdraft') {
+      state.overdrafts.push({ id: createId('overdraft'), ...common, type: 'overdraft', accountId: '', limit: account.creditLimit ?? null });
+      added.overdrafts += 1;
+    } else {
+      state.debts.push({ id: createId('debt'), ...common, type: account.accountType || 'Credit report account' });
+      added.debts += 1;
+    }
+  }
+  return added;
+}
+
+function applyReportedAccountFields(existing, account, report) {
+  if (account.currentBalance !== null && account.currentBalance !== undefined && Number.isFinite(Number(account.currentBalance))) existing.currentBalance = Number(account.currentBalance);
+  if (account.apr !== null && account.apr !== undefined) existing.apr = account.apr;
+  if (account.contractualPayment !== null && account.contractualPayment !== undefined) existing.contractualPayment = account.contractualPayment;
+  if (account.creditLimit !== null && account.creditLimit !== undefined) {
+    existing.creditLimit = account.creditLimit;
+    if ('limit' in existing) existing.limit = account.creditLimit;
+  }
+  if (account.originalBalance !== null && account.originalBalance !== undefined) existing.originalBalance = account.originalBalance;
+  if (account.openedDate) existing.openedDate = account.openedDate;
+  if (account.defaultDate) existing.defaultDate = account.defaultDate;
+  if (account.accountReference) existing.accountReference = account.accountReference;
+  if (account.status) {
+    existing.reportedStatus = account.status;
+    existing.status = creditReportDebtStatus(account.status);
+  }
+  existing.lastReportedAt = account.updatedDate || report.reportDate || existing.lastReportedAt || '';
+  existing.sourceCreditReportId = report.id;
+  existing.sourceCreditAccountId = account.id;
+  existing.updatedAt = new Date().toISOString();
+}
+
+function creditPlanLabel(item) {
+  if (item.action === 'add-debt') return 'Add as new debt';
+  if (item.action === 'add-overdraft') return 'Add as overdraft';
+  if (item.action === 'existing') return 'Update tracked balance';
+  return 'No balance — do not add';
+}
+
 async function completeNextAction() {
+  if (hasCompletedCheckIn(state.checkIns)) return;
   const task = state.tasks.find((item) => item.id === pendingAction.id);
   if (task) task.completedAt = new Date().toISOString();
-  state.checkIns.push({ id: createId('checkin'), date: new Date().toISOString(), note: pendingAction.title });
-  await saveAndRender();
-  showToast('Done. You can close the app now.');
+  state.checkIns.push({ id: createId('checkin'), date: new Date().toISOString(), completed: true, kind: 'action', actionId: pendingAction.id, note: pendingAction.title });
+  await saveState();
+  await animateFocusPanel('is-completing', 360);
+  render();
+  showToast('Today is complete. You can close the app now.');
 }
 
 async function snoozeNextAction() {
   const task = state.tasks.find((item) => item.id === pendingAction.id);
-  if (task) { const tomorrow = new Date(); tomorrow.setDate(tomorrow.getDate() + 1); task.snoozedUntil = tomorrow.toISOString().slice(0, 10); }
-  await saveAndRender();
-  showToast('Snoozed for one day.');
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const snoozedUntil = localDateKey(tomorrow);
+  if (task) task.snoozedUntil = snoozedUntil;
+  else {
+    state.settings.snoozedActions ||= {};
+    state.settings.snoozedActions[pendingAction.id] = snoozedUntil;
+  }
+  await saveState();
+  await animateFocusPanel('is-switching', 180);
+  render();
+  const panel = document.querySelector('.focus-panel');
+  panel.classList.add('is-arriving');
+  window.setTimeout(() => panel.classList.remove('is-arriving'), 320);
+  showToast('Snoozed until tomorrow. Here is your next available step.');
 }
 
 async function logCheckIn() {
-  state.checkIns.push({ id: createId('checkin'), date: new Date().toISOString(), note: 'Five-minute check-in' });
-  await saveAndRender();
-  showToast('Check-in logged. That is enough for today.');
+  if (hasCompletedCheckIn(state.checkIns)) {
+    showToast('Today’s check-in is already complete.');
+    return;
+  }
+  state.checkIns.push({ id: createId('checkin'), date: new Date().toISOString(), completed: true, kind: 'five-minute', note: 'Five-minute check-in' });
+  await saveState();
+  await animateFocusPanel('is-completing', 360);
+  render();
+  showToast('Five-minute check-in complete. That is enough for today.');
+}
+
+async function animateFocusPanel(className, duration) {
+  const panel = document.querySelector('.focus-panel');
+  if (!panel || panel.hidden) return;
+  panel.classList.add(className);
+  await new Promise((resolve) => window.setTimeout(resolve, duration));
+  panel.classList.remove(className);
 }
 
 function handleEditClick(event) {
@@ -439,10 +616,12 @@ function editorDefinitions(type) {
   ];
   if (type === 'payslip') return [['notes', 'Notes', 'textarea', '', 'wide-field']];
   if (type === 'budget') return [['section','Section','select',[['Essentials','Essentials'],['Debt minimums','Debt minimums'],['Flexible','Flexible'],['Goals','Goals']]], ['category','Category','text'], ['planned','Planned monthly amount','number'], ['notes','Notes','textarea','','wide-field']];
-  const base = [['name','Name','text'], ['type','Type','text'], ['currentBalance','Current balance','number'], ['aprPercent','APR (%) - leave blank if unknown','number'], ['contractualPayment','Contractual payment','number'], ['status','Status','select',[['current','Current'],['arrears','Arrears'],['defaulted','Defaulted'],['over_limit','Over limit']]], ['includeInPlan','Include in payoff plan','checkbox'], ['arrangementConfirmed','Payment arrangement confirmed','checkbox'], ['interestFrozen','Interest or charges frozen','checkbox'], ['description','Description','textarea','','wide-field'], ['notes','Notes','textarea','','wide-field']];
+  const base = [['name','Name','text'], ['type','Type','text'], ['accountReference','Account reference / last four digits','text'], ['openedDate','Opened date','date'], ['defaultDate','Default date','date'], ['lastReportedAt','Last reported date','date'], ['currentBalance','Current balance','number'], ['aprPercent','APR (%) - leave blank if unknown','number'], ['contractualPayment','Contractual payment','number'], ['status','Status','select',[['current','Current'],['arrears','Arrears'],['defaulted','Defaulted'],['over_limit','Over limit']]], ['includeInPlan','Include in payoff plan','checkbox'], ['arrangementConfirmed','Payment arrangement confirmed','checkbox'], ['interestFrozen','Interest or charges frozen','checkbox'], ['description','Description','textarea','','wide-field'], ['notes','Notes','textarea','','wide-field']];
   if (type === 'overdraft') {
     base.splice(1, 0, ['accountId', 'Linked account', 'select', [['','Not linked'], ...state.accounts.map((account) => [account.id, account.name])]]);
-    base.splice(4, 0, ['limit','Overdraft limit','number']);
+    base.splice(8, 0, ['limit','Overdraft limit','number']);
+  } else {
+    base.splice(7, 0, ['originalBalance','Original balance / amount','number'], ['creditLimit','Credit limit','number']);
   }
   return base;
 }
@@ -504,7 +683,7 @@ async function handleDocumentClick(event) {
   const open = event.target.closest('[data-document-open]');
   if (open) { try { await window.financeAPI.openDocument(open.dataset.documentOpen); } catch (error) { showToast(error.message); } return; }
   const remove = event.target.closest('[data-document-delete]');
-  if (remove && window.confirm('Permanently delete this encrypted document? Its imported payment records will remain.')) {
+  if (remove && window.confirm('Permanently delete this encrypted document? Records already imported from it will remain.')) {
     state = await window.financeAPI.deleteDocument(remove.dataset.documentDelete); render(); showToast('Encrypted document deleted.');
   }
 }
@@ -617,6 +796,7 @@ function element(tag, className = '', text = '') { const output = document.creat
 function append(parent, ...children) { parent.append(...children); return parent; }
 function clear(node) { while (node.firstChild) node.firstChild.remove(); }
 function monthLabel(month) { if (!/^\d{4}-\d{2}$/.test(month || '')) return month || 'Unknown'; return new Intl.DateTimeFormat('en-GB', { month: 'long', year: 'numeric' }).format(new Date(`${month}-01T12:00:00`)); }
+function localDateKey(value) { const date = value instanceof Date ? value : new Date(value); return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`; }
 function titleCase(value) { return String(value || '').replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()); }
 function statusLabel(value) { return value ? `Status: ${titleCase(value)}` : 'No notes yet'; }
 function showToast(message) { const toast = byId('toast'); toast.textContent = message; toast.hidden = false; window.clearTimeout(showToast.timer); showToast.timer = window.setTimeout(() => { toast.hidden = true; }, 4200); }

--- a/scripts/check-project.mjs
+++ b/scripts/check-project.mjs
@@ -13,7 +13,7 @@ for (const file of javascript) {
 }
 
 const seed = JSON.parse(fs.readFileSync(path.join(root, 'seed-data.json'), 'utf8'));
-const emptyCollections = ['accounts', 'transactions', 'payslips', 'taxDocuments', 'debts', 'overdrafts', 'budgets', 'scheduledPayments', 'documents', 'tasks', 'checkIns', 'importBatches'];
+const emptyCollections = ['accounts', 'transactions', 'payslips', 'taxDocuments', 'creditReports', 'debts', 'overdrafts', 'budgets', 'scheduledPayments', 'documents', 'tasks', 'checkIns', 'importBatches'];
 for (const collection of emptyCollections) {
   if (!Array.isArray(seed[collection]) || seed[collection].length) throw new Error(`Public seed ${collection} must be an empty array.`);
 }

--- a/seed-data.json
+++ b/seed-data.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "meta": {
     "createdAt": "",
     "updatedAt": ""
@@ -15,6 +15,7 @@
   "transactions": [],
   "payslips": [],
   "taxDocuments": [],
+  "creditReports": [],
   "debts": [],
   "overdrafts": [],
   "budgets": [],

--- a/static-preview-server.js
+++ b/static-preview-server.js
@@ -11,7 +11,8 @@ const publicFiles = new Map([
   ['/styles.css', ['styles.css', 'text/css; charset=utf-8']],
   ['/renderer-app.js', ['renderer-app.js', 'text/javascript; charset=utf-8']],
   ['/finance-core.js', ['finance-core.js', 'text/javascript; charset=utf-8']],
-  ['/assets/onestep-money-icon.png', ['assets/onestep-money-icon.png', 'image/png']]
+  ['/assets/onestep-money-icon.png', ['assets/onestep-money-icon.png', 'image/png']],
+  ['/assets/onestep-money-wordmark.png', ['assets/onestep-money-wordmark.png', 'image/png']]
 ]);
 
 http.createServer(async (request, response) => {

--- a/styles.css
+++ b/styles.css
@@ -1,210 +1,585 @@
 :root {
   color-scheme: light;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --ink: #17202b;
-  --muted: #677386;
-  --canvas: #f4f3ef;
+  --ink: #10233f;
+  --ink-soft: #263b58;
+  --muted: #6d7c91;
+  --canvas: #f3f7fb;
   --panel: #ffffff;
-  --line: #e4e2da;
-  --dark: #0d1117;
-  --dark-soft: #171d25;
-  --orange: #f46f16;
-  --orange-dark: #c94e00;
-  --orange-soft: #fff0e5;
-  --green: #18754b;
-  --green-soft: #e7f6ee;
-  --red: #b83b45;
-  --red-soft: #fdebed;
-  --amber: #8b5c00;
-  --amber-soft: #fff4d8;
-  --shadow: 0 18px 45px rgba(22, 28, 37, 0.08);
+  --panel-soft: #f8fafc;
+  --line: #dfe7f0;
+  --line-strong: #ccd9e6;
+  --navy: #0c295d;
+  --navy-deep: #061a38;
+  --navy-soft: #eaf0f8;
+  --teal: #18b99e;
+  --teal-dark: #087f73;
+  --teal-soft: #e6f8f4;
+  --green: #11845e;
+  --green-soft: #e5f7ef;
+  --red: #c14152;
+  --red-soft: #fdecef;
+  --amber: #9a6a0a;
+  --amber-soft: #fff6df;
+  --shadow-sm: 0 3px 12px rgba(18, 45, 78, 0.055);
+  --shadow: 0 16px 45px rgba(18, 45, 78, 0.09);
+  --shadow-strong: 0 28px 75px rgba(2, 22, 50, 0.2);
 }
 
 * { box-sizing: border-box; }
-html { min-width: 320px; background: var(--canvas); }
-body { margin: 0; color: var(--ink); background: var(--canvas); }
+html { min-width: 320px; min-height: 100%; background: var(--canvas); }
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 82% -10%, rgba(24, 185, 158, 0.09), transparent 29rem),
+    linear-gradient(145deg, #f7f9fc 0%, var(--canvas) 54%, #eef5f8 100%);
+}
+body::before {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  content: "";
+  opacity: 0.22;
+  background-image: radial-gradient(rgba(12, 41, 93, 0.16) 0.65px, transparent 0.65px);
+  background-size: 18px 18px;
+  mask-image: linear-gradient(to bottom, black, transparent 65%);
+}
+[hidden] { display: none !important; }
 button, input, select, textarea { font: inherit; }
 button { cursor: pointer; }
-button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible { outline: 3px solid rgba(244, 111, 22, 0.42); outline-offset: 2px; }
-button:disabled { cursor: not-allowed; opacity: 0.55; }
+button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible, summary:focus-visible {
+  outline: 3px solid rgba(24, 185, 158, 0.32);
+  outline-offset: 3px;
+}
+button:disabled { cursor: not-allowed; opacity: 0.5; filter: saturate(0.55); }
 h1, h2, h3, p { margin-top: 0; }
-h1 { font-size: clamp(1.7rem, 2.6vw, 2.35rem); letter-spacing: -0.035em; margin-bottom: 0; }
-h2 { font-size: 1.2rem; letter-spacing: -0.02em; margin-bottom: 0.45rem; }
-h3 { font-size: 1rem; margin-bottom: 0.25rem; }
+h1 { margin-bottom: 0; font-size: clamp(1.65rem, 2.25vw, 2.2rem); letter-spacing: -0.045em; line-height: 1.05; }
+h2 { margin-bottom: 0.45rem; font-size: 1.18rem; letter-spacing: -0.025em; }
+h3 { margin-bottom: 0.25rem; font-size: 0.98rem; letter-spacing: -0.012em; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 
-.desktop-required { max-width: 560px; margin: 15vh auto; padding: 2rem; text-align: center; }
-.app-shell { min-height: 100vh; display: grid; grid-template-columns: 250px minmax(0, 1fr); }
-.sidebar { position: sticky; top: 0; height: 100vh; background: var(--dark); color: #fff; padding: 1.15rem; display: flex; flex-direction: column; gap: 1.4rem; }
-.brand { display: flex; align-items: center; gap: 0.75rem; padding: 0.45rem; }
-.brand-mark { width: 42px; height: 42px; display: block; border-radius: 12px; object-fit: cover; background: #fff; }
-.brand div { display: grid; gap: 0.12rem; }
-.brand span:last-child { color: #9ba6b5; font-size: 0.72rem; }
-.sidebar nav { display: grid; gap: 0.3rem; }
-.nav-button { width: 100%; display: flex; align-items: center; gap: 0.72rem; padding: 0.72rem 0.8rem; border: 0; border-radius: 11px; color: #aeb7c4; background: transparent; text-align: left; font-weight: 700; }
-.nav-button span { width: 20px; text-align: center; color: #697584; }
-.nav-button:hover { color: #fff; background: rgba(255,255,255,0.06); }
-.nav-button.active { color: #fff; background: var(--dark-soft); box-shadow: inset 3px 0 var(--orange); }
-.nav-button.active span { color: var(--orange); }
-.privacy-status { margin-top: auto; display: flex; align-items: center; gap: 0.55rem; color: #aeb7c4; font-size: 0.76rem; padding: 0.7rem; line-height: 1.35; }
-.status-dot { width: 9px; height: 9px; flex: 0 0 9px; border-radius: 50%; background: #6f7782; }
-.status-dot.good { background: #43cf87; box-shadow: 0 0 0 4px rgba(67,207,135,0.12); }
-.status-dot.bad { background: #ff6975; }
+.desktop-required {
+  width: min(560px, calc(100vw - 2rem));
+  margin: 12vh auto;
+  padding: 2.6rem;
+  overflow: hidden;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(204, 217, 230, 0.82);
+  border-radius: 28px;
+  box-shadow: var(--shadow-strong);
+}
+.desktop-required img { width: min(380px, 100%); margin-bottom: 2.2rem; }
+.desktop-required > p:last-child { max-width: 420px; margin: 0.7rem auto 0; color: var(--muted); line-height: 1.6; }
 
-.main-content { min-width: 0; padding: 1.5rem clamp(1rem, 3vw, 2.6rem) 3rem; }
-.topbar { max-width: 1260px; margin: 0 auto 1.5rem; min-height: 64px; display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.app-shell { min-height: 100vh; display: grid; grid-template-columns: 264px minmax(0, 1fr); }
+.sidebar {
+  position: sticky;
+  top: 0;
+  isolation: isolate;
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1rem;
+  color: #fff;
+  background: linear-gradient(165deg, #071a38 0%, #0b2b5d 57%, #093c66 100%);
+  box-shadow: 9px 0 34px rgba(7, 31, 68, 0.09);
+}
+.sidebar::before, .sidebar::after {
+  position: absolute;
+  z-index: -1;
+  pointer-events: none;
+  border-radius: 50%;
+  content: "";
+}
+.sidebar::before {
+  top: -105px;
+  left: -80px;
+  width: 280px;
+  height: 280px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 0 0 28px rgba(255, 255, 255, 0.025), 0 0 0 58px rgba(255, 255, 255, 0.018);
+}
+.sidebar::after {
+  right: -90px;
+  bottom: 80px;
+  width: 210px;
+  height: 210px;
+  background: radial-gradient(circle, rgba(24, 185, 158, 0.3), transparent 68%);
+  filter: blur(8px);
+}
+.brand {
+  min-height: 61px;
+  display: flex;
+  align-items: center;
+  gap: 0.78rem;
+  padding: 0.48rem 0.48rem 0.78rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+.brand-mark {
+  width: 46px;
+  height: 46px;
+  flex: 0 0 46px;
+  display: block;
+  object-fit: cover;
+  background: #fff;
+  border: 3px solid rgba(255, 255, 255, 0.9);
+  border-radius: 15px;
+  box-shadow: 0 9px 24px rgba(1, 18, 40, 0.28);
+}
+.brand-copy { min-width: 0; display: grid; gap: 0.12rem; }
+.brand-copy strong { white-space: nowrap; font-size: 1.02rem; letter-spacing: -0.025em; }
+.brand-copy strong span:last-child { color: #5ee1ca; }
+.brand-copy > span { overflow: hidden; color: #aebdd1; font-size: 0.67rem; text-overflow: ellipsis; white-space: nowrap; }
+.sidebar nav {
+  min-height: 0;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.28rem;
+  padding-right: 0.08rem;
+  scrollbar-width: none;
+}
+.sidebar nav::-webkit-scrollbar { display: none; }
+.nav-button {
+  position: relative;
+  width: 100%;
+  min-height: 45px;
+  display: flex;
+  align-items: center;
+  gap: 0.78rem;
+  padding: 0.7rem 0.78rem;
+  border: 1px solid transparent;
+  border-radius: 13px;
+  color: #b8c5d8;
+  background: transparent;
+  text-align: left;
+  font-size: 0.83rem;
+  font-weight: 710;
+  transition: color 180ms ease, background 180ms ease, border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+.nav-button svg {
+  width: 19px;
+  height: 19px;
+  flex: 0 0 19px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.72;
+}
+.nav-button:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.065);
+  transform: translateX(2px);
+}
+.nav-button.active {
+  color: #fff;
+  background: linear-gradient(105deg, rgba(24, 185, 158, 0.25), rgba(255, 255, 255, 0.095));
+  border-color: rgba(102, 227, 205, 0.22);
+  box-shadow: 0 8px 24px rgba(1, 19, 45, 0.2), inset 3px 0 #42d4bc;
+}
+.nav-button.active svg { color: #5be0c8; opacity: 1; filter: drop-shadow(0 0 8px rgba(53, 208, 181, 0.38)); }
+.privacy-status {
+  position: relative;
+  z-index: 1;
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.78rem;
+  color: #bdc9d9;
+  background: rgba(4, 20, 44, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 14px;
+  font-size: 0.7rem;
+  line-height: 1.35;
+  backdrop-filter: blur(10px);
+}
+.privacy-copy { min-width: 0; display: grid; gap: 0.12rem; }
+.privacy-copy strong { color: #f2f7fc; font-size: 0.72rem; }
+.privacy-copy span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.status-dot { width: 9px; height: 9px; flex: 0 0 9px; border-radius: 50%; background: #74839a; box-shadow: 0 0 0 4px rgba(116, 131, 154, 0.1); }
+.status-dot.good { background: #4fe2b1; box-shadow: 0 0 0 4px rgba(79, 226, 177, 0.13), 0 0 13px rgba(79, 226, 177, 0.44); animation: statusPulse 2.8s ease-in-out infinite; }
+.status-dot.bad { background: #ff7181; box-shadow: 0 0 0 4px rgba(255, 113, 129, 0.12); }
+
+.main-content { min-width: 0; padding: 1rem clamp(1.1rem, 3vw, 2.8rem) 3.5rem; }
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  max-width: 1300px;
+  min-height: 76px;
+  margin: 0 auto 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: linear-gradient(to bottom, rgba(244, 248, 252, 0.96) 65%, rgba(244, 248, 252, 0));
+  backdrop-filter: blur(10px);
+}
+.title-stack { display: grid; gap: 0.1rem; }
 .topbar-actions, .button-row, .focus-actions, .section-actions { display: flex; align-items: center; gap: 0.7rem; }
 .section-actions { justify-content: space-between; margin-bottom: 1.1rem; align-items: flex-end; }
-.section-actions p { color: var(--muted); margin-bottom: 0; max-width: 720px; }
-.eyebrow { color: var(--orange-dark); font-size: 0.68rem; letter-spacing: 0.17em; font-weight: 900; margin-bottom: 0.35rem; }
-.view { display: none; max-width: 1260px; margin: 0 auto; }
-.view.active { display: block; }
-.compact-field { display: flex; align-items: center; gap: 0.45rem; font-size: 0.78rem; color: var(--muted); font-weight: 700; }
-.compact-field select { min-width: 135px; }
-.streak-chip, .time-chip, .status-pill { display: inline-flex; align-items: center; gap: 0.38rem; border-radius: 999px; padding: 0.48rem 0.68rem; background: #fff; border: 1px solid var(--line); color: var(--ink); font-size: 0.78rem; }
-.streak-chip span { color: var(--orange); }
+.section-actions > div:first-child { max-width: 760px; }
+.section-actions p { margin-bottom: 0; color: var(--muted); line-height: 1.52; }
+.eyebrow { margin-bottom: 0.32rem; color: var(--teal-dark); font-size: 0.65rem; font-weight: 850; letter-spacing: 0.18em; }
+.view { max-width: 1300px; margin: 0 auto; display: none; }
+.view.active { display: block; animation: viewIn 340ms cubic-bezier(0.2, 0.75, 0.25, 1) both; }
+.compact-field { display: flex; align-items: center; gap: 0.5rem; color: var(--muted); font-size: 0.75rem; font-weight: 720; }
+.compact-field select { min-width: 142px; padding-block: 0.57rem; }
+.streak-chip, .time-chip, .status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.5rem 0.72rem;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  box-shadow: var(--shadow-sm);
+  font-size: 0.76rem;
+  backdrop-filter: blur(10px);
+}
+.streak-icon { color: var(--teal); font-size: 0.72rem; filter: drop-shadow(0 2px 4px rgba(24, 185, 158, 0.28)); }
 
-.focus-panel { display: flex; justify-content: space-between; gap: 1.5rem; align-items: center; color: #fff; background: linear-gradient(130deg, #111820 0%, #1f2935 70%, #2d2119 100%); border-radius: 22px; padding: clamp(1.35rem, 3vw, 2.25rem); box-shadow: var(--shadow); }
-.focus-panel .eyebrow { color: #ff9b59; }
-.focus-panel h2 { font-size: clamp(1.45rem, 3vw, 2.15rem); max-width: 760px; }
-.focus-panel p:not(.eyebrow) { color: #c5cdd7; max-width: 720px; margin: 0; line-height: 1.55; }
-.focus-actions { min-width: 155px; flex-direction: column; align-items: stretch; }
-.focus-actions .time-chip { align-self: flex-end; background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.14); color: #fff; }
-.permission-slip { color: var(--muted); text-align: center; font-size: 0.86rem; margin: 0.75rem 0 1.25rem; }
+.focus-panel {
+  position: relative;
+  isolation: isolate;
+  min-height: 190px;
+  overflow: hidden;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+  padding: clamp(1.45rem, 3vw, 2.35rem);
+  color: #fff;
+  background: linear-gradient(118deg, #071d43 0%, #0b3268 57%, #086c76 125%);
+  border: 1px solid rgba(91, 224, 200, 0.18);
+  border-radius: 25px;
+  box-shadow: 0 23px 56px rgba(7, 35, 76, 0.2);
+}
+.focus-panel::before {
+  position: absolute;
+  z-index: -1;
+  top: -130px;
+  right: 8%;
+  width: 420px;
+  height: 420px;
+  border: 1px solid rgba(112, 232, 212, 0.14);
+  border-radius: 50%;
+  box-shadow: 0 0 0 42px rgba(82, 218, 195, 0.035), 0 0 0 90px rgba(82, 218, 195, 0.022);
+  content: "";
+  animation: floatRing 9s ease-in-out infinite;
+}
+.focus-panel::after {
+  position: absolute;
+  z-index: -1;
+  right: -30px;
+  bottom: -80px;
+  width: 260px;
+  height: 190px;
+  content: "";
+  background: radial-gradient(circle, rgba(44, 218, 188, 0.28), transparent 67%);
+  filter: blur(12px);
+}
+.focus-copy { min-width: 0; display: flex; align-items: flex-start; gap: 1.15rem; }
+.step-emblem {
+  position: relative;
+  width: 54px;
+  height: 54px;
+  flex: 0 0 54px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 50%;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset -12px -12px 0 rgba(25, 202, 171, 0.26), 0 10px 22px rgba(1, 16, 39, 0.22);
+  font-size: 1.45rem;
+  font-weight: 850;
+  backdrop-filter: blur(10px);
+}
+.step-emblem::after {
+  position: absolute;
+  right: 1px;
+  bottom: 1px;
+  width: 18px;
+  height: 18px;
+  content: "";
+  background: var(--teal);
+  border: 3px solid #0a3f70;
+  border-radius: 6px 6px 50% 6px;
+}
+.focus-panel .eyebrow { color: #67e0cb; }
+.focus-panel h2 { max-width: 760px; margin-bottom: 0.58rem; font-size: clamp(1.42rem, 2.65vw, 2.08rem); letter-spacing: -0.035em; line-height: 1.12; }
+.focus-panel p:not(.eyebrow) { max-width: 720px; margin: 0; color: #c4d3e4; line-height: 1.55; }
+.focus-actions { min-width: 164px; flex-direction: column; align-items: stretch; }
+.focus-actions .time-chip { align-self: flex-end; color: #d9e7f5; background: rgba(255, 255, 255, 0.08); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
+.focus-panel .primary-button { color: var(--navy-deep); background: #fff; box-shadow: 0 10px 25px rgba(1, 17, 41, 0.22); }
+.focus-panel .primary-button:hover { color: var(--navy); background: #eafbf7; }
+.focus-panel .secondary-button { color: #e9f3fc; background: rgba(255, 255, 255, 0.07); border-color: rgba(255, 255, 255, 0.16); }
+.focus-panel .secondary-button:hover { background: rgba(255, 255, 255, 0.13); }
+.focus-panel.is-completing { pointer-events: none; animation: focusComplete 360ms cubic-bezier(0.45, 0, 0.85, 0.4) forwards; }
+.focus-panel.is-switching { pointer-events: none; animation: focusSwitchOut 180ms ease-in forwards; }
+.focus-panel.is-arriving { animation: focusSwitchIn 300ms cubic-bezier(0.2, 0.8, 0.2, 1) both; }
+.daily-complete {
+  min-height: 82px;
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem 1.15rem;
+  color: #31586a;
+  background: linear-gradient(125deg, rgba(231, 249, 245, 0.86), rgba(248, 252, 252, 0.96));
+  border: 1px solid #c8e9e2;
+  border-radius: 17px;
+  box-shadow: var(--shadow-sm);
+  animation: completionIn 320ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+.daily-complete-icon { width: 38px; height: 38px; flex: 0 0 38px; display: grid; place-items: center; color: #fff; background: linear-gradient(135deg, #0b8d7b, #27c8ad); border-radius: 50%; box-shadow: 0 8px 18px rgba(12, 149, 127, 0.2); font-weight: 900; }
+.daily-complete strong { display: block; margin-bottom: 0.15rem; color: var(--navy); }
+.daily-complete p { margin: 0; color: var(--muted); font-size: 0.82rem; line-height: 1.45; }
+.permission-slip { display: flex; align-items: center; justify-content: center; gap: 0.42rem; margin: 0.72rem 0 1.2rem; color: var(--muted); text-align: center; font-size: 0.81rem; }
+.permission-slip span { width: 18px; height: 18px; display: inline-grid; place-items: center; color: var(--teal-dark); background: var(--teal-soft); border-radius: 50%; font-size: 0.68rem; font-weight: 900; }
 
-.primary-button, .secondary-button, .danger-button, .icon-button, .prompt-chips button, .edit-button { border: 0; border-radius: 11px; padding: 0.72rem 0.92rem; font-weight: 800; }
-.primary-button { background: var(--orange); color: #fff; box-shadow: 0 7px 18px rgba(244,111,22,0.2); }
-.primary-button:hover { background: var(--orange-dark); }
-.secondary-button, .edit-button { background: #fff; color: var(--ink); border: 1px solid var(--line); }
-.secondary-button:hover, .edit-button:hover { background: #f7f5f1; }
-.danger-button { background: var(--red-soft); color: var(--red); }
-.icon-button { width: 38px; height: 38px; padding: 0; background: transparent; font-size: 1.6rem; color: var(--muted); }
+.primary-button, .secondary-button, .danger-button, .icon-button, .prompt-chips button, .edit-button {
+  position: relative;
+  border: 0;
+  border-radius: 11px;
+  padding: 0.7rem 0.94rem;
+  font-weight: 770;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+.primary-button { color: #fff; background: linear-gradient(115deg, #12aa91, #19bfa2); box-shadow: 0 7px 18px rgba(12, 149, 127, 0.19); }
+.primary-button:hover { background: linear-gradient(115deg, #098879, #11aa91); box-shadow: 0 10px 23px rgba(8, 127, 115, 0.24); transform: translateY(-1px); }
+.primary-button:active, .secondary-button:active, .edit-button:active { transform: translateY(1px); }
+.secondary-button, .edit-button { color: var(--ink-soft); background: #fff; border: 1px solid var(--line-strong); box-shadow: 0 2px 7px rgba(18, 45, 78, 0.035); }
+.secondary-button:hover, .edit-button:hover { color: var(--navy); background: #f5fafb; border-color: #9edbd1; transform: translateY(-1px); }
+.danger-button { color: var(--red); background: var(--red-soft); }
+.danger-button:hover { background: #f9dce1; }
+.icon-button { width: 38px; height: 38px; padding: 0; color: var(--muted); background: transparent; font-size: 1.55rem; }
+.icon-button:hover { color: var(--navy); background: var(--navy-soft); }
 
-.metric-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.8rem; margin-bottom: 1rem; }
+.metric-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.85rem; margin-bottom: 1rem; }
 .metric-grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.metric-card, .panel { background: var(--panel); border: 1px solid var(--line); border-radius: 16px; padding: 1.05rem 1.15rem; box-shadow: 0 7px 24px rgba(25,32,42,0.035); }
-.metric-card { display: grid; gap: 0.22rem; }
-.metric-card span, .budget-summary span { color: var(--muted); font-size: 0.8rem; font-weight: 700; }
-.metric-card strong { font-size: 1.45rem; letter-spacing: -0.03em; }
+.metric-card, .panel {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--line);
+  border-radius: 17px;
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(12px);
+}
+.metric-card {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  display: grid;
+  gap: 0.23rem;
+  padding: 1.08rem 1.14rem 1.05rem;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+.metric-card::before {
+  position: absolute;
+  z-index: -1;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  content: "";
+  background: linear-gradient(90deg, var(--teal), rgba(24, 185, 158, 0));
+  opacity: 0.7;
+}
+.metric-card::after {
+  position: absolute;
+  z-index: -1;
+  top: -32px;
+  right: -30px;
+  width: 84px;
+  height: 84px;
+  content: "";
+  background: var(--teal-soft);
+  border-radius: 50%;
+  opacity: 0.55;
+}
+.metric-card:hover { border-color: #c7ddd9; box-shadow: 0 12px 30px rgba(18, 45, 78, 0.085); transform: translateY(-2px); }
+.metric-card span, .budget-summary span { color: var(--muted); font-size: 0.76rem; font-weight: 700; }
+.metric-card strong { color: var(--navy-deep); font-size: 1.43rem; letter-spacing: -0.035em; font-variant-numeric: tabular-nums; }
 .metric-card small { color: var(--muted); }
-.two-column { display: grid; grid-template-columns: minmax(0, 1.3fr) minmax(300px, 0.7fr); gap: 1rem; }
-.panel-heading { display: flex; justify-content: space-between; gap: 1rem; }
-.encouragement-panel { background: var(--orange-soft); border-color: #ffd6ba; }
-.progress-track { height: 10px; overflow: hidden; background: rgba(201,78,0,0.12); border-radius: 999px; margin: 1.1rem 0 0.8rem; }
-.progress-track span { display: block; height: 100%; background: var(--orange); border-radius: inherit; width: 0; }
-.checks-list { display: grid; gap: 0.6rem; margin-top: 0.9rem; }
-.check-card { border-radius: 12px; padding: 0.82rem 0.9rem; background: #f7f7f4; border-left: 4px solid #94a0ae; }
-.check-card.urgent { background: var(--red-soft); border-color: var(--red); }
-.check-card.warning { background: var(--amber-soft); border-color: #d49a20; }
-.check-card.positive { background: var(--green-soft); border-color: var(--green); }
-.check-card p { margin: 0; color: #4f5b6b; line-height: 1.48; font-size: 0.9rem; }
+.panel { padding: 1.1rem 1.18rem; }
+.two-column { display: grid; grid-template-columns: minmax(0, 1.28fr) minmax(300px, 0.72fr); gap: 1rem; }
+.panel-heading { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; }
+.encouragement-panel { background: linear-gradient(145deg, #e9faf6, #f7fcfb); border-color: #c6ebe4; }
+.encouragement-panel > .secondary-button { margin-top: 0.15rem; }
+.check-in-status { margin: 0.55rem 0 0; color: #638078; font-size: 0.74rem; line-height: 1.42; }
+.progress-track { height: 9px; overflow: hidden; margin: 1.05rem 0 0.8rem; background: rgba(8, 127, 115, 0.12); border-radius: 999px; }
+.progress-track span { width: 0; height: 100%; display: block; background: linear-gradient(90deg, #0a8879, #25cdb0); border-radius: inherit; box-shadow: 0 0 12px rgba(24, 185, 158, 0.32); transition: width 700ms cubic-bezier(0.2, 0.8, 0.2, 1); }
+.checks-list { display: grid; gap: 0.62rem; margin-top: 0.9rem; }
+.check-card { position: relative; overflow: hidden; padding: 0.82rem 0.9rem 0.82rem 1rem; background: #f6f8fb; border: 1px solid #e9eef4; border-left: 3px solid #95a5b8; border-radius: 12px; }
+.check-card::after { position: absolute; top: 0; right: 0; width: 54px; height: 54px; content: ""; background: currentColor; border-radius: 50%; opacity: 0.025; transform: translate(18px, -18px); }
+.check-card.urgent { color: #9e2f40; background: var(--red-soft); border-color: #f5cfd6; border-left-color: var(--red); }
+.check-card.warning { color: #7b5709; background: var(--amber-soft); border-color: #f0dfb5; border-left-color: #d1a13e; }
+.check-card.positive { color: #0c684b; background: var(--green-soft); border-color: #c8eadc; border-left-color: var(--green); }
+.check-card h3 { color: var(--ink); }
+.check-card p { margin: 0; color: #52637a; font-size: 0.87rem; line-height: 1.48; }
 
-label { display: grid; gap: 0.35rem; color: #4f5b6b; font-size: 0.82rem; font-weight: 750; }
-input, select, textarea { width: 100%; border: 1px solid #d7d7d1; background: #fff; color: var(--ink); border-radius: 10px; padding: 0.68rem 0.75rem; }
-textarea { resize: vertical; line-height: 1.45; }
-.filter-bar { display: grid; grid-template-columns: minmax(240px, 1fr) 180px 170px; gap: 0.7rem; margin: 1rem 0; }
-.table-wrap { width: 100%; overflow: auto; border: 1px solid var(--line); border-radius: 14px; background: #fff; }
-table { width: 100%; border-collapse: collapse; font-size: 0.86rem; }
-th { position: sticky; top: 0; z-index: 1; background: #f7f6f2; color: #667183; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em; }
-th, td { padding: 0.72rem 0.68rem; text-align: left; border-bottom: 1px solid #eeece6; vertical-align: top; }
-td.amount { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+label { display: grid; gap: 0.36rem; color: #53647b; font-size: 0.79rem; font-weight: 710; }
+input, select, textarea {
+  width: 100%;
+  padding: 0.68rem 0.75rem;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  box-shadow: inset 0 1px 2px rgba(18, 45, 78, 0.025);
+  transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+input:hover, select:hover, textarea:hover { border-color: #acc2d5; }
+input:focus, select:focus, textarea:focus { background: #fff; border-color: #61cdbc; box-shadow: 0 0 0 4px rgba(24, 185, 158, 0.09); }
+textarea { resize: vertical; line-height: 1.48; }
+.filter-bar { display: grid; grid-template-columns: minmax(240px, 1fr) 180px 170px; gap: 0.7rem; margin: 1rem 0; padding: 0.78rem; background: rgba(255, 255, 255, 0.68); border: 1px solid rgba(223, 231, 240, 0.85); border-radius: 15px; }
+.table-wrap { width: 100%; overflow: auto; background: rgba(255, 255, 255, 0.95); border: 1px solid var(--line); border-radius: 15px; box-shadow: var(--shadow-sm); }
+table { width: 100%; border-collapse: collapse; font-size: 0.84rem; }
+th { position: sticky; top: 0; z-index: 1; color: #64758b; background: #f4f8fb; font-size: 0.68rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; }
+th, td { padding: 0.75rem 0.7rem; text-align: left; vertical-align: top; border-bottom: 1px solid #eaf0f5; }
+tbody tr { transition: background 140ms ease; }
+tbody tr:hover { background: #f8fbfc; }
+td.amount { text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; }
 td.incoming { color: var(--green); font-weight: 750; }
-td.outgoing { color: #8b3740; }
+td.outgoing { color: #a63b49; }
 tr:last-child td { border-bottom: 0; }
 .description-cell { min-width: 220px; max-width: 440px; }
 .description-cell strong, .description-cell span { display: block; overflow-wrap: anywhere; }
-.description-cell span, .note-preview, .table-caption, .muted, .privacy-note { color: var(--muted); font-size: 0.82rem; }
+.description-cell span, .note-preview, .table-caption, .muted, .privacy-note { color: var(--muted); font-size: 0.8rem; }
 .table-caption { margin: 0.65rem 0; }
-.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.24rem 0.46rem; font-size: 0.7rem; font-weight: 850; background: #edf0f4; color: #536071; }
-.badge.orange { color: #9a430c; background: var(--orange-soft); }
+.badge { display: inline-flex; align-items: center; padding: 0.25rem 0.5rem; color: #53647a; background: #edf2f7; border-radius: 999px; font-size: 0.68rem; font-weight: 820; }
+.badge.orange { color: var(--teal-dark); background: var(--teal-soft); }
 .badge.red { color: var(--red); background: var(--red-soft); }
 .badge.green { color: var(--green); background: var(--green-soft); }
 
 .card-list { display: grid; gap: 0.75rem; }
-.entity-card { display: grid; grid-template-columns: minmax(180px, 1.3fr) repeat(3, minmax(110px, 0.55fr)) auto; align-items: center; gap: 0.8rem; background: #fff; border: 1px solid var(--line); border-radius: 15px; padding: 1rem; }
+.entity-card {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.3fr) repeat(3, minmax(110px, 0.55fr)) auto;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid var(--line);
+  border-radius: 15px;
+  box-shadow: var(--shadow-sm);
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+.entity-card:hover { border-color: #c6dadf; box-shadow: 0 11px 27px rgba(18, 45, 78, 0.075); transform: translateY(-1px); }
 .entity-card .entity-title { min-width: 0; }
-.entity-card .entity-title p { color: var(--muted); margin: 0.25rem 0 0; font-size: 0.82rem; overflow-wrap: anywhere; }
+.entity-card .entity-title p { margin: 0.25rem 0 0; overflow-wrap: anywhere; color: var(--muted); font-size: 0.8rem; line-height: 1.42; }
 .entity-stat { display: grid; gap: 0.15rem; }
-.entity-stat span { color: var(--muted); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.055em; }
-.entity-stat strong { font-size: 0.95rem; }
-.payslip-card { background: #fff; border: 1px solid var(--line); border-radius: 16px; overflow: hidden; }
+.entity-stat span { color: var(--muted); font-size: 0.66rem; letter-spacing: 0.06em; text-transform: uppercase; }
+.entity-stat strong { color: var(--ink-soft); font-size: 0.92rem; font-variant-numeric: tabular-nums; }
+.entity-controls { display: flex; justify-content: flex-end; }
+.payslip-card { overflow: hidden; background: rgba(255, 255, 255, 0.95); border: 1px solid var(--line); border-radius: 16px; box-shadow: var(--shadow-sm); }
 .payslip-summary { display: grid; grid-template-columns: minmax(170px, 1fr) repeat(3, minmax(110px, 0.55fr)) auto; align-items: center; gap: 0.8rem; padding: 1rem; }
-.payslip-details { border-top: 1px solid var(--line); background: #faf9f6; padding: 1rem; display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
-.line-item-list { display: grid; gap: 0.35rem; }
-.line-item { display: flex; justify-content: space-between; gap: 1rem; font-size: 0.84rem; }
+.payslip-card details { border-top: 1px solid var(--line); }
+.payslip-card summary { padding: 0.72rem 1rem; color: var(--teal-dark); background: #f7fbfb; font-size: 0.79rem; font-weight: 760; cursor: pointer; }
+.payslip-card details[open] summary { border-bottom: 1px solid var(--line); }
+.payslip-details { display: grid; grid-template-columns: 1fr 1fr; gap: 1.2rem; padding: 1rem; background: #fbfcfd; }
+.line-item-list { display: grid; gap: 0.38rem; }
+.line-item { display: flex; justify-content: space-between; gap: 1rem; color: #52647a; font-size: 0.82rem; }
 
-.budget-summary { display: grid; grid-template-columns: repeat(3, 1fr); margin-bottom: 1rem; }
-.budget-summary div { display: grid; gap: 0.3rem; padding: 0.3rem 1rem; border-right: 1px solid var(--line); }
+.budget-summary { display: grid; grid-template-columns: repeat(3, 1fr); margin-bottom: 1rem; padding: 0.8rem; }
+.budget-summary div { display: grid; gap: 0.3rem; padding: 0.4rem 1rem; border-right: 1px solid var(--line); }
 .budget-summary div:last-child { border-right: 0; }
-.budget-summary strong { font-size: 1.35rem; }
-.budget-list { display: grid; gap: 0.62rem; margin-top: 0.9rem; }
-.budget-item { display: grid; gap: 0.38rem; }
-.budget-line { display: flex; justify-content: space-between; gap: 0.8rem; align-items: center; font-size: 0.85rem; }
-.budget-line button { padding: 0; border: 0; background: none; color: var(--ink); font-weight: 800; text-align: left; }
-.budget-bar { height: 7px; background: #ecebe6; border-radius: 999px; overflow: hidden; }
-.budget-bar span { display: block; height: 100%; background: var(--orange); border-radius: inherit; max-width: 100%; }
+.budget-summary strong { color: var(--navy); font-size: 1.3rem; font-variant-numeric: tabular-nums; }
+.budget-list { display: grid; gap: 0.65rem; margin-top: 0.9rem; }
+.budget-item { display: grid; gap: 0.4rem; }
+.budget-line { display: flex; align-items: center; justify-content: space-between; gap: 0.8rem; font-size: 0.83rem; }
+.budget-line button { padding: 0; color: var(--ink); background: none; border: 0; font-weight: 760; text-align: left; }
+.budget-bar { height: 7px; overflow: hidden; background: #e8eef3; border-radius: 999px; }
+.budget-bar span { max-width: 100%; height: 100%; display: block; background: linear-gradient(90deg, #0c8878, #2acbb0); border-radius: inherit; transition: width 650ms cubic-bezier(0.2, 0.8, 0.2, 1); }
 
-.prompt-chips { display: flex; gap: 0.55rem; flex-wrap: wrap; margin: 1rem 0; }
-.prompt-chips button { color: #93420c; background: var(--orange-soft); border: 1px solid #ffd5b9; padding: 0.55rem 0.72rem; }
-.chat-messages { min-height: 310px; max-height: 540px; overflow: auto; background: #fff; border: 1px solid var(--line); border-radius: 16px; padding: 1rem; display: flex; flex-direction: column; gap: 0.8rem; }
-.chat-message { max-width: min(760px, 88%); padding: 0.85rem 0.95rem; border-radius: 14px; white-space: pre-wrap; line-height: 1.5; font-size: 0.9rem; }
-.chat-message.user { align-self: flex-end; color: #fff; background: var(--dark-soft); border-bottom-right-radius: 4px; }
-.chat-message.guide { background: var(--orange-soft); border-bottom-left-radius: 4px; }
+.prompt-chips { display: flex; flex-wrap: wrap; gap: 0.55rem; margin: 1rem 0; }
+.prompt-chips button { padding: 0.55rem 0.74rem; color: var(--teal-dark); background: var(--teal-soft); border: 1px solid #c0e8e0; }
+.prompt-chips button:hover { color: var(--navy); background: #d9f5ef; transform: translateY(-1px); }
+.chat-messages { min-height: 310px; max-height: 540px; overflow: auto; display: flex; flex-direction: column; gap: 0.8rem; padding: 1rem; background: rgba(255, 255, 255, 0.94); border: 1px solid var(--line); border-radius: 16px; box-shadow: var(--shadow-sm); }
+.chat-message { max-width: min(760px, 88%); padding: 0.85rem 0.95rem; border-radius: 14px; font-size: 0.88rem; line-height: 1.52; white-space: pre-wrap; animation: messageIn 250ms ease both; }
+.chat-message.user { align-self: flex-end; color: #fff; background: linear-gradient(135deg, var(--navy), #16427b); border-bottom-right-radius: 4px; box-shadow: 0 7px 18px rgba(12, 41, 93, 0.16); }
+.chat-message.guide { background: var(--teal-soft); border: 1px solid #cbece6; border-bottom-left-radius: 4px; }
 .chat-message small { display: block; margin-top: 0.5rem; color: var(--muted); }
-.chat-form { display: grid; grid-template-columns: 1fr auto; gap: 0.65rem; margin-top: 0.7rem; align-items: end; }
-.status-pill.good { color: var(--green); background: var(--green-soft); border-color: #b8e6ce; }
-.status-pill.warning { color: var(--amber); background: var(--amber-soft); border-color: #edd7a3; }
+.chat-form { display: grid; grid-template-columns: 1fr auto; gap: 0.65rem; align-items: end; margin-top: 0.7rem; }
+.status-pill.good { color: var(--green); background: var(--green-soft); border-color: #bde8d6; }
+.status-pill.warning { color: var(--amber); background: var(--amber-soft); border-color: #ecd9a9; }
 
 .settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }
-.settings-grid .panel { display: grid; gap: 0.75rem; align-content: start; }
+.settings-grid .panel { display: grid; align-content: start; gap: 0.75rem; }
 .settings-grid .panel h2 { margin-bottom: 0.25rem; }
-.compact-card-list { display: grid; gap: 0.55rem; }
-.compact-card-list .entity-card { grid-template-columns: minmax(0, 1fr) auto; padding: 0.75rem; }
+.compact-card-list { display: grid; gap: 0.55rem; margin-top: 0.8rem; }
+.compact-card-list .entity-card { grid-template-columns: minmax(0, 1fr) auto; padding: 0.78rem; }
 .compact-card-list .entity-stat { display: none; }
-.empty-inline { color: var(--muted); font-size: 0.84rem; padding: 0.5rem 0; line-height: 1.45; }
+.empty-inline { padding: 0.5rem 0; color: var(--muted); font-size: 0.82rem; line-height: 1.45; }
 
-.modal { width: min(620px, calc(100vw - 2rem)); max-height: calc(100vh - 2rem); border: 0; border-radius: 18px; padding: 0; box-shadow: 0 35px 90px rgba(0,0,0,0.3); }
+.modal { width: min(620px, calc(100vw - 2rem)); max-height: calc(100vh - 2rem); overflow: auto; padding: 0; background: #fff; border: 1px solid rgba(255, 255, 255, 0.55); border-radius: 21px; box-shadow: 0 35px 90px rgba(1, 20, 47, 0.34); }
+.modal[open] { animation: modalIn 240ms cubic-bezier(0.2, 0.75, 0.25, 1) both; }
 .modal.wide { width: min(1080px, calc(100vw - 2rem)); }
-.modal::backdrop { background: rgba(7,10,14,0.68); backdrop-filter: blur(3px); }
-.modal form { padding: 1.2rem; }
+.modal::backdrop { background: rgba(4, 20, 45, 0.66); backdrop-filter: blur(7px); }
+.modal form { padding: 1.25rem; }
 .modal-heading, .modal-actions { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.modal-heading { padding-bottom: 0.88rem; border-bottom: 1px solid var(--line); }
 .modal-actions { justify-content: flex-end; margin-top: 1rem; }
 .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.8rem; margin-top: 1rem; }
 .form-grid .wide-field { grid-column: 1 / -1; }
-.warning-box { border: 1px solid #e2bb57; background: var(--amber-soft); color: #6f4b05; border-radius: 11px; padding: 0.75rem; margin: 0.8rem 0; white-space: pre-wrap; }
+.warning-box { margin: 0.8rem 0; padding: 0.78rem; color: #6f4c07; background: var(--amber-soft); border: 1px solid #e5c879; border-radius: 11px; white-space: pre-wrap; }
 .import-summary { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.55rem; margin-top: 0.9rem; }
-.import-summary div { background: #f7f6f2; border-radius: 11px; padding: 0.72rem; display: grid; gap: 0.2rem; }
-.import-summary span { color: var(--muted); font-size: 0.72rem; }
+.import-summary div { display: grid; gap: 0.2rem; padding: 0.75rem; background: #f3f8fa; border: 1px solid #e7eef3; border-radius: 11px; }
+.import-summary span { color: var(--muted); font-size: 0.69rem; }
+.import-summary strong { color: var(--navy); font-variant-numeric: tabular-nums; }
 .preview-table { max-height: 390px; margin-top: 0.8rem; }
-.toast { position: fixed; right: 1.2rem; bottom: 1.2rem; z-index: 10; max-width: 380px; color: #fff; background: var(--dark-soft); border-radius: 12px; padding: 0.8rem 1rem; box-shadow: var(--shadow); }
+.toast { position: fixed; right: 1.2rem; bottom: 1.2rem; z-index: 10; max-width: 380px; padding: 0.82rem 1rem 0.82rem 2.7rem; color: #fff; background: linear-gradient(125deg, #071d43, #0b3e65); border: 1px solid rgba(91, 224, 200, 0.2); border-radius: 14px; box-shadow: 0 19px 50px rgba(4, 25, 56, 0.28); animation: toastIn 260ms cubic-bezier(0.2, 0.8, 0.2, 1) both; }
+.toast::before { position: absolute; top: 50%; left: 0.9rem; width: 21px; height: 21px; display: grid; place-items: center; content: "✓"; color: var(--navy-deep); background: #55ddc5; border-radius: 50%; font-size: 0.72rem; font-weight: 900; transform: translateY(-50%); }
 
-@media (max-width: 1080px) {
-  .app-shell { grid-template-columns: 84px minmax(0, 1fr); }
-  .sidebar { padding: 0.9rem 0.6rem; }
-  .brand { justify-content: center; }
-  .brand div, .nav-button:not(.active)::after, .nav-button { font-size: 0; }
-  .nav-button { justify-content: center; padding: 0.75rem; }
-  .nav-button span { font-size: 0.95rem; }
-  .privacy-status { justify-content: center; }
-  .privacy-status span:last-child { display: none; }
+@keyframes viewIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes modalIn { from { opacity: 0; transform: translateY(14px) scale(0.985); } to { opacity: 1; transform: translateY(0) scale(1); } }
+@keyframes messageIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes toastIn { from { opacity: 0; transform: translateX(15px) translateY(8px); } to { opacity: 1; transform: translate(0); } }
+@keyframes floatRing { 0%, 100% { transform: translate3d(0, 0, 0) rotate(0); } 50% { transform: translate3d(12px, 8px, 0) rotate(4deg); } }
+@keyframes statusPulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.14); } }
+@keyframes focusComplete { 0% { opacity: 1; transform: translateY(0) scale(1); max-height: 260px; } 62% { opacity: 0; transform: translateY(-8px) scale(0.99); max-height: 260px; } 100% { opacity: 0; transform: translateY(-8px) scale(0.99); max-height: 0; min-height: 0; padding-block: 0; border-width: 0; } }
+@keyframes focusSwitchOut { to { opacity: 0; transform: translateY(-5px); } }
+@keyframes focusSwitchIn { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes completionIn { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: translateY(0); } }
+
+@media (max-width: 1120px) {
+  .app-shell { grid-template-columns: 86px minmax(0, 1fr); }
+  .sidebar { padding: 0.9rem 0.65rem; }
+  .brand { justify-content: center; padding-inline: 0; }
+  .brand-copy, .nav-label, .privacy-copy { display: none; }
+  .nav-button { justify-content: center; padding: 0.73rem; }
+  .nav-button:hover { transform: translateY(-1px); }
+  .privacy-status { justify-content: center; padding: 0.78rem 0.5rem; }
   .entity-card { grid-template-columns: minmax(180px, 1fr) repeat(2, minmax(100px, 0.5fr)) auto; }
   .entity-card .optional-stat { display: none; }
 }
 
-@media (max-width: 780px) {
+@media (max-width: 840px) {
   .app-shell { display: block; }
-  .sidebar { position: fixed; inset: auto 0 0 0; z-index: 5; width: 100%; height: auto; padding: 0.45rem; }
-  .brand, .privacy-status { display: none; }
-  .sidebar nav { grid-template-columns: repeat(6, 1fr); overflow-x: auto; }
-  .nav-button { min-width: 54px; }
+  .sidebar { position: fixed; inset: auto 0 0 0; z-index: 6; width: 100%; height: auto; padding: 0.45rem; }
+  .sidebar::before, .sidebar::after, .brand, .privacy-status { display: none; }
+  .sidebar nav { grid-template-columns: repeat(9, minmax(58px, 1fr)); overflow-x: auto; }
+  .nav-button { min-width: 56px; min-height: 48px; }
   .main-content { padding-bottom: 5rem; }
   .topbar, .section-actions, .focus-panel { align-items: flex-start; flex-direction: column; }
+  .topbar { position: relative; min-height: auto; padding-block: 0.5rem; background: transparent; backdrop-filter: none; }
+  .focus-copy { gap: 0.8rem; }
   .focus-actions { width: 100%; }
   .topbar-actions { width: 100%; justify-content: space-between; }
   .metric-grid, .metric-grid.three, .two-column, .settings-grid, .filter-bar { grid-template-columns: 1fr; }
   .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .budget-summary { grid-template-columns: 1fr; }
   .budget-summary div { border-right: 0; border-bottom: 1px solid var(--line); }
+  .budget-summary div:last-child { border-bottom: 0; }
   .entity-card, .payslip-summary { grid-template-columns: 1fr 1fr; }
   .entity-title { grid-column: 1 / -1; }
   .payslip-details { grid-template-columns: 1fr; }
@@ -214,11 +589,18 @@ tr:last-child td { border-bottom: 0; }
   .chat-form { grid-template-columns: 1fr; }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 560px) {
+  .main-content { padding-inline: 0.78rem; }
   .metric-grid { grid-template-columns: 1fr; }
-  .topbar-actions, .button-row { align-items: stretch; flex-direction: column; width: 100%; }
+  .topbar-actions, .button-row { width: 100%; align-items: stretch; flex-direction: column; }
   .section-actions .button-row, .section-actions .primary-button { width: 100%; }
+  .focus-panel { border-radius: 20px; }
+  .focus-copy { display: block; }
+  .step-emblem { margin-bottom: 1rem; }
   .entity-card, .payslip-summary { grid-template-columns: 1fr; }
+  .entity-controls { justify-content: stretch; }
+  .entity-controls .edit-button { width: 100%; }
+  .permission-slip { align-items: flex-start; text-align: left; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/styles.css
+++ b/styles.css
@@ -328,6 +328,7 @@ h3 { margin-bottom: 0.25rem; font-size: 0.98rem; letter-spacing: -0.012em; }
 .focus-panel.is-completing { pointer-events: none; animation: focusComplete 360ms cubic-bezier(0.45, 0, 0.85, 0.4) forwards; }
 .focus-panel.is-switching { pointer-events: none; animation: focusSwitchOut 180ms ease-in forwards; }
 .focus-panel.is-arriving { animation: focusSwitchIn 300ms cubic-bezier(0.2, 0.8, 0.2, 1) both; }
+.focus-panel.is-blocked { animation: attentionNudge 420ms ease both; }
 .daily-complete {
   min-height: 82px;
   display: flex;
@@ -550,6 +551,7 @@ tr:last-child td { border-bottom: 0; }
 @keyframes focusSwitchOut { to { opacity: 0; transform: translateY(-5px); } }
 @keyframes focusSwitchIn { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes completionIn { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes attentionNudge { 0%, 100% { transform: translateX(0); } 28% { transform: translateX(-5px); } 58% { transform: translateX(4px); } 80% { transform: translateX(-2px); } }
 
 @media (max-width: 1120px) {
   .app-shell { grid-template-columns: 86px minmax(0, 1fr); }

--- a/tests/document-import.test.js
+++ b/tests/document-import.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { parseCsvStatement, parseOfxStatement, parsePayslipText, parseQifStatement } from '../document-import.js';
+import { parseCreditReportText, parseCsvStatement, parseImportedDocument, parseOfxStatement, parsePayslipText, parsePdfStatement, parseQifStatement } from '../document-import.js';
 
 test('CSV with separate debit and credit columns keeps a positive BACS credit as income', () => {
   const result = parseCsvStatement('Date,Description,Debit,Credit,Balance\n31/01/2025,BACS PAYROLL,,2500.00,100.00', 'pay.csv', 'acct-1');
@@ -13,6 +13,36 @@ test('CSV with separate debit and credit columns keeps a positive BACS credit as
 test('signed amount CSV distinguishes incoming and outgoing', () => {
   const result = parseCsvStatement('Date,Description,Amount\n01/02/2025,Refund,12.50\n02/02/2025,Purchase,-4.25', 'signed.csv', 'acct-1');
   assert.deepEqual(result.records.map((item) => [item.incoming, item.outgoing]), [[12.5, 0], [0, 4.25]]);
+});
+
+test('semicolon exports can contain a preamble and common UK bank headings', () => {
+  const csv = '\uFEFFExample Current Account\nTransaction Date;Transaction Description;Debit Amount;Credit Amount;Account Balance\n1 August 2025;Example Books;12.50;;87.50\n2 August 2025;Example Refund;;5.00;92.50';
+  const result = parseCsvStatement(csv, 'semicolon.csv', 'acct-1');
+  assert.equal(result.records.length, 2);
+  assert.equal(result.records[0].date, '2025-08-01');
+  assert.equal(result.records[0].outgoing, 12.5);
+  assert.equal(result.records[1].incoming, 5);
+  assert.equal(result.records[0].sourceRow, 3);
+});
+
+test('tab-separated exports support timestamps, counter parties and debit type codes', () => {
+  const tsv = 'Completed Date\tCounter Party\tTransaction Type\tAmount (GBP)\tBalance (GBP)\n2025-08-01 10:15:00\tExample Market\tCARD_PAYMENT\t12.50\t87.50\n2025-08-02 09:00:00\tExample Employer\tCREDIT\t25.00\t112.50';
+  const result = parseCsvStatement(tsv, 'starling-style.tsv', 'acct-1');
+  assert.deepEqual(result.records.map((item) => [item.incoming, item.outgoing]), [[0, 12.5], [25, 0]]);
+});
+
+test('specific description and amount headings win over generic metadata columns', () => {
+  const csv = 'Value Date,Name,Description,Value\n01/08/2025,Example Account,Example Purchase,-4.25';
+  const result = parseCsvStatement(csv, 'metadata-columns.csv', 'acct-1');
+  assert.equal(result.records[0].description, 'Example Purchase');
+  assert.equal(result.records[0].outgoing, 4.25);
+});
+
+test('descending statement exports expose the latest reconciled balance for account sync', () => {
+  const csv = 'Date,Description,Amount,Balance\n02/08/2025,Example Refund,5.00,92.50\n01/08/2025,Example Purchase,-12.50,87.50';
+  const result = parseCsvStatement(csv, 'descending.csv', 'acct-1');
+  assert.equal(result.summary.openingBalance, 100);
+  assert.equal(result.summary.closingBalance, 92.5);
 });
 
 test('invalid dates are rejected and never changed to today', () => {
@@ -34,6 +64,76 @@ test('OFX parser supports common unclosed SGML tags', () => {
   assert.equal(result.records.length, 1);
   assert.equal(result.records[0].date, '2025-02-01');
   assert.equal(result.records[0].outgoing, 9.99);
+});
+
+test('QFX files use the OFX transaction parser', () => {
+  const qfx = '<STMTTRN><TRNTYPE>CREDIT<DTPOSTED>20250802<TRNAMT>15.00<FITID>QFX1<NAME>Example refund</STMTTRN></BANKTRANLIST>';
+  const result = parseImportedDocument('example.qfx', qfx, 'statement', 'acct-1');
+  assert.equal(result.records.length, 1);
+  assert.equal(result.records[0].incoming, 15);
+});
+
+test('labelled PDF tables use the conservative generic fallback and reconcile', () => {
+  const item = (text, x) => ({ text, x, width: text.length * 5, y: 0, height: 10 });
+  const line = (items) => ({ items, text: items.map((entry) => entry.text).join(' ') });
+  const document = {
+    text: 'Example Bank\nOpening balance £100.00\nClosing balance £112.50',
+    pages: [{
+      width: 600,
+      lines: [
+        line([item('Date', 10), item('Description', 100), item('Type', 280), item('Money Out', 350), item('Money In', 430), item('Balance', 510)]),
+        line([item('01 August 2025', 10), item('Example Books', 100), item('DEB', 280), item('12.50', 350), item('87.50', 510)]),
+        line([item('02 August 2025', 10), item('Example Refund', 100), item('FPI', 280), item('25.00', 430), item('112.50', 510)])
+      ]
+    }]
+  };
+  const result = parsePdfStatement(document, 'accessible-table.pdf', 'acct-1');
+  assert.equal(result.records.length, 2);
+  assert.equal(result.records[0].outgoing, 12.5);
+  assert.equal(result.records[1].incoming, 25);
+  assert.equal(result.reconciled, true);
+});
+
+test('Lloyds-branded PDFs reuse the reconciled LBG statement layout', () => {
+  const items = [
+    { text: '1 Aug 25', x: 10 },
+    { text: 'Example Employer', x: 100 },
+    { text: 'FPI', x: 280 },
+    { text: '1000.00', x: 350 },
+    { text: '1000.00', x: 510 }
+  ];
+  const document = { text: 'Lloyds Bank plc', pages: [{ lines: [{ items, text: items.map((item) => item.text).join(' ') }] }] };
+  const result = parsePdfStatement(document, 'lloyds-layout.pdf', '');
+  assert.equal(result.records.length, 1);
+  assert.equal(result.records[0].accountId, 'Lloyds');
+  assert.equal(result.records[0].incoming, 1000);
+  assert.equal(result.reconciled, true);
+});
+
+test('credit report parser extracts labelled score and debt details without guessing omissions', () => {
+  const text = `Experian Credit Report
+  Report date: 8 August 2025
+  Credit score: 612 out of 999
+  Lender: Example Card Provider Ltd
+  Account type: Credit card
+  Account number: ****1234
+  Current balance: £420.50
+  Credit limit: £1,200
+  Minimum payment: £25.00
+  APR: 29.9%
+  Account status: Up to date
+  Opened: 4 June 2021
+  Last updated: 2 August 2025`;
+  const result = parseCreditReportText(text, 'example-credit-report.pdf');
+  const account = result.records[0].accounts[0];
+  assert.equal(result.summary.provider, 'Experian');
+  assert.equal(result.summary.reportDate, '2025-08-08');
+  assert.equal(result.summary.score, 612);
+  assert.equal(account.currentBalance, 420.5);
+  assert.equal(account.creditLimit, 1200);
+  assert.equal(account.contractualPayment, 25);
+  assert.equal(account.apr, 0.299);
+  assert.equal(account.accountReference, '••••1234');
 });
 
 test('JPA payslip parser reconciles gross, detailed deductions and net pay', () => {

--- a/tests/finance-core.test.js
+++ b/tests/finance-core.test.js
@@ -2,13 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildFinancialChecks, buildNextAction, calculateBudgetRows, calculatePeriodSummary, debtPlan, exportTransactionsCsv,
-  findDuplicateCandidates, formatCurrency, matchInternalTransfers
+  findDuplicateCandidates, formatCurrency, hasCompletedCheckIn, matchInternalTransfers, planCreditReportAccounts, syncStatementAccount
 } from '../finance-core.js';
 
 const baseState = () => ({
   profile: { dependableIncome: 2000 },
   settings: { selectedMonth: '2025-01', extraDebtPayment: 100, emergencyBufferTarget: 500, emergencyBufferBalance: 0 },
-  transactions: [], payslips: [], debts: [], overdrafts: [], budgets: [], tasks: [], checkIns: []
+  transactions: [], payslips: [], creditReports: [], debts: [], overdrafts: [], budgets: [], tasks: [], checkIns: []
 });
 
 test('currency uses UK pounds', () => {
@@ -24,6 +24,18 @@ test('a blank installation gives one onboarding action without example finance d
 test('an account with no payments advances onboarding to one statement import', () => {
   const state = { ...baseState(), accounts: [{ id: 'account-1', name: 'Main account' }] };
   assert.equal(buildNextAction(state).id, 'generated-first-import');
+});
+
+test('a generated action snoozed until tomorrow is replaced with a five-minute check-in', () => {
+  const state = { ...baseState(), accounts: [], settings: { ...baseState().settings, snoozedActions: { 'generated-first-account': '2025-01-11' } } };
+  assert.equal(buildNextAction(state, new Date(2025, 0, 10, 12)).id, 'generated-checkin');
+});
+
+test('today completion recognises both action and five-minute check-ins but not another day', () => {
+  const now = new Date(2025, 0, 10, 12);
+  assert.equal(hasCompletedCheckIn([{ date: new Date(2025, 0, 10, 9).toISOString(), completed: true }], now), true);
+  assert.equal(hasCompletedCheckIn([{ date: new Date(2025, 0, 9, 23).toISOString(), completed: true }], now), false);
+  assert.equal(hasCompletedCheckIn([{ date: new Date(2025, 0, 10, 9).toISOString(), completed: false }], now), false);
 });
 
 test('monthly summary excludes confirmed internal transfers and keeps overdrafts separate', () => {
@@ -82,6 +94,31 @@ test('payoff model visibly blocks overpayments while an overdraft arrangement is
   assert.equal(plan.safeToOverpay, false);
   assert.deepEqual(plan.blockers, ['Bank overdraft']);
   assert.deepEqual(plan.unknownApr, ['Card']);
+});
+
+test('credit report planning updates matches, adds new debts and keeps overdrafts separate', () => {
+  const debts = [{ id: 'existing-card', name: 'Example Card Provider Limited', type: 'Credit card', accountReference: '••••1234' }];
+  const accounts = [
+    { lender: 'Example Card Provider Ltd', accountType: 'Credit card', accountReference: '****1234', currentBalance: 400 },
+    { lender: 'Example Loan Provider', accountType: 'Personal loan', currentBalance: 800 },
+    { lender: 'Example Current Provider', accountType: 'Current account', currentBalance: 75 },
+    { lender: 'Example Settled Provider', accountType: 'Store card', currentBalance: 0 }
+  ];
+  const plan = planCreditReportAccounts(debts, [], accounts);
+  assert.deepEqual(plan.map((item) => item.action), ['existing', 'add-debt', 'add-overdraft', 'no-balance']);
+});
+
+test('reconciled statements create and then clear linked overdraft usage automatically', () => {
+  const state = { overdrafts: [] };
+  const account = { id: 'acct-1', name: 'Example Main', institution: 'Example Bank', openingBalance: null };
+  const overdrawn = { reconciled: true, institution: 'Example Bank', records: [{ date: '2025-08-31' }], summary: { openingBalance: 100, closingBalance: -75, overdraftLimit: 100 } };
+  assert.equal(syncStatementAccount(state, account, overdrawn, 'doc-1'), 'overdraft-created');
+  assert.equal(account.currentBalance, -75);
+  assert.equal(state.overdrafts[0].currentBalance, 75);
+  assert.equal(state.overdrafts[0].limit, 100);
+  const inCredit = { ...overdrawn, records: [{ date: '2025-09-30' }], summary: { ...overdrawn.summary, closingBalance: 25 } };
+  assert.equal(syncStatementAccount(state, account, inCredit, 'doc-2'), 'overdraft-updated');
+  assert.equal(state.overdrafts[0].currentBalance, 0);
 });
 
 test('CSV export quotes fields and neutralises spreadsheet formulas', () => {


### PR DESCRIPTION
### Purpose

This branch expands OneStep Money 2.2.0 so financial-document imports do more of the work automatically while preserving the app’s local-first privacy model. It has been amended onto the v2.1.3 mainline at `a3b9b838686c0ad1e56e0c00506c7c5c2daed366`. It addresses limited bank-statement format support, adds credit-report importing, synchronises statement balances and overdrafts, prevents duplicate credit-report debts, and improves the ADHD-friendly daily completion flow and product UI.

### Work completed

#### Bank-statement importing

- Added CSV, TSV and semicolon-delimited statement support.
- Added preamble-row detection and common UK bank header aliases.
- Added support for timestamps, counterparty/merchant columns, debit/credit type codes and separate money-in/money-out columns.
- Added QFX support through the existing OFX transaction parser.
- Extended recognised PDF layouts to Lloyds and Bank of Scotland through the reconciled LBG parser.
- Added a conservative generic accessible-PDF table fallback for clearly labelled Date, Description and Amount or Money In/Money Out columns.
- Added chronological balance-chain validation, opening/closing balance extraction, institution detection, overdraft-limit extraction and visible review warnings where reconciliation is uncertain.
- Kept invalid dates and amounts as rejected data rather than replacing them with guessed values.

#### Statement-driven account and overdraft automation

- Reconciled statements now update the linked account’s closing balance and statement date.
- Missing account institution and opening-balance values are filled when the statement supplies them.
- A negative closing balance automatically creates or links an overdraft record.
- Linked overdraft usage, arranged limit, detected APR, statement date and over-limit status are refreshed from later statements.
- Returning to credit clears the linked overdraft’s used balance without deleting the overdraft record.
- Unreconciled statements do not change account or overdraft balances.

#### Credit-report importing and debt automation

- Added secure PDF credit-report importing as a separate document type.
- Added provider detection for Experian, ClearScore, Credit Karma, TransUnion, Equifax and TotallyMoney.
- Added conservative extraction of clearly labelled report date, score, score range, lender, account type, reference, balance, limit, minimum/regular payment, APR, status, opened date and updated date.
- Added lender/reference/type matching against existing debts and overdrafts.
- Matched borrowing is updated with supplied report values; missing values are not guessed.
- Positive unmatched balances are created automatically after import confirmation.
- Reported current-account overdrafts stay in the Overdrafts section instead of becoming debts.
- Untracked zero-balance accounts are retained in the report record but are not created as debts.
- Source document links are retained for imported reports and the borrowing records they update.

#### Daily check-in behaviour

- Completing an action or five-minute check-in now records completion for the local calendar day.
- Completed daily content transitions to a dedicated “Today’s check-in is complete” state.
- Snoozing generated actions substitutes the five-minute check-in instead of repeatedly showing the same step.
- When all available steps are snoozed, the app shows a passive done-for-today state.
- Added completion, switching, arrival and blocked-action feedback animations.

#### UI and branding

- Applied the OneStep Money wordmark and “One clear move at a time” identity throughout the shell.
- Reworked navigation with icons and clearer labels.
- Added visible private-device secure-storage status.
- Added a branded immediate-action panel, streak chip, momentum panel, completion state and clearer permission-to-stop copy.
- Added the Credit reports panel and import action.
- Refined panels, tables, forms, modals, status components, responsive layouts and mobile navigation.
- Updated the Electron window background and static preview asset routing to match the new design.

#### v2.1.3 compatibility and conflict resolution

- Merged the released v2.1.3 mainline into the feature branch with a normal merge commit; no history was rewritten.
- Preserved the v2.1.3 PDF DOMMatrix compatibility fix and its native canvas dependency.
- Preserved privacy-safe diagnostic logging, encrypted local detail logs and diagnostic export controls.
- Preserved the data-driven reporting-month selector and its missing-month behaviour.
- Preserved the v2.1.3 defaulted-debt safety baseline.
- Resolved package metadata in favour of the feature’s intended 2.2.0 version while retaining all v2.1.3 dependencies.
- Combined diagnostic preview styling with the refreshed OneStep toast treatment.
- Combined month-selector, diagnostic, PDF, daily-completion, credit-report and overdraft test imports and coverage.
- Verified that the final merge differs from v2.1.3 only by the intended 15 feature files.

#### Version and documentation

- Updated the application version from 2.1.1 to 2.2.0.
- Documented the new statement formats, credit-report behaviour and automatic synchronisation.
- Updated public-project validation for the new empty creditReports collection.

### Files changed

- `README.md` — documents expanded statement formats, supported credit-report providers and automatic account/debt/overdraft synchronisation.
- `data-store.js` — migrates stored state to schema 5, adds creditReports, restores nested source-document links and recognises TSV/QFX MIME types.
- `document-import.js` — implements wider delimited-file parsing, QFX support, LBG and generic PDF parsing, reconciliation improvements and labelled credit-report extraction.
- `finance-core.js` — adds safe credit-report account matching/planning, statement-to-account/overdraft synchronisation and daily completion/snooze logic.
- `index.html` — adds the refreshed branded shell, icon navigation, secure-storage status, daily completion UI and Credit reports controls.
- `main-process.js` — adds credit-report file selection, TSV/QFX statement filters, nested report-account document links and canonical credit-report filenames.
- `package.json` — updates the application version to 2.2.0.
- `package-lock.json` — keeps lockfile package metadata aligned with version 2.2.0.
- `renderer-app.js` — renders credit reports, previews and applies import automation, synchronises statements and implements the completed/snoozed daily-action experience.
- `scripts/check-project.mjs` — requires the public creditReports seed collection to remain empty.
- `seed-data.json` — advances the public blank-state schema to 5 and adds an empty creditReports collection.
- `static-preview-server.js` — serves the OneStep Money wordmark in browser previews.
- `styles.css` — provides the complete responsive visual refresh and interaction animations.
- `tests/document-import.test.js` — adds regression coverage for wider CSV/TSV formats, QFX, generic/LBG PDFs, reconciliation and credit-report extraction.
- `tests/finance-core.test.js` — adds coverage for daily completion, credit-report matching/creation and statement-driven overdraft creation/clearing.

### User-facing changes

After merge, users can import a wider range of UK bank exports and labelled PDF statements. Confirmed, reconciled imports update the linked account and overdraft automatically. Users can also import a credit-report PDF; supplied values update existing borrowing and positive unmatched accounts are added without merging debts and overdrafts together. The app has a redesigned OneStep interface, clearer private-storage feedback, and daily actions that visibly finish, snooze or transition to a completed state.

### Technical changes

- Stored-state schema increases from 4 to 5 by adding `creditReports: []`.
- Existing state is migrated in place; all existing collections are preserved and missing creditReports defaults to an empty array.
- Backup restoration remaps credit-report and borrowing source-document IDs so encrypted-vault references remain valid.
- Import automation is gated by statement reconciliation and finite closing balances.
- Credit-report matching uses normalised lender, optional last-four reference and account type; it does not fuzzy-match unrelated lenders or invent missing report fields.
- No new runtime or development dependencies were added, removed or updated.
- No telemetry, analytics, cloud storage or external network service was added.
- Imported originals and derived records remain within the existing encrypted local vault/state model.

### Testing and verification

- `npm test` — passed: 35/35 combined automated tests, including all v2.1.3 regression tests.
- `npm run check` — passed: JavaScript/project validation completed for 17 JavaScript files and 13 empty public seed collections.
- `node scripts/privacy-check.mjs` (run by `npm run check`) — passed: 31 repository files checked.
- `npx electron-builder --win dir --x64` — passed: Windows x64 application packaged successfully and `OneStep Money.exe` produced.
- Git-tree verification — passed: remote final tree `d1046101f153354626c9db5601bbfb6c29ceab44` exactly matches the locally validated branch tree.
- Electron interactive window smoke test — not completed because the hosted Linux environment blocks Chromium DBus/udev window access. This is an environment restriction; Windows packaging completed successfully.
- NSIS installer build — not completed because Wine is unavailable in the hosted Linux environment.
- Separate lint and type-check commands — not run because the repository does not define them.

### Data and migration impact

Existing user data is preserved. On load, schema-4 data migrates to schema 5 by retaining every existing collection and initialising only the missing `creditReports` collection. Existing encrypted documents are not renamed or moved. Backup restoration now also repairs credit-report account links and statement-source links for debts/overdrafts. Statement automation only writes balances after reconciliation, and credit-report imports only write after the user confirms the import preview.

No imported documents, financial records or user vault/database files are part of this branch.

### Known limitations

- The credit-report parser is deliberately label-based and provider-neutral; the user’s exact report layout still needs validation against an actual supplied PDF.
- Scanned/image-only PDFs or inaccessible table layouts cannot be reliably parsed and remain available for manual review.
- Generic PDF statement fallback requires clearly labelled accessible text and reconciliation before account balances are changed.
- The packaged Windows executable is unsigned and may trigger Microsoft SmartScreen.
- Interactive Electron rendering could not be exercised in this Linux host, and the NSIS installer could not be built here because Wine is unavailable.

### Excluded work

- No GitHub release, version tag or auto-update release was published.
- No pull request was merged and no change was made directly to `main`.
- No OCR/cloud document processing, telemetry or remote financial-data storage was added.
- Provider-specific tuning against the user’s actual credit-report PDF was not included because that report was not available in the workspace.

### Branch details

* Branch: `feature/automated-financial-imports`
* Commit SHA: `c266d32a8ba1307d060c48753b886c6e68ff8024`
* Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/5
* Target branch: `main`

### Confirmations

* No changes were committed or pushed directly to `main`.
* The pull request has not been merged.
* No personal financial data, imported documents, credentials, secrets or sensitive logs were committed.
* Only files relevant to the requested work were changed.
