### PR TITLE
[v2.1.5][Bug] Fail-safe data recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@ release/
 tmp/
 user-data/
 automatic-backups/
+recovery-copies/
 finance-state.json
 vault-key.json
 document-vault/
 *.vault
+*.restore
 *.osmb
 *.lfb
 *.hfb

--- a/data-store.js
+++ b/data-store.js
@@ -1,73 +1,232 @@
 import crypto from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { safeStorage } from 'electron';
 
 const STATE_FILE = 'finance-state.json';
 const KEY_FILE = 'vault-key.json';
 const VAULT_MAGIC = Buffer.from('LFVLT001');
 const BACKUP_MAGIC = Buffer.from('LFB1');
 const LEGACY_BACKUP_MAGIC = Buffer.from('HFB1');
+const CURRENT_SCHEMA_VERSION = 5;
+const FRESH_START_CONFIRMATION_MS = 5 * 60 * 1000;
+const STATE_COLLECTIONS = Object.freeze([
+  'accounts', 'transactions', 'payslips', 'taxDocuments', 'creditReports', 'debts', 'overdrafts',
+  'budgets', 'scheduledPayments', 'documents', 'tasks', 'checkIns', 'importBatches'
+]);
+
+export const RECOVERY_MODES = Object.freeze({
+  NORMAL: 'normal',
+  REQUIRED: 'recovery_required',
+  RESOLVING: 'resolution_in_progress'
+});
+
+export const LOAD_REASON_CODES = Object.freeze({
+  STATE_NOT_FOUND: 'state_not_found',
+  READ_FAILURE: 'read_failure',
+  DECRYPTION_FAILURE: 'decryption_failure',
+  ENCRYPTION_KEY_UNAVAILABLE: 'encryption_key_unavailable',
+  INVALID_CONTENT: 'invalid_content',
+  SCHEMA_VALIDATION_FAILURE: 'schema_validation_failure',
+  MIGRATION_FAILURE: 'migration_failure',
+  UNKNOWN_STORAGE_FAILURE: 'unknown_storage_failure'
+});
+
+export class RecoveryModeError extends Error {
+  constructor(mode) {
+    super('Saving is paused while financial data recovery is required.');
+    this.name = 'RecoveryModeError';
+    this.code = 'RECOVERY_MODE_ACTIVE';
+    this.result = { status: 'blocked', mode, reasonCode: 'recovery_mode_active' };
+  }
+}
+
+class StateLoadError extends Error {
+  constructor(reasonCode, cause = null) {
+    super(reasonCode);
+    this.name = 'StateLoadError';
+    this.reasonCode = reasonCode;
+    this.cause = cause;
+  }
+}
 
 export class FinanceDataStore {
-  constructor(userDataPath, seedPath, diagnostics = null) {
+  constructor(userDataPath, seedPath, diagnostics = null, options = {}) {
     this.userDataPath = userDataPath;
     this.seedPath = seedPath;
     this.statePath = path.join(userDataPath, STATE_FILE);
     this.vaultPath = path.join(userDataPath, 'document-vault');
     this.backupPath = path.join(userDataPath, 'automatic-backups');
+    this.recoveryPath = path.join(userDataPath, 'recovery-copies');
     this.keyPath = path.join(userDataPath, KEY_FILE);
     this.vaultKey = null;
     this.diagnostics = diagnostics;
+    this.secureStorage = options.secureStorage;
+    this.clock = typeof options.clock === 'function' ? options.clock : () => new Date();
+    this.migrate = typeof options.migrateState === 'function' ? options.migrateState : migrateState;
+    this.mode = RECOVERY_MODES.NORMAL;
+    this.recovery = null;
+    this.backupCandidates = new Map();
+    this.freshStartConfirmation = null;
   }
 
   async initialise() {
-    await fs.mkdir(this.userDataPath, { recursive: true });
-    await fs.mkdir(this.vaultPath, { recursive: true });
-    await fs.mkdir(this.backupPath, { recursive: true });
-    await this.loadOrCreateVaultKey();
+    await fs.mkdir(this.userDataPath, { recursive: true, mode: 0o700 });
+    await fs.mkdir(this.vaultPath, { recursive: true, mode: 0o700 });
+    await fs.mkdir(this.backupPath, { recursive: true, mode: 0o700 });
+    await fs.mkdir(this.recoveryPath, { recursive: true, mode: 0o700 });
   }
 
   encryptionStatus() {
+    const available = this.encryptionAvailable();
     return {
-      available: safeStorage.isEncryptionAvailable(),
-      backend: safeStorage.isEncryptionAvailable() ? 'Operating-system protected' : 'Unavailable'
+      available,
+      backend: available ? 'Operating-system protected' : 'Unavailable'
     };
   }
 
   async loadState() {
-    try {
-      const envelope = JSON.parse(await fs.readFile(this.statePath, 'utf8'));
-      const state = envelope.encrypted
-        ? JSON.parse(safeStorage.decryptString(Buffer.from(envelope.payload, 'base64')))
-        : JSON.parse(Buffer.from(envelope.payload, 'base64').toString('utf8'));
-      return migrateState(state);
-    } catch (error) {
-      if (error.code !== 'ENOENT') {
-        await this.diagnostics?.record('STATE_LOAD_RECOVERED', { error }).catch(() => {});
-        await this.createAutomaticBackup('unreadable-state').catch(() => {});
-      }
-      const seed = JSON.parse(await fs.readFile(this.seedPath, 'utf8'));
-      const state = migrateState(seed);
-      await this.saveState(state);
-      return state;
+    const inspected = await this.inspectStateFile(this.statePath);
+    if (inspected.status === 'not_found') {
+      return this.createFirstInstallState();
     }
+    if (inspected.status === 'failed') {
+      return this.enterRecovery(inspected.reasonCode, inspected.error);
+    }
+
+    try {
+      await this.loadOrCreateVaultKey({ hasDocuments: inspected.state.documents.length > 0 });
+    } catch (error) {
+      return this.enterRecovery(LOAD_REASON_CODES.ENCRYPTION_KEY_UNAVAILABLE, error);
+    }
+
+    this.clearRecovery();
+    return this.normalResult(inspected.state, 'existing');
   }
 
   async saveState(state) {
-    const clean = migrateState(structuredClone(state));
-    clean.meta.updatedAt = new Date().toISOString();
+    this.assertWritable();
+    return this.writeState(state);
+  }
+
+  assertWritable() {
+    if (this.mode !== RECOVERY_MODES.NORMAL) throw new RecoveryModeError(this.mode);
+  }
+
+  recoveryStatus() {
+    return this.recovery ? structuredClone(this.recovery) : null;
+  }
+
+  async retryRecoveryLoad() {
+    if (this.mode !== RECOVERY_MODES.REQUIRED) return { status: 'invalid_operation', mode: this.mode };
+    this.mode = RECOVERY_MODES.RESOLVING;
+    const inspected = await this.inspectStateFile(this.statePath);
+    if (inspected.status === 'loaded') {
+      try {
+        await this.loadOrCreateVaultKey({ hasDocuments: inspected.state.documents.length > 0 });
+        this.clearRecovery();
+        return this.normalResult(inspected.state, 'existing');
+      } catch (error) {
+        return this.enterRecovery(LOAD_REASON_CODES.ENCRYPTION_KEY_UNAVAILABLE, error);
+      }
+    }
+    const reasonCode = inspected.status === 'not_found' ? LOAD_REASON_CODES.STATE_NOT_FOUND : inspected.reasonCode;
+    return this.enterRecovery(reasonCode, inspected.error);
+  }
+
+  async restoreRecoveryBackup(backupId) {
+    if (this.mode !== RECOVERY_MODES.REQUIRED) return { status: 'invalid_operation', mode: this.mode };
+    let candidatePath = this.backupCandidates.get(String(backupId));
+    if (!candidatePath) {
+      await this.refreshRecoveryBackups();
+      candidatePath = this.backupCandidates.get(String(backupId));
+    }
+    if (!candidatePath) return this.recoveryFailure('backup_not_found');
+
+    this.mode = RECOVERY_MODES.RESOLVING;
+    let originalBytes;
+    let installed = false;
+    try {
+      const candidate = await this.inspectStateFile(candidatePath);
+      if (candidate.status !== 'loaded') throw new StateLoadError(candidate.reasonCode || 'backup_invalid');
+      const backupBytes = await fs.readFile(candidatePath);
+      originalBytes = await fs.readFile(this.statePath);
+      await atomicWrite(this.statePath, backupBytes);
+      installed = true;
+      const reopened = await this.inspectStateFile(this.statePath);
+      if (reopened.status !== 'loaded') throw new StateLoadError(reopened.reasonCode || 'restored_state_invalid');
+      await this.loadOrCreateVaultKey({ hasDocuments: reopened.state.documents.length > 0 });
+      this.clearRecovery();
+      return this.normalResult(reopened.state, 'restored_backup');
+    } catch (error) {
+      if (installed && originalBytes) await atomicWrite(this.statePath, originalBytes).catch(() => {});
+      await this.diagnostics?.record('RECOVERY_OPERATION_FAILED', { error, reasonCode: 'restore_failed' }).catch(() => {});
+      return this.recoveryFailure('restore_failed');
+    }
+  }
+
+  requestFreshStart() {
+    if (this.mode !== RECOVERY_MODES.REQUIRED) return { status: 'invalid_operation', mode: this.mode };
+    const token = crypto.randomUUID();
+    this.freshStartConfirmation = { token, expiresAt: this.clock().getTime() + FRESH_START_CONFIRMATION_MS };
+    return { status: 'confirmation_required', token, expiresAt: new Date(this.freshStartConfirmation.expiresAt).toISOString() };
+  }
+
+  cancelFreshStart(token) {
+    if (this.freshStartConfirmation?.token === token) this.freshStartConfirmation = null;
+    return this.recoveryResult();
+  }
+
+  async confirmFreshStart(token) {
+    if (this.mode !== RECOVERY_MODES.REQUIRED) return { status: 'invalid_operation', mode: this.mode };
+    if (!this.freshStartConfirmation || token !== this.freshStartConfirmation.token || this.clock().getTime() > this.freshStartConfirmation.expiresAt) {
+      return this.recoveryFailure('confirmation_invalid');
+    }
+
+    this.mode = RECOVERY_MODES.RESOLVING;
+    this.freshStartConfirmation = null;
+    let originalBytes;
+    let installed = false;
+    try {
+      originalBytes = await fs.readFile(this.statePath);
+      if (!this.recovery?.recoveryCopyCreated) {
+        const copy = await this.createRecoveryCopy();
+        if (!copy.created) throw new StateLoadError('recovery_copy_required');
+        this.recovery.recoveryCopyCreated = true;
+        this.recovery.recoveryCopyFileName = copy.fileName;
+      }
+      const seed = await this.readSeedState();
+      await this.loadOrCreateVaultKey({ hasDocuments: false });
+      await this.writeState(seed, { bypassRecovery: true });
+      installed = true;
+      const reopened = await this.inspectStateFile(this.statePath);
+      if (reopened.status !== 'loaded') throw new StateLoadError(reopened.reasonCode || 'fresh_state_invalid');
+      this.clearRecovery();
+      return this.normalResult(reopened.state, 'fresh_start');
+    } catch (error) {
+      if (installed && originalBytes) await atomicWrite(this.statePath, originalBytes).catch(() => {});
+      await this.diagnostics?.record('RECOVERY_OPERATION_FAILED', { error, reasonCode: 'fresh_start_failed' }).catch(() => {});
+      return this.recoveryFailure('fresh_start_failed');
+    }
+  }
+
+  async writeState(state, options = {}) {
+    if (!options.bypassRecovery) this.assertWritable();
+    const clean = this.migrate(structuredClone(state));
+    validateMigratedState(clean);
+    clean.meta.updatedAt = this.clock().toISOString();
     const json = JSON.stringify(clean);
-    const encrypted = safeStorage.isEncryptionAvailable();
+    const encrypted = this.encryptionAvailable();
     const payload = encrypted
-      ? safeStorage.encryptString(json).toString('base64')
+      ? this.secureStorage.encryptString(json).toString('base64')
       : Buffer.from(json, 'utf8').toString('base64');
     await atomicWrite(this.statePath, JSON.stringify({ version: 1, encrypted, payload }));
     return clean;
   }
 
   async createAutomaticBackup(reason = 'before-change') {
-    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    this.assertWritable();
+    const stamp = this.clock().toISOString().replace(/[:.]/g, '-');
     const destination = path.join(this.backupPath, `${stamp}-${slug(reason)}.json`);
     try {
       await fs.copyFile(this.statePath, destination);
@@ -78,8 +237,199 @@ export class FinanceDataStore {
     }
   }
 
+  encryptionAvailable() {
+    try {
+      return Boolean(this.secureStorage?.isEncryptionAvailable());
+    } catch {
+      return false;
+    }
+  }
+
+  normalResult(state, source) {
+    return {
+      status: 'normal',
+      mode: RECOVERY_MODES.NORMAL,
+      source,
+      state,
+      encryption: this.encryptionStatus()
+    };
+  }
+
+  recoveryResult() {
+    return {
+      status: 'recovery_required',
+      mode: RECOVERY_MODES.REQUIRED,
+      recovery: this.recoveryStatus(),
+      encryption: this.encryptionStatus()
+    };
+  }
+
+  recoveryFailure(reasonCode) {
+    this.mode = RECOVERY_MODES.REQUIRED;
+    if (this.recovery) this.recovery.lastOperationError = reasonCode;
+    return this.recoveryResult();
+  }
+
+  clearRecovery() {
+    this.mode = RECOVERY_MODES.NORMAL;
+    this.recovery = null;
+    this.backupCandidates.clear();
+    this.freshStartConfirmation = null;
+  }
+
+  async createFirstInstallState() {
+    const seed = await this.readSeedState();
+    await this.loadOrCreateVaultKey({ hasDocuments: false });
+    const saved = await this.writeState(seed, { bypassRecovery: true });
+    const reopened = await this.inspectStateFile(this.statePath);
+    if (reopened.status !== 'loaded') throw new StateLoadError(reopened.reasonCode || LOAD_REASON_CODES.UNKNOWN_STORAGE_FAILURE);
+    this.clearRecovery();
+    return this.normalResult(saved, 'first_install');
+  }
+
+  async readSeedState() {
+    const seed = JSON.parse(await fs.readFile(this.seedPath, 'utf8'));
+    validateStoredState(seed);
+    let migrated;
+    try {
+      migrated = this.migrate(structuredClone(seed));
+    } catch (error) {
+      throw new StateLoadError(LOAD_REASON_CODES.MIGRATION_FAILURE, error);
+    }
+    validateMigratedState(migrated);
+    return migrated;
+  }
+
+  async inspectStateFile(target) {
+    let stat;
+    try {
+      stat = await fs.lstat(target);
+    } catch (error) {
+      if (error.code === 'ENOENT') return { status: 'not_found' };
+      return { status: 'failed', reasonCode: LOAD_REASON_CODES.READ_FAILURE, error };
+    }
+    if (!stat.isFile()) {
+      return { status: 'failed', reasonCode: LOAD_REASON_CODES.READ_FAILURE, error: new Error('State path is not a regular file.') };
+    }
+
+    let bytes;
+    try {
+      bytes = await fs.readFile(target);
+    } catch (error) {
+      return { status: 'failed', reasonCode: LOAD_REASON_CODES.READ_FAILURE, error };
+    }
+
+    try {
+      const envelope = parseJson(bytes.toString('utf8'), LOAD_REASON_CODES.INVALID_CONTENT);
+      if (!isPlainObject(envelope) || envelope.version !== 1 || typeof envelope.encrypted !== 'boolean' || !isCanonicalBase64(envelope.payload)) {
+        throw new StateLoadError(LOAD_REASON_CODES.INVALID_CONTENT);
+      }
+
+      let serialised;
+      if (envelope.encrypted) {
+        if (!this.encryptionAvailable()) throw new StateLoadError(LOAD_REASON_CODES.ENCRYPTION_KEY_UNAVAILABLE);
+        try {
+          serialised = this.secureStorage.decryptString(Buffer.from(envelope.payload, 'base64'));
+        } catch (error) {
+          throw new StateLoadError(classifyDecryptionFailure(error), error);
+        }
+      } else {
+        serialised = Buffer.from(envelope.payload, 'base64').toString('utf8');
+      }
+
+      const stored = parseJson(serialised, LOAD_REASON_CODES.INVALID_CONTENT);
+      validateStoredState(stored);
+      let migrated;
+      try {
+        migrated = this.migrate(structuredClone(stored));
+      } catch (error) {
+        throw new StateLoadError(LOAD_REASON_CODES.MIGRATION_FAILURE, error);
+      }
+      validateMigratedState(migrated);
+      return { status: 'loaded', state: migrated, bytes, schemaVersion: migrated.schemaVersion };
+    } catch (error) {
+      const failure = error instanceof StateLoadError
+        ? error
+        : new StateLoadError(LOAD_REASON_CODES.UNKNOWN_STORAGE_FAILURE, error);
+      return { status: 'failed', reasonCode: failure.reasonCode, error: failure.cause || failure };
+    }
+  }
+
+  async enterRecovery(reasonCode, error = null) {
+    this.mode = RECOVERY_MODES.REQUIRED;
+    this.freshStartConfirmation = null;
+    const copy = await this.createRecoveryCopy();
+    this.recovery = {
+      reasonCode: reasonCode || LOAD_REASON_CODES.UNKNOWN_STORAGE_FAILURE,
+      recoveryCopyCreated: copy.created,
+      recoveryCopyFileName: copy.created ? copy.fileName : null,
+      backupDiscoveryFailed: false,
+      backups: [],
+      lastOperationError: null
+    };
+    await this.refreshRecoveryBackups();
+    await this.diagnostics?.record('STATE_RECOVERY_REQUIRED', {
+      error,
+      reasonCode: this.recovery.reasonCode
+    }).catch(() => {});
+    return this.recoveryResult();
+  }
+
+  async createRecoveryCopy() {
+    const stamp = this.clock().toISOString().replace(/[:.]/g, '-');
+    const fileName = `finance-state.recovery-${stamp}-${crypto.randomUUID()}.json`;
+    const destination = path.join(this.recoveryPath, fileName);
+    try {
+      await fs.copyFile(this.statePath, destination, fsConstants.COPYFILE_EXCL);
+      const [original, copy] = await Promise.all([fs.readFile(this.statePath), fs.readFile(destination)]);
+      if (sha256(original) !== sha256(copy)) {
+        await fs.unlink(destination).catch(() => {});
+        return { created: false, fileName: null };
+      }
+      return { created: true, fileName };
+    } catch {
+      return { created: false, fileName: null };
+    }
+  }
+
+  async refreshRecoveryBackups() {
+    this.backupCandidates.clear();
+    try {
+      const entries = await fs.readdir(this.backupPath, { withFileTypes: true });
+      const backups = [];
+      for (const entry of entries) {
+        if (!entry.isFile() || path.extname(entry.name).toLowerCase() !== '.json') continue;
+        const target = path.join(this.backupPath, entry.name);
+        const id = sha256(Buffer.from(entry.name, 'utf8')).slice(0, 24);
+        const [inspection, stat] = await Promise.all([this.inspectStateFile(target), fs.stat(target)]);
+        const valid = inspection.status === 'loaded';
+        this.backupCandidates.set(id, target);
+        backups.push({
+          id,
+          createdAt: stat.mtime.toISOString(),
+          valid,
+          compatible: valid,
+          schemaVersion: valid ? inspection.schemaVersion : null,
+          reasonCode: valid ? null : inspection.reasonCode || LOAD_REASON_CODES.UNKNOWN_STORAGE_FAILURE
+        });
+      }
+      backups.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+      if (this.recovery) {
+        this.recovery.backups = backups;
+        this.recovery.backupDiscoveryFailed = false;
+      }
+    } catch (error) {
+      if (this.recovery) {
+        this.recovery.backups = [];
+        this.recovery.backupDiscoveryFailed = true;
+      }
+      await this.diagnostics?.record('RECOVERY_OPERATION_FAILED', { error, reasonCode: 'backup_discovery_failed' }).catch(() => {});
+    }
+  }
+
   async storeDocument(filePath, kind, existingDocuments = []) {
-    if (!safeStorage.isEncryptionAvailable() || !this.vaultKey) {
+    this.assertWritable();
+    if (!this.encryptionAvailable() || !this.vaultKey) {
       throw new Error('Secure document storage is unavailable on this device.');
     }
 
@@ -109,7 +459,7 @@ export class FinanceDataStore {
         mimeType: mimeFromName(filePath),
         size: bytes.length,
         sha256: digest,
-        importedAt: new Date().toISOString(),
+        importedAt: this.clock().toISOString(),
         parseStatus: 'pending',
         linkedRecordIds: [],
         notes: ''
@@ -126,6 +476,7 @@ export class FinanceDataStore {
   }
 
   async deleteDocument(id, documents) {
+    this.assertWritable();
     const document = documents.find((entry) => entry.id === id);
     if (!document) return false;
     await fs.unlink(path.join(this.vaultPath, document.storedName)).catch((error) => {
@@ -142,7 +493,7 @@ export class FinanceDataStore {
       documents.push({ metadata: document, contents: bytes.toString('base64') });
     }
 
-    const payload = Buffer.from(JSON.stringify({ version: 1, createdAt: new Date().toISOString(), state, documents }), 'utf8');
+    const payload = Buffer.from(JSON.stringify({ version: 1, createdAt: this.clock().toISOString(), state, documents }), 'utf8');
     const salt = crypto.randomBytes(16);
     const iv = crypto.randomBytes(12);
     const key = crypto.scryptSync(passphrase, salt, 32);
@@ -153,6 +504,7 @@ export class FinanceDataStore {
   }
 
   async restorePortableBackup(source, passphrase) {
+    this.assertWritable();
     requirePassphrase(passphrase);
     const contents = await fs.readFile(source);
     const magic = contents.subarray(0, 4);
@@ -214,18 +566,24 @@ export class FinanceDataStore {
     return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
   }
 
-  async loadOrCreateVaultKey() {
-    if (!safeStorage.isEncryptionAvailable()) {
+  async loadOrCreateVaultKey({ hasDocuments = false } = {}) {
+    if (!this.encryptionAvailable()) {
       this.vaultKey = null;
+      if (hasDocuments) throw new StateLoadError(LOAD_REASON_CODES.ENCRYPTION_KEY_UNAVAILABLE);
       return;
     }
     try {
       const stored = JSON.parse(await fs.readFile(this.keyPath, 'utf8'));
-      this.vaultKey = Buffer.from(safeStorage.decryptString(Buffer.from(stored.encryptedKey, 'base64')), 'base64');
+      if (!isPlainObject(stored) || stored.version !== 1 || !isCanonicalBase64(stored.encryptedKey)) {
+        throw new StateLoadError(LOAD_REASON_CODES.ENCRYPTION_KEY_UNAVAILABLE);
+      }
+      this.vaultKey = Buffer.from(this.secureStorage.decryptString(Buffer.from(stored.encryptedKey, 'base64')), 'base64');
+      if (this.vaultKey.length !== 32) throw new StateLoadError(LOAD_REASON_CODES.ENCRYPTION_KEY_UNAVAILABLE);
     } catch (error) {
-      if (error.code !== 'ENOENT') throw error;
+      if (error.code !== 'ENOENT' && hasDocuments) throw error;
+      if (error.code === 'ENOENT' && hasDocuments) throw new StateLoadError(LOAD_REASON_CODES.ENCRYPTION_KEY_UNAVAILABLE, error);
       this.vaultKey = crypto.randomBytes(32);
-      const encryptedKey = safeStorage.encryptString(this.vaultKey.toString('base64')).toString('base64');
+      const encryptedKey = this.secureStorage.encryptString(this.vaultKey.toString('base64')).toString('base64');
       await atomicWrite(this.keyPath, JSON.stringify({ version: 1, encryptedKey }));
     }
   }
@@ -234,7 +592,7 @@ export class FinanceDataStore {
 function migrateState(input) {
   const state = input && typeof input === 'object' ? input : {};
   return {
-    schemaVersion: 5,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
     meta: { createdAt: state.meta?.createdAt || new Date().toISOString(), updatedAt: state.meta?.updatedAt || new Date().toISOString() },
     profile: state.profile || { name: '', locale: 'en-GB', currency: 'GBP', dependableIncome: 0, paydayDay: 30 },
     accounts: Array.isArray(state.accounts) ? state.accounts : [],
@@ -283,4 +641,78 @@ function requirePassphrase(passphrase) {
 
 function slug(value) {
   return String(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'backup';
+}
+
+function parseJson(value, reasonCode) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new StateLoadError(reasonCode, error);
+  }
+}
+
+function validateStoredState(state) {
+  if (!isPlainObject(state)) throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+  if (state.schemaVersion !== undefined && (!Number.isInteger(state.schemaVersion) || state.schemaVersion < 1 || state.schemaVersion > CURRENT_SCHEMA_VERSION)) {
+    throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+  }
+  for (const collection of STATE_COLLECTIONS) {
+    if (state[collection] !== undefined && !Array.isArray(state[collection])) {
+      throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+    }
+  }
+  for (const objectName of ['meta', 'profile', 'settings']) {
+    if (state[objectName] !== undefined && !isPlainObject(state[objectName])) {
+      throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+    }
+  }
+  if (state.settings?.reminders !== undefined && !isPlainObject(state.settings.reminders)) {
+    throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+  }
+}
+
+function validateMigratedState(state) {
+  if (!isPlainObject(state) || state.schemaVersion !== CURRENT_SCHEMA_VERSION) {
+    throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+  }
+  for (const collection of STATE_COLLECTIONS) {
+    if (!Array.isArray(state[collection])) throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+  }
+  if (!isPlainObject(state.meta) || !isPlainObject(state.profile) || !isPlainObject(state.settings) || !isPlainObject(state.settings.reminders)) {
+    throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+  }
+  for (const value of [
+    state.profile.dependableIncome,
+    state.settings.extraDebtPayment,
+    state.settings.emergencyBufferTarget,
+    state.settings.emergencyBufferBalance,
+    state.settings.extraIncomeDebtPercent
+  ]) {
+    if (!Number.isFinite(Number(value))) throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+  }
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isCanonicalBase64(value) {
+  return typeof value === 'string'
+    && value.length > 0
+    && value.length % 4 === 0
+    && /^[A-Za-z0-9+/]+={0,2}$/.test(value)
+    && Buffer.from(value, 'base64').toString('base64') === value;
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function classifyDecryptionFailure(error) {
+  const code = String(error?.code || '').toUpperCase();
+  const message = String(error?.message || '');
+  if (['ENOKEY', 'KEY_NOT_FOUND', 'CREDENTIAL_NOT_FOUND'].includes(code) || /(?:encryption |credential )?key (?:is )?(?:missing|not found|unavailable)/i.test(message)) {
+    return LOAD_REASON_CODES.ENCRYPTION_KEY_UNAVAILABLE;
+  }
+  return LOAD_REASON_CODES.DECRYPTION_FAILURE;
 }

--- a/diagnostic-logger.js
+++ b/diagnostic-logger.js
@@ -16,6 +16,8 @@ const EVENT_DEFINITIONS = Object.freeze({
   SECURE_STORAGE_UNAVAILABLE: { level: 'warning', reference: 'SEC-101', stage: 'secure_storage', layer: 'startup' },
   STATE_LOAD_RECOVERED: { level: 'error', reference: 'DAT-101', stage: 'state_load', layer: 'detail' },
   STATE_SAVE_FAILED: { level: 'error', reference: 'DAT-102', stage: 'state_save', layer: 'detail' },
+  STATE_RECOVERY_REQUIRED: { level: 'error', reference: 'DAT-103', stage: 'state_recovery', layer: 'detail', fields: ['reasonCode'] },
+  RECOVERY_OPERATION_FAILED: { level: 'error', reference: 'DAT-104', stage: 'state_recovery', layer: 'detail', fields: ['reasonCode'] },
   DOCUMENT_IMPORT_FAILED: { level: 'error', reference: 'IMP-101', stage: 'document_import', layer: 'detail', fields: ['documentType', 'fileType'] },
   DOCUMENT_OPEN_FAILED: { level: 'error', reference: 'DOC-101', stage: 'document_open', layer: 'detail' },
   DOCUMENT_DELETE_FAILED: { level: 'error', reference: 'DOC-102', stage: 'document_delete', layer: 'detail' },
@@ -40,6 +42,11 @@ const FAULT_CLASSIFIERS = [
 
 const ALLOWED_DOCUMENT_TYPES = new Set(['statement', 'payslip']);
 const ALLOWED_FILE_TYPES = new Set(['pdf', 'csv', 'qif', 'ofx', 'json']);
+const ALLOWED_REASON_CODES = new Set([
+  'state_not_found', 'read_failure', 'decryption_failure', 'encryption_key_unavailable',
+  'invalid_content', 'schema_validation_failure', 'migration_failure', 'unknown_storage_failure',
+  'backup_discovery_failed', 'restore_failed', 'fresh_start_failed'
+]);
 const ALLOWED_ERROR_NAMES = new Set(['Error', 'TypeError', 'ReferenceError', 'RangeError', 'SyntaxError', 'URIError', 'AggregateError']);
 const ALLOWED_CLASSIFICATIONS = new Set(['PDF_RENDER_DOMMATRIX_MISSING', 'PDF_RENDER_DOMPOINT_MISSING', 'DOCUMENT_FORMAT_UNSUPPORTED', 'FILE_DAMAGED', 'STORAGE_FULL', 'PERMISSION_DENIED', 'SECURE_STORAGE_UNAVAILABLE', 'UNCLASSIFIED_FAILURE']);
 const ALLOWED_REFERENCES = new Set([
@@ -144,6 +151,7 @@ export class DiagnosticLogger {
       const details = [
         entry.documentType ? `document_type=${entry.documentType}` : '',
         entry.fileType ? `file_type=${entry.fileType}` : '',
+        entry.reasonCode ? `reason_code=${entry.reasonCode}` : '',
         entry.fault?.name ? `fault=${entry.fault.name}` : '',
         entry.fault?.classification ? `classification=${entry.fault.classification}` : ''
       ].filter(Boolean).join(' ');
@@ -298,6 +306,7 @@ function normaliseStoredEntry(entry) {
 
 function sanitiseField(field, value) {
   if (field === 'documentType') return ALLOWED_DOCUMENT_TYPES.has(value) ? value : null;
+  if (field === 'reasonCode') return ALLOWED_REASON_CODES.has(value) ? value : null;
   if (field === 'fileType') {
     const extension = String(value || '').toLowerCase().replace(/^\./, '');
     return ALLOWED_FILE_TYPES.has(extension) ? extension : null;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,34 @@
       <p>Your private data and document vault are available only in Electron desktop mode.</p>
     </div>
 
+    <main id="recoveryScreen" class="recovery-screen" hidden>
+      <section class="recovery-card" aria-labelledby="recoveryTitle">
+        <div class="recovery-mark" aria-hidden="true">!</div>
+        <p class="eyebrow">DATA RECOVERY</p>
+        <h1 id="recoveryTitle">OneStep couldn’t open your financial data</h1>
+        <p class="recovery-lead">Your existing data has not been replaced. Saving has been paused while you choose how to recover it.</p>
+        <div class="recovery-notice">
+          <strong id="recoveryReason">The stored data could not be validated.</strong>
+          <span id="recoveryCopyStatus"></span>
+        </div>
+
+        <div class="recovery-section">
+          <div class="recovery-section-heading"><div><h2>Available backups</h2><p>Only backups that pass integrity and compatibility checks can be restored.</p></div></div>
+          <div id="recoveryBackupList" class="recovery-backups"></div>
+        </div>
+
+        <div class="recovery-actions">
+          <button id="retryRecoveryButton" class="primary-button" type="button">Try opening the data again</button>
+          <p id="recoveryStatus" class="muted" role="status" aria-live="polite"></p>
+        </div>
+
+        <div class="recovery-destructive">
+          <div><h2>Start again</h2><p>This creates a new financial state. Your existing data will not appear in the new installation.</p></div>
+          <button id="requestFreshStartButton" class="danger-button" type="button">Review start-again warning</button>
+        </div>
+      </section>
+    </main>
+
     <div id="appShell" class="app-shell" hidden>
       <aside class="sidebar">
         <div class="brand">
@@ -139,6 +167,8 @@
     <dialog id="importDialog" class="modal wide"><form method="dialog"><div class="modal-heading"><div><p class="eyebrow">IMPORT PREVIEW</p><h2 id="importTitle">Review before importing</h2></div><button class="icon-button" value="cancel" aria-label="Close">×</button></div><div id="importSummary" class="import-summary"></div><div id="importWarnings" class="warning-box" hidden></div><div class="table-wrap preview-table"><table><thead id="importPreviewHead"></thead><tbody id="importPreviewRows"></tbody></table></div><div class="modal-actions"><button value="cancel" class="secondary-button">Keep document only</button><button id="confirmImportButton" value="default" class="primary-button">Import reviewed records</button></div></form></dialog>
 
     <dialog id="diagnosticsDialog" class="modal wide"><form method="dialog"><div class="modal-heading"><div><p class="eyebrow">PRIVATE SUPPORT REPORT</p><h2>Review diagnostics</h2></div><button class="icon-button" value="cancel" aria-label="Close">×</button></div><p id="diagnosticsSummary" class="muted"></p><div class="warning-box">Exported reports are readable text so support can inspect them. They are not uploaded automatically—only share the file with someone you trust.</div><pre id="diagnosticsPreview" class="diagnostic-preview" tabindex="0"></pre><div class="modal-actions"><button value="cancel" class="secondary-button">Close</button><button id="exportDiagnosticsButton" type="button" class="primary-button">Export this report</button></div></form></dialog>
+
+    <dialog id="freshStartDialog" class="modal destructive-modal"><form id="freshStartForm" method="dialog"><div class="modal-heading"><div><p class="eyebrow danger-eyebrow">DESTRUCTIVE ACTION</p><h2>Start with new financial data?</h2></div><button class="icon-button" value="cancel" aria-label="Close">×</button></div><div class="destructive-warning"><strong>Your current data will not appear in the new installation.</strong><p>OneStep will preserve the unreadable state in a separate recovery copy before creating anything new. This action should only be used when retrying and restoring a valid backup are not possible.</p></div><label class="confirmation-check"><input id="freshStartAcknowledgement" type="checkbox" />I understand that OneStep will create a new blank financial state.</label><p id="freshStartStatus" class="muted" role="status" aria-live="polite"></p><div class="modal-actions"><button value="cancel" class="secondary-button">Cancel</button><button id="confirmFreshStartButton" type="button" class="danger-button" disabled>Start again</button></div></form></dialog>
 
     <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
     <script type="module" src="renderer-app.js"></script>

--- a/main-process.js
+++ b/main-process.js
@@ -17,6 +17,7 @@ const __dirname = path.dirname(__filename);
 let mainWindow;
 let store;
 let currentState;
+let currentLoadResult;
 let diagnostics;
 let diagnosticPreviewCache;
 
@@ -37,9 +38,10 @@ app.whenReady().then(async () => {
   await diagnostics.record('APP_STARTED');
   if (!diagnostics.encryptionAvailable()) await diagnostics.record('SECURE_STORAGE_UNAVAILABLE');
 
-  store = new FinanceDataStore(app.getPath('userData'), path.join(__dirname, 'seed-data.json'), diagnostics);
+  store = new FinanceDataStore(app.getPath('userData'), path.join(__dirname, 'seed-data.json'), diagnostics, { secureStorage: safeStorage });
   await store.initialise();
-  currentState = await store.loadState();
+  currentLoadResult = await store.loadState();
+  currentState = currentLoadResult.status === 'normal' ? currentLoadResult.state : null;
   registerVaultProtocol();
   registerIpcHandlers();
   createWindow();
@@ -122,8 +124,12 @@ function sendUpdateStatus(status) {
 }
 
 function registerIpcHandlers() {
-  ipcMain.handle('state:load', async () => ({ state: currentState, encryption: store.encryptionStatus() }));
+  ipcMain.handle('state:load', async () => currentState && store.mode === 'normal'
+    ? { ...currentLoadResult, status: 'normal', mode: 'normal', state: currentState, encryption: store.encryptionStatus() }
+    : currentLoadResult);
   ipcMain.handle('state:save', async (_event, nextState) => {
+    const blocked = blockedMutationResult();
+    if (blocked) return blocked;
     try {
       if (!nextState || JSON.stringify(nextState).length > 25_000_000) throw new Error('The data update is invalid or too large.');
       currentState = await store.saveState(nextState);
@@ -134,7 +140,15 @@ function registerIpcHandlers() {
     }
   });
 
+  ipcMain.handle('recovery:retry', async () => applyRecoveryResult(await store.retryRecoveryLoad()));
+  ipcMain.handle('recovery:restore-backup', async (_event, backupId) => applyRecoveryResult(await store.restoreRecoveryBackup(backupId)));
+  ipcMain.handle('recovery:fresh-start:request', async () => store.requestFreshStart());
+  ipcMain.handle('recovery:fresh-start:cancel', async (_event, token) => store.cancelFreshStart(token));
+  ipcMain.handle('recovery:fresh-start:confirm', async (_event, token) => applyRecoveryResult(await store.confirmFreshStart(token)));
+
   ipcMain.handle('import:choose', async (_event, options = {}) => {
+    const blocked = blockedMutationResult();
+    if (blocked) return blocked;
     const kind = ['payslip', 'credit-report'].includes(options.kind) ? options.kind : 'statement';
     const selection = await dialog.showOpenDialog(mainWindow, {
       title: kind === 'payslip' ? 'Import payslip' : kind === 'credit-report' ? 'Import credit report' : 'Import bank statement',
@@ -179,6 +193,8 @@ function registerIpcHandlers() {
   });
 
   ipcMain.handle('document:open', async (_event, id) => {
+    const blocked = blockedMutationResult();
+    if (blocked) return blocked;
     try {
       if (!currentState.documents.some((document) => document.id === id)) throw new Error('Document not found.');
       const viewer = new BrowserWindow({
@@ -200,6 +216,8 @@ function registerIpcHandlers() {
   });
 
   ipcMain.handle('document:delete', async (_event, id) => {
+    const blocked = blockedMutationResult();
+    if (blocked) return blocked;
     try {
       await store.createAutomaticBackup('before-document-delete');
       await store.deleteDocument(id, currentState.documents);
@@ -213,6 +231,8 @@ function registerIpcHandlers() {
   });
 
   ipcMain.handle('backup:create', async (_event, passphrase) => {
+    const blocked = blockedMutationResult();
+    if (blocked) return blocked;
     try {
       const selection = await dialog.showSaveDialog(mainWindow, { title: 'Create encrypted backup', defaultPath: `onestep-money-backup-${new Date().toISOString().slice(0, 10)}.osmb`, filters: [{ name: 'OneStep Money backup', extensions: ['osmb'] }] });
       if (selection.canceled || !selection.filePath) return { canceled: true };
@@ -225,6 +245,8 @@ function registerIpcHandlers() {
   });
 
   ipcMain.handle('backup:restore', async (_event, passphrase) => {
+    const blocked = blockedMutationResult();
+    if (blocked) return blocked;
     try {
       const selection = await dialog.showOpenDialog(mainWindow, { title: 'Restore encrypted backup', properties: ['openFile'], filters: [{ name: 'OneStep Money backup', extensions: ['osmb', 'hfb'] }] });
       if (selection.canceled) return { canceled: true };
@@ -236,14 +258,22 @@ function registerIpcHandlers() {
     }
   });
 
-  ipcMain.handle('llm:status', async (_event, model) => checkLocalModel(model || currentState.settings.llmModel));
-  ipcMain.handle('llm:ask', async (_event, question) => askLocalModel(question, currentState, currentState.settings.llmModel));
+  ipcMain.handle('llm:status', async (_event, model) => {
+    const blocked = blockedMutationResult();
+    return blocked || checkLocalModel(model || currentState.settings.llmModel);
+  });
+  ipcMain.handle('llm:ask', async (_event, question) => {
+    const blocked = blockedMutationResult();
+    return blocked || askLocalModel(question, currentState, currentState.settings.llmModel);
+  });
   ipcMain.handle('update:check', async () => {
     if (!app.isPackaged) return { state: 'development', message: 'Updates are disabled in development mode.', currentVersion: app.getVersion() };
     await autoUpdater.checkForUpdates();
     return { state: 'checking', message: 'Checking for updates…', currentVersion: app.getVersion() };
   });
   ipcMain.handle('update:install', async () => {
+    const blocked = blockedMutationResult();
+    if (blocked) return blocked;
     if (!app.isPackaged) return false;
     await store.createAutomaticBackup('before-update');
     setImmediate(() => autoUpdater.quitAndInstall(false, true));
@@ -295,6 +325,17 @@ function registerIpcHandlers() {
     await diagnostics.record(eventName);
     return true;
   });
+}
+
+function blockedMutationResult() {
+  if (!store || store.mode === 'normal') return null;
+  return { status: 'blocked', mode: store.mode, reasonCode: 'recovery_mode_active', message: 'Saving is paused while financial data recovery is required.' };
+}
+
+function applyRecoveryResult(result) {
+  currentLoadResult = result;
+  currentState = result?.status === 'normal' ? result.state : null;
+  return result;
 }
 
 function registerVaultProtocol() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onestep-money",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -3,6 +3,11 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('financeAPI', Object.freeze({
   loadState: () => ipcRenderer.invoke('state:load'),
   saveState: (state) => ipcRenderer.invoke('state:save', state),
+  retryRecovery: () => ipcRenderer.invoke('recovery:retry'),
+  restoreRecoveryBackup: (backupId) => ipcRenderer.invoke('recovery:restore-backup', backupId),
+  requestFreshStart: () => ipcRenderer.invoke('recovery:fresh-start:request'),
+  cancelFreshStart: (token) => ipcRenderer.invoke('recovery:fresh-start:cancel', token),
+  confirmFreshStart: (token) => ipcRenderer.invoke('recovery:fresh-start:confirm', token),
   importFiles: (options) => ipcRenderer.invoke('import:choose', options),
   openDocument: (id) => ipcRenderer.invoke('document:open', id),
   deleteDocument: (id) => ipcRenderer.invoke('document:delete', id),

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -12,6 +12,10 @@ let importQueue = [];
 let currentImport = null;
 let editorContext = null;
 let diagnosticPreviewToken = null;
+let recoveryResult = null;
+let freshStartToken = null;
+let normalEventsBound = false;
+let recoveryEventsBound = false;
 
 const viewMeta = {
   today: ['ONE CLEAR MOVE', 'Today'], transactions: ['MONEY IN AND OUT', 'Payments'], pay: ['WHERE GROSS PAY GOES', 'Pay'],
@@ -33,18 +37,183 @@ async function initialise() {
   }
   try {
     const loaded = await window.financeAPI.loadState();
-    state = loaded.state;
-    encryption = loaded.encryption;
-    byId('appShell').hidden = false;
-    bindEvents();
-    populateMonthOptions();
-    populateAccountOptions();
-    render();
-    checkModel();
+    if (loaded.status === 'recovery_required') showRecoveryMode(loaded);
+    else if (loaded.status === 'normal') activateNormalMode(loaded);
+    else throw new Error('The secure data store returned an unsupported startup state.');
   } catch (error) {
     byId('desktopRequired').hidden = false;
     byId('desktopRequired').querySelector('p').textContent = `The secure data store could not be opened: ${error.message}`;
   }
+}
+
+function activateNormalMode(loaded) {
+  state = loaded.state;
+  encryption = loaded.encryption;
+  recoveryResult = null;
+  freshStartToken = null;
+  byId('desktopRequired').hidden = true;
+  byId('recoveryScreen').hidden = true;
+  byId('appShell').hidden = false;
+  if (!normalEventsBound) {
+    bindEvents();
+    normalEventsBound = true;
+  }
+  populateMonthOptions();
+  populateAccountOptions();
+  render();
+  checkModel();
+}
+
+function showRecoveryMode(result) {
+  recoveryResult = result;
+  byId('desktopRequired').hidden = true;
+  byId('appShell').hidden = true;
+  byId('recoveryScreen').hidden = false;
+  if (!recoveryEventsBound) {
+    bindRecoveryEvents();
+    recoveryEventsBound = true;
+  }
+  renderRecoveryMode();
+}
+
+function bindRecoveryEvents() {
+  byId('retryRecoveryButton').addEventListener('click', retryRecovery);
+  byId('recoveryBackupList').addEventListener('click', restoreRecoveryBackup);
+  byId('requestFreshStartButton').addEventListener('click', requestFreshStart);
+  byId('freshStartAcknowledgement').addEventListener('change', () => {
+    byId('confirmFreshStartButton').disabled = !byId('freshStartAcknowledgement').checked;
+  });
+  byId('confirmFreshStartButton').addEventListener('click', confirmFreshStart);
+  byId('freshStartDialog').addEventListener('close', cancelFreshStart);
+}
+
+function renderRecoveryMode() {
+  const recovery = recoveryResult?.recovery || {};
+  const reasonMessages = {
+    state_not_found: 'The original state file is no longer available. OneStep will not treat this as a first installation while recovery is active.',
+    read_failure: 'OneStep could not read the existing state file. This may be a temporary permission or storage problem.',
+    decryption_failure: 'The existing state could not be decrypted or authenticated.',
+    encryption_key_unavailable: 'The encryption service or key required to open the existing data is unavailable.',
+    invalid_content: 'The existing state is incomplete or contains invalid data.',
+    schema_validation_failure: 'The existing state did not pass OneStep’s data-integrity checks.',
+    migration_failure: 'OneStep could not safely update the stored data to the current schema.',
+    unknown_storage_failure: 'An unexpected storage error prevented OneStep from safely opening the existing data.'
+  };
+  byId('recoveryReason').textContent = reasonMessages[recovery.reasonCode] || reasonMessages.unknown_storage_failure;
+  byId('recoveryCopyStatus').textContent = recovery.recoveryCopyCreated
+    ? 'A separate byte-for-byte recovery copy was created and verified. The original file was left unchanged.'
+    : 'OneStep could not verify a separate recovery copy. The original file has still not been replaced.';
+
+  const list = byId('recoveryBackupList');
+  clear(list);
+  const backups = recovery.backups || [];
+  const newestValid = backups.find((backup) => backup.valid);
+  for (const backup of backups) {
+    const card = element('article', `recovery-backup ${backup.valid ? '' : 'invalid'}`.trim());
+    const copy = element('div', 'recovery-backup-copy');
+    const title = backup.valid && backup.id === newestValid?.id ? 'Newest valid backup' : backup.valid ? 'Valid backup' : 'Backup could not be validated';
+    append(copy, element('strong', '', title), element('span', '', `${formatRecoveryDate(backup.createdAt)}${backup.schemaVersion ? ` · Schema ${backup.schemaVersion}` : ''}`));
+    card.append(copy);
+    if (backup.valid) {
+      const button = element('button', 'primary-button', 'Restore this backup');
+      button.type = 'button';
+      button.dataset.recoveryBackup = backup.id;
+      card.append(button);
+    } else {
+      card.append(element('span', 'badge red', 'Not usable'));
+    }
+    list.append(card);
+  }
+  if (!backups.length) {
+    list.append(element('p', 'muted', recovery.backupDiscoveryFailed
+      ? 'OneStep could not inspect the local backup folder. You can try opening the original data again.'
+      : 'No local backups were found. You can still retry opening the original data.'));
+  }
+
+  const statusMessages = {
+    restore_failed: 'That backup could not be restored. Recovery mode is still active and the original state remains preserved.',
+    backup_not_found: 'That backup is no longer available. Recovery mode is still active.',
+    fresh_start_failed: 'A new state could not be created safely. Recovery mode is still active.',
+    confirmation_invalid: 'The start-again confirmation expired. Review the warning again if you still want to continue.'
+  };
+  byId('recoveryStatus').textContent = statusMessages[recovery.lastOperationError] || '';
+}
+
+async function retryRecovery() {
+  const button = byId('retryRecoveryButton');
+  button.disabled = true;
+  byId('recoveryStatus').textContent = 'Trying to open and validate the original data…';
+  try {
+    handleRecoveryResponse(await window.financeAPI.retryRecovery());
+  } catch {
+    byId('recoveryStatus').textContent = 'The data still could not be opened. Recovery mode remains active.';
+  } finally {
+    button.disabled = false;
+  }
+}
+
+async function restoreRecoveryBackup(event) {
+  const button = event.target.closest('[data-recovery-backup]');
+  if (!button) return;
+  if (!window.confirm('Restore this validated backup as the active financial state?')) return;
+  button.disabled = true;
+  byId('recoveryStatus').textContent = 'Restoring and reopening the selected backup…';
+  try {
+    handleRecoveryResponse(await window.financeAPI.restoreRecoveryBackup(button.dataset.recoveryBackup));
+  } catch {
+    byId('recoveryStatus').textContent = 'The backup could not be restored. Recovery mode remains active.';
+  } finally {
+    button.disabled = false;
+  }
+}
+
+async function requestFreshStart() {
+  const result = await window.financeAPI.requestFreshStart();
+  if (result.status !== 'confirmation_required') {
+    byId('recoveryStatus').textContent = 'The start-again confirmation could not be opened.';
+    return;
+  }
+  freshStartToken = result.token;
+  byId('freshStartAcknowledgement').checked = false;
+  byId('confirmFreshStartButton').disabled = true;
+  byId('freshStartStatus').textContent = '';
+  byId('freshStartDialog').showModal();
+}
+
+async function confirmFreshStart() {
+  if (!freshStartToken || !byId('freshStartAcknowledgement').checked) return;
+  const button = byId('confirmFreshStartButton');
+  button.disabled = true;
+  byId('freshStartStatus').textContent = 'Preserving the original data and creating a new state…';
+  const token = freshStartToken;
+  try {
+    const result = await window.financeAPI.confirmFreshStart(token);
+    freshStartToken = null;
+    byId('freshStartDialog').close('confirmed');
+    handleRecoveryResponse(result);
+  } catch {
+    byId('freshStartStatus').textContent = 'A new state could not be created safely. Nothing has been cleared.';
+    button.disabled = false;
+  }
+}
+
+async function cancelFreshStart() {
+  if (!freshStartToken) return;
+  const token = freshStartToken;
+  freshStartToken = null;
+  await window.financeAPI.cancelFreshStart(token).catch(() => {});
+}
+
+function handleRecoveryResponse(result) {
+  if (result?.status === 'normal') activateNormalMode(result);
+  else if (result?.status === 'recovery_required') showRecoveryMode(result);
+  else byId('recoveryStatus').textContent = 'Recovery could not continue. Your data has not been replaced.';
+}
+
+function formatRecoveryDate(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Date unavailable';
+  return new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
 }
 
 function bindEvents() {
@@ -354,6 +523,7 @@ async function importDocuments(kind) {
   }
   try {
     const results = await window.financeAPI.importFiles({ kind, accountId: kind === 'statement' ? byId('statementAccountSelect').value : '' });
+    if (results?.status === 'blocked') throw new Error(results.message || 'Saving is paused while recovery is required.');
     for (const result of results) {
       if (!state.documents.some((documentItem) => documentItem.id === result.document.id)) {
         state.documents.push(result.document);
@@ -840,7 +1010,9 @@ async function deleteDiagnostics() {
 async function saveAndRender() { await saveState(); render(); }
 async function saveState() {
   synchroniseSelectedMonth();
-  state = await window.financeAPI.saveState(state);
+  const saved = await window.financeAPI.saveState(state);
+  if (saved?.status === 'blocked') throw new Error(saved.message || 'Saving is paused while recovery is required.');
+  state = saved;
 }
 
 function populateMonthOptions() {

--- a/styles.css
+++ b/styles.css
@@ -75,6 +75,62 @@ h3 { margin-bottom: 0.25rem; font-size: 0.98rem; letter-spacing: -0.012em; }
 .desktop-required img { width: min(380px, 100%); margin-bottom: 2.2rem; }
 .desktop-required > p:last-child { max-width: 420px; margin: 0.7rem auto 0; color: var(--muted); line-height: 1.6; }
 
+.recovery-screen {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 3rem);
+  background:
+    radial-gradient(circle at 50% 0%, rgba(24, 185, 158, 0.11), transparent 30rem),
+    linear-gradient(145deg, #eef4f9, #f8fafc);
+}
+.recovery-card {
+  width: min(820px, 100%);
+  padding: clamp(1.5rem, 4vw, 2.7rem);
+  background: rgba(255, 255, 255, 0.97);
+  border: 1px solid var(--line-strong);
+  border-radius: 26px;
+  box-shadow: var(--shadow-strong);
+}
+.recovery-mark {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 1.2rem;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  background: linear-gradient(135deg, var(--navy), #155b78);
+  border-radius: 15px;
+  box-shadow: 0 10px 25px rgba(12, 41, 93, 0.2);
+  font-size: 1.3rem;
+  font-weight: 900;
+}
+.recovery-lead { max-width: 680px; margin: 0.8rem 0 1.2rem; color: var(--ink-soft); font-size: 1rem; line-height: 1.6; }
+.recovery-notice { display: grid; gap: 0.25rem; padding: 0.9rem 1rem; color: #52637a; background: var(--navy-soft); border: 1px solid #d8e2ed; border-radius: 13px; font-size: 0.84rem; line-height: 1.5; }
+.recovery-notice strong { color: var(--navy); }
+.recovery-section { margin-top: 1.5rem; }
+.recovery-section-heading { display: flex; justify-content: space-between; gap: 1rem; }
+.recovery-section-heading p { margin: 0; color: var(--muted); font-size: 0.82rem; line-height: 1.5; }
+.recovery-backups { display: grid; gap: 0.6rem; margin-top: 0.8rem; }
+.recovery-backup {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 0.9rem;
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: 13px;
+}
+.recovery-backup-copy { display: grid; gap: 0.18rem; }
+.recovery-backup-copy span { color: var(--muted); font-size: 0.75rem; }
+.recovery-backup.invalid { background: #fafafa; opacity: 0.78; }
+.recovery-actions { margin-top: 1.2rem; }
+.recovery-actions .muted { min-height: 1.2em; margin: 0.65rem 0 0; }
+.recovery-destructive { margin-top: 1.5rem; padding-top: 1.2rem; display: flex; align-items: center; justify-content: space-between; gap: 1.5rem; border-top: 1px solid var(--line); }
+.recovery-destructive h2 { color: var(--red); }
+.recovery-destructive p { max-width: 530px; margin: 0; color: var(--muted); font-size: 0.82rem; line-height: 1.5; }
+
 .app-shell { min-height: 100vh; display: grid; grid-template-columns: 264px minmax(0, 1fr); }
 .sidebar {
   position: sticky;
@@ -530,6 +586,12 @@ tr:last-child td { border-bottom: 0; }
 .modal-heading, .modal-actions { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
 .modal-heading { padding-bottom: 0.88rem; border-bottom: 1px solid var(--line); }
 .modal-actions { justify-content: flex-end; margin-top: 1rem; }
+.destructive-modal { border-color: #f1c8cf; }
+.danger-eyebrow { color: var(--red); }
+.destructive-warning { margin-top: 1rem; padding: 0.95rem; color: #793240; background: var(--red-soft); border: 1px solid #f2cbd2; border-radius: 12px; line-height: 1.5; }
+.destructive-warning p { margin: 0.35rem 0 0; color: #71535a; font-size: 0.83rem; }
+.confirmation-check { margin-top: 1rem; display: grid; grid-template-columns: auto 1fr; align-items: start; gap: 0.7rem; color: var(--ink-soft); line-height: 1.45; }
+.confirmation-check input { width: 18px; height: 18px; margin-top: 0.1rem; }
 .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.8rem; margin-top: 1rem; }
 .form-grid .wide-field { grid-column: 1 / -1; }
 .warning-box { margin: 0.8rem 0; padding: 0.78rem; color: #6f4c07; background: var(--amber-soft); border: 1px solid #e5c879; border-radius: 11px; white-space: pre-wrap; }
@@ -604,6 +666,8 @@ tr:last-child td { border-bottom: 0; }
   .entity-controls { justify-content: stretch; }
   .entity-controls .edit-button { width: 100%; }
   .permission-slip { align-items: flex-start; text-align: left; }
+  .recovery-destructive, .recovery-backup { align-items: stretch; flex-direction: column; }
+  .recovery-backup .primary-button, .recovery-destructive .danger-button { width: 100%; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tests/data-store-recovery.test.js
+++ b/tests/data-store-recovery.test.js
@@ -1,0 +1,279 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { FinanceDataStore, RecoveryModeError } from '../data-store.js';
+
+const seedPath = new URL('../seed-data.json', import.meta.url);
+const fixedNow = new Date('2026-08-08T12:34:56.000Z');
+
+test('a genuine first launch creates one valid initial state and starts normally', async (t) => {
+  const harness = await createHarness(t);
+
+  const first = await harness.store.loadState();
+  assert.equal(first.status, 'normal');
+  assert.equal(first.source, 'first_install');
+  assert.equal(first.state.schemaVersion, 5);
+
+  const firstBytes = await fs.readFile(harness.store.statePath);
+  const second = await harness.store.loadState();
+  assert.equal(second.status, 'normal');
+  assert.equal(second.source, 'existing');
+  assert.deepEqual(await fs.readFile(harness.store.statePath), firstBytes);
+  assert.deepEqual(await fs.readdir(harness.store.recoveryPath), []);
+});
+
+test('a valid existing state opens normally without rewriting it', async (t) => {
+  const harness = await createHarness(t);
+  const original = stateEnvelope(validState({ profile: { ...validState().profile, name: 'Fictional User' } }));
+  await fs.writeFile(harness.store.statePath, original);
+
+  const result = await harness.store.loadState();
+
+  assert.equal(result.status, 'normal');
+  assert.equal(result.source, 'existing');
+  assert.equal(result.state.profile.name, 'Fictional User');
+  assert.deepEqual(await fs.readFile(harness.store.statePath), original);
+});
+
+for (const scenario of [
+  { name: 'corrupt JSON', bytes: Buffer.from('{not-json'), reason: 'invalid_content' },
+  { name: 'a truncated envelope', bytes: Buffer.from('{"version":1,"encrypted":false,"payload":"abc'), reason: 'invalid_content' },
+  { name: 'an invalid schema', bytes: stateEnvelope(validState({ accounts: {} })), reason: 'schema_validation_failure' }
+]) {
+  test(`${scenario.name} enters recovery without replacing the original`, async (t) => {
+    const harness = await createHarness(t);
+    await fs.writeFile(harness.store.statePath, scenario.bytes);
+
+    const result = await harness.store.loadState();
+
+    assert.equal(result.status, 'recovery_required');
+    assert.equal(result.recovery.reasonCode, scenario.reason);
+    assert.equal(result.recovery.recoveryCopyCreated, true);
+    assert.deepEqual(await fs.readFile(harness.store.statePath), scenario.bytes);
+    const copies = await fs.readdir(harness.store.recoveryPath);
+    assert.equal(copies.length, 1);
+    assert.deepEqual(await fs.readFile(path.join(harness.store.recoveryPath, copies[0])), scenario.bytes);
+  });
+}
+
+test('decryption and missing-key failures have distinct safe reason codes', async (t) => {
+  const encrypted = stateEnvelope(validState(), true);
+  const decryptFailure = await createHarness(t, {
+    secureStorage: secureStorage({ decryptString: () => { throw new Error('fictional authentication material must not be logged'); } })
+  });
+  await fs.writeFile(decryptFailure.store.statePath, encrypted);
+  assert.equal((await decryptFailure.store.loadState()).recovery.reasonCode, 'decryption_failure');
+  assert.deepEqual(await fs.readFile(decryptFailure.store.statePath), encrypted);
+
+  const missingKey = await createHarness(t, { secureStorage: secureStorage({ available: false }) });
+  await fs.writeFile(missingKey.store.statePath, encrypted);
+  assert.equal((await missingKey.store.loadState()).recovery.reasonCode, 'encryption_key_unavailable');
+  assert.deepEqual(await fs.readFile(missingKey.store.statePath), encrypted);
+});
+
+test('migration failure enters recovery and preserves the stored bytes', async (t) => {
+  const harness = await createHarness(t, { migrateState: () => { throw new Error('fictional migration failure'); } });
+  const original = stateEnvelope(validState());
+  await fs.writeFile(harness.store.statePath, original);
+
+  const result = await harness.store.loadState();
+
+  assert.equal(result.recovery.reasonCode, 'migration_failure');
+  assert.deepEqual(await fs.readFile(harness.store.statePath), original);
+});
+
+test('read failure and recovery-copy failure never trigger a blank-state write', async (t) => {
+  const readFailure = await createHarness(t);
+  await fs.mkdir(readFailure.store.statePath);
+  const readResult = await readFailure.store.loadState();
+  assert.equal(readResult.status, 'recovery_required');
+  assert.equal(readResult.recovery.reasonCode, 'read_failure');
+  assert.equal(readResult.recovery.recoveryCopyCreated, false);
+  assert.equal((await fs.stat(readFailure.store.statePath)).isDirectory(), true);
+
+  const copyFailure = await createHarness(t);
+  const original = Buffer.from('unreadable fictional state');
+  await fs.writeFile(copyFailure.store.statePath, original);
+  copyFailure.store.createRecoveryCopy = async () => ({ created: false, fileName: null });
+  const copyResult = await copyFailure.store.loadState();
+  assert.equal(copyResult.status, 'recovery_required');
+  assert.equal(copyResult.recovery.recoveryCopyCreated, false);
+  assert.deepEqual(await fs.readFile(copyFailure.store.statePath), original);
+});
+
+test('recovery centrally blocks saves, imports, deletes and automatic backups', async (t) => {
+  const harness = await createHarness(t);
+  const original = Buffer.from('invalid state');
+  await fs.writeFile(harness.store.statePath, original);
+  await harness.store.loadState();
+  const fixture = path.join(harness.directory, 'fictional-statement.txt');
+  await fs.writeFile(fixture, 'fictional contents');
+
+  await assert.rejects(harness.store.saveState(validState()), RecoveryModeError);
+  await assert.rejects(harness.store.createAutomaticBackup('autosave'), RecoveryModeError);
+  await assert.rejects(harness.store.storeDocument(fixture, 'statement', []), RecoveryModeError);
+  await assert.rejects(harness.store.deleteDocument('00000000-0000-0000-0000-000000000000', []), RecoveryModeError);
+  assert.deepEqual(await fs.readFile(harness.store.statePath), original);
+});
+
+test('valid backups are identified, corrupt backups are rejected, and discovery is read-only', async (t) => {
+  const harness = await createHarness(t);
+  const corruptState = Buffer.from('invalid active state');
+  const validBackup = stateEnvelope(validState({ profile: { ...validState().profile, name: 'Backup User' } }));
+  const corruptBackup = Buffer.from('invalid backup');
+  const validPath = path.join(harness.store.backupPath, '2026-08-07-valid.json');
+  const corruptPath = path.join(harness.store.backupPath, '2026-08-06-corrupt.json');
+  await fs.writeFile(harness.store.statePath, corruptState);
+  await fs.writeFile(validPath, validBackup);
+  await fs.writeFile(corruptPath, corruptBackup);
+
+  const result = await harness.store.loadState();
+
+  assert.equal(result.recovery.backups.length, 2);
+  assert.equal(result.recovery.backups.filter((backup) => backup.valid).length, 1);
+  assert.equal(result.recovery.backups.filter((backup) => !backup.valid).length, 1);
+  assert.deepEqual(await fs.readFile(validPath), validBackup);
+  assert.deepEqual(await fs.readFile(corruptPath), corruptBackup);
+  assert.deepEqual(await fs.readFile(harness.store.statePath), corruptState);
+});
+
+test('restoring a validated backup exits recovery only after the restored state reopens', async (t) => {
+  const harness = await createHarness(t);
+  const original = Buffer.from('invalid active state');
+  const backup = stateEnvelope(validState({ profile: { ...validState().profile, name: 'Restored User' } }));
+  await fs.writeFile(harness.store.statePath, original);
+  await fs.writeFile(path.join(harness.store.backupPath, '2026-08-07-valid.json'), backup);
+  const recovery = await harness.store.loadState();
+  const validBackup = recovery.recovery.backups.find((item) => item.valid);
+
+  const restored = await harness.store.restoreRecoveryBackup(validBackup.id);
+
+  assert.equal(restored.status, 'normal');
+  assert.equal(restored.source, 'restored_backup');
+  assert.equal(restored.state.profile.name, 'Restored User');
+  assert.deepEqual(await fs.readFile(harness.store.statePath), backup);
+  const recoveryCopies = await fs.readdir(harness.store.recoveryPath);
+  assert.equal(recoveryCopies.length, 1);
+  assert.deepEqual(await fs.readFile(path.join(harness.store.recoveryPath, recoveryCopies[0])), original);
+});
+
+test('a corrupt selected backup cannot replace the active state', async (t) => {
+  const harness = await createHarness(t);
+  const original = Buffer.from('invalid active state');
+  const corruptBackup = Buffer.from('invalid backup');
+  await fs.writeFile(harness.store.statePath, original);
+  await fs.writeFile(path.join(harness.store.backupPath, '2026-08-07-corrupt.json'), corruptBackup);
+  const recovery = await harness.store.loadState();
+  const invalidBackup = recovery.recovery.backups.find((item) => !item.valid);
+
+  const result = await harness.store.restoreRecoveryBackup(invalidBackup.id);
+
+  assert.equal(result.status, 'recovery_required');
+  assert.equal(result.recovery.lastOperationError, 'restore_failed');
+  assert.deepEqual(await fs.readFile(harness.store.statePath), original);
+});
+
+test('retry clears recovery only after the original becomes valid', async (t) => {
+  const harness = await createHarness(t);
+  const invalid = Buffer.from('invalid active state');
+  await fs.writeFile(harness.store.statePath, invalid);
+  await harness.store.loadState();
+
+  const failedRetry = await harness.store.retryRecoveryLoad();
+  assert.equal(failedRetry.status, 'recovery_required');
+  assert.equal((await fs.readdir(harness.store.recoveryPath)).length, 2);
+  assert.deepEqual(await fs.readFile(harness.store.statePath), invalid);
+
+  await fs.writeFile(harness.store.statePath, stateEnvelope(validState()));
+  const successfulRetry = await harness.store.retryRecoveryLoad();
+  assert.equal(successfulRetry.status, 'normal');
+  assert.equal(successfulRetry.source, 'existing');
+});
+
+test('restarting with the same unreadable state cannot bypass recovery', async (t) => {
+  const harness = await createHarness(t);
+  const original = Buffer.from('invalid active state');
+  await fs.writeFile(harness.store.statePath, original);
+  assert.equal((await harness.store.loadState()).status, 'recovery_required');
+
+  const restarted = new FinanceDataStore(harness.directory, seedPath, harness.diagnostics, {
+    secureStorage: secureStorage({ available: false }),
+    clock: () => new Date(fixedNow)
+  });
+  await restarted.initialise();
+  const result = await restarted.loadState();
+
+  assert.equal(result.status, 'recovery_required');
+  assert.equal(result.recovery.reasonCode, 'invalid_content');
+  assert.deepEqual(await fs.readFile(restarted.statePath), original);
+});
+
+test('fresh start requires a live confirmation and cancellation changes nothing', async (t) => {
+  const harness = await createHarness(t);
+  const original = Buffer.from('invalid active state');
+  await fs.writeFile(harness.store.statePath, original);
+  await harness.store.loadState();
+
+  const request = harness.store.requestFreshStart();
+  assert.equal(request.status, 'confirmation_required');
+  harness.store.cancelFreshStart(request.token);
+  const cancelled = await harness.store.confirmFreshStart(request.token);
+  assert.equal(cancelled.status, 'recovery_required');
+  assert.equal(cancelled.recovery.lastOperationError, 'confirmation_invalid');
+  assert.deepEqual(await fs.readFile(harness.store.statePath), original);
+
+  const confirmedRequest = harness.store.requestFreshStart();
+  const confirmed = await harness.store.confirmFreshStart(confirmedRequest.token);
+  assert.equal(confirmed.status, 'normal');
+  assert.equal(confirmed.source, 'fresh_start');
+  assert.equal(confirmed.state.schemaVersion, 5);
+  assert.equal(confirmed.state.accounts.length, 0);
+  assert.notDeepEqual(await fs.readFile(harness.store.statePath), original);
+  const recoveryCopies = await fs.readdir(harness.store.recoveryPath);
+  assert.ok(recoveryCopies.length >= 1);
+  assert.deepEqual(await fs.readFile(path.join(harness.store.recoveryPath, recoveryCopies[0])), original);
+});
+
+async function createHarness(t, options = {}) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-recovery-'));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const diagnostics = { events: [], async record(name, context) { this.events.push({ name, context }); } };
+  const store = new FinanceDataStore(directory, seedPath, diagnostics, {
+    secureStorage: options.secureStorage || secureStorage({ available: false }),
+    clock: () => new Date(fixedNow),
+    migrateState: options.migrateState
+  });
+  await store.initialise();
+  return { directory, diagnostics, store };
+}
+
+function secureStorage(options = {}) {
+  const available = options.available ?? true;
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: options.encryptString || ((value) => Buffer.from(value, 'utf8')),
+    decryptString: options.decryptString || ((value) => value.toString('utf8'))
+  };
+}
+
+function validState(overrides = {}) {
+  return {
+    schemaVersion: 5,
+    meta: { createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:00:00.000Z' },
+    profile: { name: '', locale: 'en-GB', currency: 'GBP', dependableIncome: 0, paydayDay: 30 },
+    accounts: [], transactions: [], payslips: [], taxDocuments: [], creditReports: [], debts: [], overdrafts: [],
+    budgets: [], scheduledPayments: [], documents: [], tasks: [], checkIns: [], importBatches: [],
+    settings: {
+      selectedMonth: '2026-08', extraDebtPayment: 0, emergencyBufferTarget: 500, emergencyBufferBalance: 0,
+      extraIncomeDebtPercent: 80, llmModel: 'qwen2.5:1.5b', reminders: { weekly: false, weeklyDay: 'monday', hour: 9 }
+    },
+    ...overrides
+  };
+}
+
+function stateEnvelope(state, encrypted = false) {
+  const payload = Buffer.from(JSON.stringify(state), 'utf8').toString('base64');
+  return Buffer.from(JSON.stringify({ version: 1, encrypted, payload }), 'utf8');
+}

--- a/tests/diagnostic-logger.test.js
+++ b/tests/diagnostic-logger.test.js
@@ -47,6 +47,22 @@ test('detailed diagnostics are not written when secure storage is unavailable', 
   await assert.rejects(fs.access(path.join(directory, 'diagnostics', 'diagnostics-0.enc')));
 });
 
+test('recovery diagnostics retain only safe reason codes', async (t) => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-diagnostics-'));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const logger = createLogger(directory);
+
+  await logger.record('STATE_RECOVERY_REQUIRED', {
+    reasonCode: 'decryption_failure',
+    error: new Error('balance £9876.54 key=fictional-secret decrypted={"name":"Private User"}')
+  });
+  const report = await logger.buildReport();
+
+  assert.match(report.text, /DAT-103 STATE_RECOVERY_REQUIRED/);
+  assert.match(report.text, /reason_code=decryption_failure/);
+  assert.doesNotMatch(report.text, /9876|fictional-secret|Private User|decrypted/);
+});
+
 test('diagnostics expire after fourteen days and can be deleted locally', async (t) => {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-diagnostics-'));
   t.after(() => fs.rm(directory, { recursive: true, force: true }));

--- a/tests/preload-bridge.test.js
+++ b/tests/preload-bridge.test.js
@@ -40,6 +40,11 @@ test('sandboxed preload exposes the complete desktop API', async () => {
   assert.ok(Object.isFrozen(exposed.api));
   await exposed.api.loadState();
   await exposed.api.saveState({ ok: true });
+  await exposed.api.retryRecovery();
+  await exposed.api.restoreRecoveryBackup('backup-id');
+  await exposed.api.requestFreshStart();
+  await exposed.api.cancelFreshStart('confirmation-token');
+  await exposed.api.confirmFreshStart('confirmation-token');
   await exposed.api.importFiles({ kind: 'statement' });
   await exposed.api.previewDiagnostics();
   await exposed.api.exportDiagnostics('preview-token');
@@ -49,6 +54,11 @@ test('sandboxed preload exposes the complete desktop API', async () => {
   assert.deepEqual(invocations, [
     ['state:load'],
     ['state:save', { ok: true }],
+    ['recovery:retry'],
+    ['recovery:restore-backup', 'backup-id'],
+    ['recovery:fresh-start:request'],
+    ['recovery:fresh-start:cancel', 'confirmation-token'],
+    ['recovery:fresh-start:confirm', 'confirmation-token'],
     ['import:choose', { kind: 'statement' }],
     ['diagnostics:preview'],
     ['diagnostics:export', 'preview-token'],


### PR DESCRIPTION
### Purpose

Deliver OneStep Money v2.1.5 data-integrity protection so an existing unreadable financial state can never be mistaken for a first installation, silently replaced with seed data, or copied into the normal backup chain.

The previous startup path caught every load failure, created an automatic backup from the unreadable active file, generated the public seed state, saved it as active data, and returned it to the renderer as if startup had succeeded. This draft replaces that fallback with an explicit recovery state controlled by the Electron main process and persistence layer.

### Work completed

#### Trusted recovery state

- Added explicit `normal`, `recovery_required`, and `resolution_in_progress` persistence modes.
- Changed startup loading to return structured results instead of silently returning seed data after an error.
- Kept genuine `ENOENT` first installation separate from read, decryption, validation, migration, and unknown storage failures.
- Added safe reason codes for state-not-found during recovery, read failure, decryption failure, unavailable encryption keys, invalid content, schema validation failure, migration failure, and unknown storage failure.
- Prevented a state that disappears after recovery begins from being treated as a new installation.

#### Data preservation and write protection

- Removed the unreadable-state-to-seed fallback.
- Added collision-resistant, exclusive, byte-for-byte recovery copies in a dedicated local `recovery-copies` directory.
- Verify recovery copies by comparing SHA-256 digests after copying.
- Kept recovery copies outside the automatic-backup chain.
- Centrally reject financial-state saves, automatic backups, imports/document writes, document deletion, portable restore, and mutating IPC routes while recovery is active.
- Return an explicit `recovery_mode_active` blocked result instead of silently accepting writes.
- Added recovery files and temporary restore files to `.gitignore`.

#### Backup recovery

- Discover existing automatic local backups without altering them.
- Validate each backup through envelope integrity, decryption, parsing, schema checks, and migration before marking it usable.
- Expose only safe backup metadata: date, validation state, compatibility, and schema version.
- Identify the newest valid backup in the recovery UI.
- Revalidate a selected backup immediately before restore.
- Reopen and validate the installed state before leaving recovery.
- Roll the active state bytes back when a restore is installed but cannot be reopened.
- Keep corrupt or missing backup selections in recovery mode.

#### Recovery choices and UI

- Added a calm recovery screen headed “OneStep couldn’t open your financial data”.
- Explain that existing data has not been replaced and saving is paused.
- Added “Try opening the data again” without clearing recovery until validation succeeds.
- Added restore controls only for validated backups; invalid backups are labelled unusable.
- Added a visually separated destructive start-again action.
- Require a main-process-issued, five-minute confirmation token, a second dialog action, and an acknowledgement checkbox before creating a fresh state.
- Preserve and verify a recovery copy before a confirmed fresh start.
- Reopen the new state before leaving recovery; cancellation and invalid/expired confirmation tokens do not change the active file.

#### Diagnostics and privacy

- Added `STATE_RECOVERY_REQUIRED` and `RECOVERY_OPERATION_FAILED` diagnostic events.
- Whitelisted only sanitised recovery reason codes.
- Kept raw error messages, decrypted content, financial values, filenames, paths, and encryption material out of diagnostic reports.
- Added privacy regression coverage proving raw fictional secret/value content is excluded.

#### Release metadata

- Updated the application and lockfile version from `2.1.4` to `2.1.5`.
- The application remains on the 2.1.x release line.
- No dependency versions were added, removed, or changed.

### Files changed

- `.gitignore` — excludes `recovery-copies/` and `*.restore` so preserved state and temporary restore data cannot be committed.
- `data-store.js` — replaces unsafe fallback loading with structured validation and recovery modes; adds central write guards, recovery copies, backup discovery/validation, retry, guarded restore, explicit fresh start, reason codes, vault-key handling, and schema validation.
- `diagnostic-logger.js` — adds recovery diagnostic events and sanitised reason-code reporting.
- `index.html` — adds the recovery screen and destructive fresh-start confirmation dialog.
- `main-process.js` — keeps recovery authority in Electron’s main process, stores structured load results, blocks mutating IPC routes, and exposes controlled recovery handlers.
- `package.json` — updates the release version to 2.1.5.
- `package-lock.json` — keeps root package metadata aligned at 2.1.5; dependency resolutions are unchanged.
- `preload-bridge.cjs` — exposes only the five controlled recovery IPC methods to the sandboxed renderer.
- `renderer-app.js` — routes startup into normal or recovery UI, renders validated backup choices, handles retry/restore, and enforces the two-step fresh-start flow.
- `styles.css` — styles the responsive recovery screen, backup states, and destructive confirmation flow.
- `tests/data-store-recovery.test.js` — adds fictional regression coverage for first launch, valid load, corruption, truncation, invalid schema, decryption/key/migration/read/copy failures, byte preservation, write protection, read-only backup discovery, valid and corrupt restore, retry, restart persistence, cancellation, and confirmed fresh start.
- `tests/diagnostic-logger.test.js` — verifies recovery logs retain a safe reason code without leaking fictional values, content, or authentication material.
- `tests/preload-bridge.test.js` — verifies the sandboxed preload exposes and routes the controlled recovery API.

No files were renamed or deleted.

### User-facing changes

- Users with valid data continue into OneStep normally.
- A genuine first installation still creates the blank seed state automatically.
- Users with unreadable existing data now see a dedicated recovery screen instead of an apparently empty installation.
- The recovery screen confirms that saving is paused, reports whether a recovery copy was verified, shows valid and invalid local backups, allows retry, and separates the destructive start-again path.
- Starting again cannot occur from one click and cannot clear recovery until the new state is written and reopened successfully.

### Technical changes

- State envelope, decryption, JSON, top-level schema, migration, and post-migration validation are now separate failure stages.
- The existing stored schema remains version 5; this branch does not introduce a stored-data format migration.
- `safeStorage` is injected into the data store by the main process, which makes persistence failure paths independently testable without weakening Electron isolation.
- Recovery copies preserve the original bytes, including original encryption, and use exclusive collision-resistant filenames.
- Backup IDs exposed to the renderer are non-path hashes; local file paths are retained only in the trusted persistence instance.
- Restore and fresh-start operations temporarily enter `resolution_in_progress`; ordinary writes remain blocked during that state.
- The normal document-vault and portable-backup formats are unchanged.
- No telemetry, analytics, cloud recovery, network storage, or external error reporting was added.

### Testing and verification

- **Passed:** `npm test` — 51/51 automated tests passed.
- **Passed:** `npm run check` — syntax/project validation passed across 18 JavaScript files; seed and package checks passed.
- **Passed:** `npm run check` privacy scan — 32 repository files checked; no protected financial data, document type, credential, or secret patterns found.
- **Passed:** `git diff --check` — no whitespace errors.
- **Passed:** `npx electron-builder --dir --linux` — packaged Linux application directory built successfully from the final source.
- **Unavailable:** interactive packaged Electron desktop verification. The managed runtime denies the DBus and NETLINK syscalls required by Electron/Chromium; packaged launch exited 139 before a window could be exercised, and the environment does not permit lifting that restriction.
- **Unavailable:** complete Windows NSIS installer verification. `npm run dist:win` packaged `win-unpacked` and reached NSIS installer creation, then failed with `spawn wine ENOENT` because Wine is not installed in this Linux environment.
- **Unavailable:** no separate lint or static type-check scripts are configured in the repository; `npm run check` performs JavaScript syntax and project validation instead.

The required interactive desktop checklist remains outstanding and must be run on a Windows desktop before v2.1.5 is considered release-complete. Automated coverage exercises the corresponding persistence and recovery paths, but is not represented as a substitute for that manual acceptance check.

### Data and migration impact

- Stored financial state remains schema version 5.
- Valid existing states are loaded without rewriting the active file.
- Only a positively confirmed missing state creates seed data automatically.
- Unreadable active states remain byte-for-byte unchanged on recovery entry.
- New recovery copies are local, collision-resistant, byte-for-byte verified, and excluded from automatic rotation.
- Existing automatic backups are inspected read-only.
- A user-approved validated backup can replace only the active financial-state file in v2.1.5; transactional financial-state plus document-vault restoration remains deferred to v2.1.6.
- A confirmed fresh start preserves a verified recovery copy and creates exactly one new active state.

### Known limitations

- Interactive packaged Electron recovery verification could not be performed in this managed environment because Electron is blocked from required OS IPC/network syscalls.
- A full Windows NSIS installer could not be completed on Linux because Wine is unavailable.
- Recovery-mode restore in v2.1.5 restores the financial state only; document-vault transactionality and cross-file rollback remain v2.1.6 work.
- Automatic backup discovery covers the app’s existing local automatic-backup JSON format. Password-protected portable backups remain available through the existing normal settings flow and are not automatically scanned.

### Excluded work

- Fully transactional financial-state and document-vault restore.
- Cross-file rollback and secure cleanup for portable restores.
- Payslip content deduplication.
- Statement intelligence or credit-report reconciliation changes.
- Debt overpayment safety changes.
- Dashboard action lifecycle changes.
- General UI redesign.
- Windows release-pipeline repair.

### Branch details

- Branch: `fix/data-integrity`
- Commit SHA: `bd6f56e3f7c0ed209f8b0f85f657c1039deeb50c`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/8
- Target branch: `main`

### Confirmations

- No changes were committed or pushed directly to `main`.
- The pull request has not been merged.
- No personal financial data, imported documents, credentials, secrets, encryption keys, local vault files, or sensitive logs were committed.
- Only fictional/anonymised test fixtures are used.
- Only files relevant to v2.1.5 data integrity and its release metadata were changed.
