### PR TITLE
[v2.1.7][UI/UX] Version display and privacy layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,10 @@
           <button class="nav-button" data-view="documents"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3h8l4 4v14H6z"/><path d="M14 3v5h4M9 12h6M9 16h6"/></svg><span class="nav-label">Documents</span></button>
           <button class="nav-button" data-view="settings"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1-2.8 2.8-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.6v.2h-4V21a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1L4.2 17l.1-.1a1.7 1.7 0 0 0 .3-1.9A1.7 1.7 0 0 0 3 14H2.8v-4H3a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9L4.2 7 7 4.2l.1.1a1.7 1.7 0 0 0 1.9.3 1.7 1.7 0 0 0 1-1.6v-.2h4V3a1.7 1.7 0 0 0 1 1.6 1.7 1.7 0 0 0 1.9-.3l.1-.1L19.8 7l-.1.1a1.7 1.7 0 0 0-.3 1.9 1.7 1.7 0 0 0 1.6 1h.2v4H21a1.7 1.7 0 0 0-1.6 1Z"/></svg><span class="nav-label">Settings</span></button>
         </nav>
-        <div class="privacy-status"><span id="encryptionDot" class="status-dot"></span><span class="privacy-copy"><strong>Private on this device</strong><span id="encryptionText">Checking secure storage…</span></span></div>
+        <footer class="sidebar-footer">
+          <div class="privacy-status"><span id="encryptionDot" class="status-dot"></span><span class="privacy-copy"><strong>Private on this Device</strong><span id="encryptionText">Checking secure storage…</span></span></div>
+          <p id="appVersion" class="app-version" aria-label="OneStep Money version">Loading version…</p>
+        </footer>
       </aside>
 
       <main class="main-content">

--- a/main-process.js
+++ b/main-process.js
@@ -126,6 +126,7 @@ function sendUpdateStatus(status) {
 }
 
 function registerIpcHandlers() {
+  ipcMain.handle('app:version', () => app.getVersion());
   ipcMain.handle('state:load', async () => currentState && store.mode === 'normal'
     ? { ...currentLoadResult, status: 'normal', mode: 'normal', state: currentState, encryption: store.encryptionStatus() }
     : currentLoadResult);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onestep-money",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -1,6 +1,7 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('financeAPI', Object.freeze({
+  getAppVersion: () => ipcRenderer.invoke('app:version'),
   loadState: () => ipcRenderer.invoke('state:load'),
   saveState: (state) => ipcRenderer.invoke('state:save', state),
   retryRecovery: () => ipcRenderer.invoke('recovery:retry'),

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -39,6 +39,9 @@ async function initialise() {
     byId('desktopRequired').hidden = false;
     return;
   }
+  window.financeAPI.getAppVersion()
+    .then(renderAppVersion)
+    .catch(() => renderAppVersion(''));
   try {
     const loaded = await window.financeAPI.loadState();
     if (loaded.status === 'recovery_required') showRecoveryMode(loaded);
@@ -48,6 +51,11 @@ async function initialise() {
     byId('desktopRequired').hidden = false;
     byId('desktopRequired').querySelector('p').textContent = `The secure data store could not be opened: ${error.message}`;
   }
+}
+
+function renderAppVersion(value) {
+  const version = String(value || '').trim().replace(/^v/i, '');
+  byId('appVersion').textContent = version ? `v${version}` : 'Version unavailable';
 }
 
 function activateNormalMode(loaded) {

--- a/styles.css
+++ b/styles.css
@@ -243,10 +243,16 @@ h3 { margin-bottom: 0.25rem; font-size: 0.98rem; letter-spacing: -0.012em; }
   box-shadow: 0 8px 24px rgba(1, 19, 45, 0.2), inset 3px 0 #42d4bc;
 }
 .nav-button.active svg { color: #5be0c8; opacity: 1; filter: drop-shadow(0 0 8px rgba(53, 208, 181, 0.38)); }
-.privacy-status {
+.sidebar-footer {
   position: relative;
   z-index: 1;
   margin-top: auto;
+  display: grid;
+  gap: 0.48rem;
+}
+.privacy-status {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: 0.7rem;
@@ -259,9 +265,17 @@ h3 { margin-bottom: 0.25rem; font-size: 0.98rem; letter-spacing: -0.012em; }
   line-height: 1.35;
   backdrop-filter: blur(10px);
 }
-.privacy-copy { min-width: 0; display: grid; gap: 0.12rem; }
-.privacy-copy strong { color: #f2f7fc; font-size: 0.72rem; }
-.privacy-copy span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.privacy-copy { min-width: 0; display: grid; gap: 0.12rem; overflow-wrap: anywhere; }
+.privacy-copy strong { color: #f2f7fc; font-size: 0.72rem; line-height: 1.35; }
+.privacy-copy span { white-space: normal; }
+.app-version {
+  margin: 0;
+  padding-inline: 0.35rem;
+  color: rgba(219, 231, 244, 0.72);
+  font-size: 0.64rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
 .status-dot { width: 9px; height: 9px; flex: 0 0 9px; border-radius: 50%; background: #74839a; box-shadow: 0 0 0 4px rgba(116, 131, 154, 0.1); }
 .status-dot.good { background: #4fe2b1; box-shadow: 0 0 0 4px rgba(79, 226, 177, 0.13), 0 0 13px rgba(79, 226, 177, 0.44); animation: statusPulse 2.8s ease-in-out infinite; }
 .status-dot.bad { background: #ff7181; box-shadow: 0 0 0 4px rgba(255, 113, 129, 0.12); }
@@ -635,10 +649,14 @@ tr:last-child td { border-bottom: 0; }
   .app-shell { grid-template-columns: 86px minmax(0, 1fr); }
   .sidebar { padding: 0.9rem 0.65rem; }
   .brand { justify-content: center; padding-inline: 0; }
-  .brand-copy, .nav-label, .privacy-copy { display: none; }
+  .brand-copy, .nav-label { display: none; }
   .nav-button { justify-content: center; padding: 0.73rem; }
   .nav-button:hover { transform: translateY(-1px); }
-  .privacy-status { justify-content: center; padding: 0.78rem 0.5rem; }
+  .privacy-status { flex-direction: column; justify-content: center; gap: 0.48rem; padding: 0.7rem 0.35rem; text-align: center; }
+  .privacy-copy { display: block; }
+  .privacy-copy strong { display: block; font-size: 0.64rem; }
+  .privacy-copy span { display: none; }
+  .app-version { padding-inline: 0; text-align: center; }
   .entity-card { grid-template-columns: minmax(180px, 1fr) repeat(2, minmax(100px, 0.5fr)) auto; }
   .entity-card .optional-stat { display: none; }
 }
@@ -646,7 +664,7 @@ tr:last-child td { border-bottom: 0; }
 @media (max-width: 840px) {
   .app-shell { display: block; }
   .sidebar { position: fixed; inset: auto 0 0 0; z-index: 6; width: 100%; height: auto; padding: 0.45rem; }
-  .sidebar::before, .sidebar::after, .brand, .privacy-status { display: none; }
+  .sidebar::before, .sidebar::after, .brand, .sidebar-footer { display: none; }
   .sidebar nav { grid-template-columns: repeat(9, minmax(58px, 1fr)); overflow-x: auto; }
   .nav-button { min-width: 56px; min-height: 48px; }
   .main-content { padding-bottom: 5rem; }

--- a/tests/preload-bridge.test.js
+++ b/tests/preload-bridge.test.js
@@ -38,6 +38,7 @@ test('sandboxed preload exposes the complete desktop API', async () => {
 
   assert.equal(exposed.name, 'financeAPI');
   assert.ok(Object.isFrozen(exposed.api));
+  await exposed.api.getAppVersion();
   await exposed.api.loadState();
   await exposed.api.saveState({ ok: true });
   await exposed.api.retryRecovery();
@@ -57,6 +58,7 @@ test('sandboxed preload exposes the complete desktop API', async () => {
   await exposed.api.recordRendererFault('RENDERER_UNHANDLED_ERROR');
   await exposed.api.checkForUpdates();
   assert.deepEqual(invocations, [
+    ['app:version'],
     ['state:load'],
     ['state:save', { ok: true }],
     ['recovery:retry'],


### PR DESCRIPTION
### Purpose

Create the v2.1.7 presentation fix on a separate branch based on released v2.1.6. The branch makes the installed application version permanently visible in the bottom-left sidebar area and fixes the local privacy indicator so its important wording is not truncated or replaced by an ellipsis.

### Work completed

#### Application version display

- Added a subtle version label below the privacy indicator in the sidebar footer.
- Added a read-only `app:version` IPC handler backed by Electron's local `app.getVersion()` metadata.
- Exposed version retrieval through the sandboxed preload bridge.
- Added renderer startup logic that normalises the value and displays it with a `v` prefix.
- Added a safe `Version unavailable` fallback without making version retrieval a startup dependency.
- Updated the application and lockfile version from `2.1.6` to `2.1.7`.

#### Privacy indicator layout

- Preserved and capitalised the complete heading as `Private on this Device`.
- Removed the single-line ellipsis treatment from the detailed secure-storage status.
- Allowed the detailed status to wrap within the card at normal sidebar widths.
- Grouped the privacy card and version label in a dedicated sidebar footer so both remain anchored without overlapping navigation.
- At the compact 86px sidebar used by the 980px minimum Electron window width, retained the complete privacy heading in a centred multi-line layout and hid only the longer technical detail.
- Kept the mobile bottom-navigation behaviour unchanged below 840px, outside Electron's configured 980px minimum width.

#### Test coverage

- Extended the preload bridge test to verify that `getAppVersion()` invokes only the new `app:version` IPC channel.

### Files changed

- `index.html` — added the sidebar footer, complete privacy heading and application-version element.
- `main-process.js` — added the read-only `app:version` IPC handler using `app.getVersion()`.
- `package.json` — advanced the release version from `2.1.6` to `2.1.7`.
- `package-lock.json` — kept root package metadata aligned at `2.1.7`; no dependency graph changed.
- `preload-bridge.cjs` — exposed `getAppVersion()` through the context-isolated desktop API.
- `renderer-app.js` — retrieves, normalises and renders the application version without blocking financial-state startup.
- `styles.css` — added footer/version styling, removed privacy-detail truncation, enabled wrapping and added the minimum-width compact privacy layout.
- `tests/preload-bridge.test.js` — added the version IPC bridge invocation assertion.

No files were added, renamed or deleted.

### User-facing changes

- The installed version now appears in the bottom-left sidebar as `v2.1.7`.
- The normal-width privacy card shows `Private on this Device` plus the complete wrapped secure-storage status, with no ellipsis.
- At the application's minimum window width, the compact sidebar still shows the full privacy heading and version without overflowing.
- The footer remains visible and stable while navigating between all main application sections.

### Technical changes

- Version information comes exclusively from local Electron application metadata; there is no hard-coded release value in the HTML or renderer.
- The new IPC capability is read-only and exposed through the existing context-isolated, sandboxed preload bridge.
- No telemetry, analytics, cloud storage, remote version lookup or new network access was introduced.
- No dependencies were added, removed or updated.
- No database, storage, backup, encryption, import or export logic was changed.
- Existing v2.1.6 transactional backup and restore behaviour remains unchanged.

### Testing and verification

- **Passed — automated tests:** `npm test`; 64/64 tests passed, including transactional backup/restore, data recovery, finance logic, privacy diagnostics and preload API coverage.
- **Passed — project checks:** `npm run check`; JavaScript syntax/project validation passed for 20 JavaScript files.
- **Passed — privacy check:** repository privacy scan passed across 34 checked files.
- **Passed — diff validation:** `git diff --check` reported no whitespace errors.
- **Passed — normal desktop layout:** locally rendered with anonymised blank seed data at 1440×940; version displayed as `v2.1.7`, the full privacy heading and detailed status were visible, and the detail used normal wrapping.
- **Passed — minimum Electron layout:** locally rendered at 980×680; the complete privacy heading and version stayed visible and the footer remained inside the 86px compact sidebar.
- **Passed — navigation regression:** all nine main navigation views were selected at both tested sizes; the footer stayed visible, in bounds and unchanged.
- **Passed — supported theme:** verified in the application's current supported visual theme.
- **Passed — Windows unpacked packaging:** `electron-builder --win dir` produced the Windows x64 unpacked application successfully from the final v2.1.6 base with package version `2.1.7`.
- **Unavailable — NSIS installer completion:** `npm run dist:win` packaged the Windows application and reached NSIS assembly, but the Linux runner does not provide the required `wine` executable (`spawn wine ENOENT`).
- **Unavailable — native Electron desktop launch:** attempted twice with Electron headless flags; this managed Linux runner blocks the required D-Bus/NETLINK access and Electron exited with SIGSEGV. Rendered UI and navigation were instead verified with a local headless Chromium preview.
- **Unavailable — lint/type checks:** the repository defines no separate lint or type-check scripts.

### Data and migration impact

None. No financial records, accounts, transactions, debts, budgets, savings data, documents, settings, database schemas, backup formats, encryption formats, imports or exports are changed. No migration or user action is required.

### Known limitations

- The NSIS installer and a native Electron window could not be completed on this Linux runner for the environment reasons recorded above. The Windows unpacked package and rendered UI checks passed.
- No application-code issues are currently known.

### Excluded work

- Unrelated sidebar or navigation redesign.
- v2.1.6 transactional backup/restore implementation.
- Financial-safety work now planned for v2.1.8.
- Any other roadmap, feature, dependency or data-model changes.

### Branch details

- Branch: `fix/version-display-privacy-layout`
- Commit SHA: `381c0b2b918a8e802df3795559489ed718c51633`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/10
- Target branch: `main`

### Confirmations

- No changes were committed or pushed directly to `main`.
- This pull request is a draft and has not been merged.
- No personal financial data, imported documents, credentials, secrets or sensitive logs were committed.
- Only files relevant to the requested v2.1.7 fix were changed.