### PR TITLE
[v2.1.9][Bug] Windows import fsync repair

### DIFF
--- a/data-store.js
+++ b/data-store.js
@@ -1654,7 +1654,7 @@ async function pathExists(target) {
 }
 
 async function syncFile(target) {
-  const handle = await fs.open(target, 'r');
+  const handle = await fs.open(target, 'r+');
   try {
     await handle.sync();
   } finally {

--- a/tests/windows-fsync-regression.test.js
+++ b/tests/windows-fsync-regression.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const seedPath = new URL('../seed-data.json', import.meta.url);
+
+test('automatic backup does not fsync a read-only file handle', async (t) => {
+  const originalOpen = fs.open;
+  fs.open = async (target, flags, ...args) => {
+    const handle = await originalOpen(target, flags, ...args);
+    if (flags !== 'r') return handle;
+
+    return new Proxy(handle, {
+      get(object, property) {
+        if (property === 'sync') {
+          return async () => {
+            const error = new Error('simulated Windows read-only fsync rejection');
+            error.code = 'EPERM';
+            throw error;
+          };
+        }
+        const value = Reflect.get(object, property, object);
+        return typeof value === 'function' ? value.bind(object) : value;
+      }
+    });
+  };
+  t.after(() => { fs.open = originalOpen; });
+
+  const { FinanceDataStore } = await import(`../data-store.js?windows-fsync=${Date.now()}`);
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-fsync-'));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+
+  const store = new FinanceDataStore(directory, seedPath, null, {
+    secureStorage: { isEncryptionAvailable: () => false },
+    appVersion: '2.1.8'
+  });
+  await store.initialise();
+  const loaded = await store.loadState();
+  assert.equal(loaded.status, 'normal');
+
+  const backupPath = await store.createAutomaticBackup('windows-fsync-regression');
+  assert.ok(backupPath);
+  const inspected = await store.validateLocalBackupSet(backupPath, { requireSemanticValidation: true });
+  assert.equal(inspected.valid, true);
+});


### PR DESCRIPTION
### Purpose

Fix the Windows regression that caused document imports to fail before parsing with `EPERM: operation not permitted, fsync`.

The regression was introduced by the v2.1.6 transactional backup durability work. `import:choose` creates an automatic safety backup before importing, and the backup manifest durability helper opened files read-only (`r`) before calling `FileHandle.sync()`. Windows can reject `fsync` on that read-only handle, aborting the pre-import backup and therefore the import.

### Work completed

#### Filesystem durability
- Changed the file-sync helper to open regular files with read/write access (`r+`) before calling `FileHandle.sync()`.
- Kept the existing write-and-sync behaviour used by atomic writes unchanged.
- Kept directory fsync compatibility handling unchanged, including the existing Windows-safe handling of unsupported/permission-style directory sync errors.
- Did not bypass, weaken, or remove the automatic pre-import backup.

#### Regression protection
- Added a focused regression test that simulates Windows returning `EPERM` when `fsync` is attempted through a read-only handle.
- The test verifies that automatic backup creation and subsequent local-backup validation complete without using a read-only file handle for file fsync.

### Files changed

- `data-store.js` — changed `syncFile()` from `fs.open(target, 'r')` to `fs.open(target, 'r+')` so regular-file durability syncing uses a handle Windows permits for fsync.
- `tests/windows-fsync-regression.test.js` — added a Windows-specific regression simulation covering the pre-import automatic-backup failure path.

### User-facing changes

- Bank statement, payslip and credit-report imports should no longer fail at the pre-import backup stage with `EPERM: operation not permitted, fsync` on Windows.
- The safety backup still occurs before import; no import protection has been removed.
- No UI, stored-data format, import format or financial recommendation behaviour is changed.

### Technical changes

- Root cause: `syncFile()` used a read-only file descriptor for `FileHandle.sync()`.
- Fix: use `r+` for regular files being explicitly fsynced.
- `syncDirectory()` remains separate and continues to tolerate the platform-specific directory-sync errors already handled by the v2.1.6 implementation.
- No dependencies were added, removed or updated.
- No database, schema, encryption, backup-format or document-vault format changes were made.

### Testing and verification

- **Passed — repository diff inspection:** branch is exactly two commits ahead of `main` and changes only `data-store.js` plus the new regression test.
- **Passed — scope verification:** production diff is one line (`r` → `r+`) and no unrelated/version files changed.
- **Unavailable — `npm test`:** the execution environment has no local checkout and outbound GitHub access is blocked, so the connected repository could not be cloned to run Node tests locally.
- **Unavailable — `npm run check`:** same local-checkout/network limitation.
- **Unavailable — Electron desktop startup:** same local-checkout/network limitation; Electron could not be launched against this branch in the current environment.
- **Unavailable — Windows manual import test:** the current execution environment is not the user's Windows desktop. The added regression test simulates the exact read-only-handle `EPERM` condition, but it could not be executed here for the reason above.
- **Unavailable — CI:** the repository currently exposes only the release workflow and no branch workflow run was created for this commit.

### Data and migration impact

None. Stored financial state, databases, settings, imported document formats, encrypted vault files and backup formats are unchanged. No migration is required.

### Known limitations

- Automated and manual runtime verification remains outstanding because the available execution environment cannot clone/run the repository.
- The final confirmation should include running the existing test/check suite and performing one Windows document import from the branch/build before merging.

### Excluded work

- No version bump or release packaging.
- No changes to import parsing or reconciliation logic.
- No changes to transactional backup/restore design beyond the specific file-handle mode causing the Windows fsync regression.
- No changes to directory-fsync compatibility behaviour.

### Branch details

* Branch: `fix/import-fsync`
* Commit SHA: `022093c796132f5a12511be670963e098f65bb91`
* Pull request: this draft pull request
* Target branch: `main`

### Confirmations

* No changes were committed or pushed directly to `main`.
* The pull request has not been merged.
* No personal financial data, imported documents, credentials, secrets, or sensitive logs were committed.
* Only files relevant to the requested work were changed.