### PR TITLE
[v2.1.10][Feature] Safe update checking

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,12 +158,23 @@
             <article class="panel"><h2>Planning</h2><label>Dependable monthly income<input id="dependableIncomeInput" type="number" min="0" step="0.01" /></label><label>Extra debt-payment target<input id="extraPaymentInput" type="number" min="0" step="10" /></label><label>Emergency-buffer target<input id="bufferTargetInput" type="number" min="0" step="50" /></label><label>Current emergency buffer<input id="bufferBalanceInput" type="number" min="0" step="1" /></label><button id="saveSettingsButton" class="primary-button">Save settings</button></article>
             <article class="panel"><h2>Local model</h2><label>Ollama model<input id="llmModelInput" type="text" value="qwen2.5:1.5b" /></label><p class="muted">Recommended small model: qwen2.5:1.5b. The app connects only to Ollama on 127.0.0.1.</p><button id="checkModelButton" class="secondary-button">Check model</button></article>
             <article class="panel"><h2>Encrypted backup</h2><p class="muted">A portable backup includes one verified snapshot of your financial data and encrypted document vault. Use a password you will remember.</p><label>Backup password<input id="backupPassphrase" type="password" minlength="8" autocomplete="new-password" /></label><div class="button-row"><button id="createBackupButton" class="primary-button">Create backup</button><button id="restoreBackupButton" class="secondary-button">Restore backup</button></div><p id="backupStatus" class="muted" aria-live="polite"></p></article>
-            <article class="panel"><h2>Updates</h2><p id="updateStatus" class="muted" aria-live="polite">Checking update status…</p><div class="button-row"><button id="checkUpdateButton" class="secondary-button">Check for updates</button><button id="installUpdateButton" class="primary-button" hidden>Restart and update</button></div></article>
+            <article class="panel"><h2>Updates</h2><p id="updateStatus" class="muted" aria-live="polite">Updates are checked automatically. OneStep never downloads or installs them.</p><div class="button-row"><button id="checkUpdateButton" class="secondary-button">Check for updates</button><button class="primary-button" data-view-update hidden>View update</button></div></article>
             <article class="panel"><h2>Diagnostics</h2><p class="muted">Fault codes and basic device details stay on this device. Financial data, document contents, names, amounts, notes, filenames and paths are never logged.</p><p class="muted">Detailed entries are encrypted, kept for up to 14 days and never uploaded automatically. Review the report before choosing where to share it.</p><div class="button-row"><button id="reviewDiagnosticsButton" class="primary-button">Review &amp; export</button><button id="deleteDiagnosticsButton" class="danger-button">Delete diagnostics</button></div><p id="diagnosticsStatus" class="muted" aria-live="polite"></p></article>
             <article class="panel"><h2>Privacy</h2><p id="privacyDetails" class="muted"></p><p class="muted">No cloud sync, analytics or external AI. Imported files are checksum-checked, encrypted and never served by the preview server.</p></article>
           </div>
         </section>
       </main>
+
+      <div id="updateNotificationRegion" class="update-notification-region" hidden>
+        <aside class="update-notification" role="status" aria-live="polite" aria-atomic="true" aria-labelledby="updateNotificationTitle">
+          <button id="dismissUpdateNotificationButton" class="update-notification-close" type="button" aria-label="Dismiss update notification">×</button>
+          <div class="update-notification-copy">
+            <h2 id="updateNotificationTitle">Update available</h2>
+            <p id="updateNotificationMessage"></p>
+            <button class="update-notification-action" type="button" data-view-update>View update</button>
+          </div>
+        </aside>
+      </div>
     </div>
 
     <dialog id="editDialog" class="modal"><form id="editForm" method="dialog"><div class="modal-heading"><div><p class="eyebrow" id="editEyebrow">EDIT</p><h2 id="editTitle">Edit item</h2></div><button class="icon-button" value="cancel" aria-label="Close">×</button></div><div id="editFields" class="form-grid"></div><div class="modal-actions"><button value="cancel" class="secondary-button">Cancel</button><button id="saveEditButton" value="default" class="primary-button">Save</button></div></form></dialog>

--- a/main-process.js
+++ b/main-process.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, protocol, safeStorage } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, protocol, safeStorage, shell } from 'electron';
 import updater from 'electron-updater';
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
@@ -9,6 +9,7 @@ import { DiagnosticLogger, RENDERER_FAULT_EVENTS } from './diagnostic-logger.js'
 import { extractPdfDocument } from './pdf-service.js';
 import { parseImportedDocument } from './document-import.js';
 import { askLocalModel, checkLocalModel } from './local-llm-service.js';
+import { SafeUpdateService } from './update-service.js';
 
 const { autoUpdater } = updater;
 
@@ -20,6 +21,7 @@ let currentState;
 let currentLoadResult;
 let diagnostics;
 let diagnosticPreviewCache;
+let updateService;
 const pendingRestoreSelections = new Map();
 let activeRestore = null;
 
@@ -101,22 +103,18 @@ function createWindow() {
 }
 
 function configureAutoUpdater() {
-  autoUpdater.autoDownload = true;
-  autoUpdater.autoInstallOnAppQuit = true;
-  autoUpdater.allowPrerelease = false;
-  autoUpdater.on('checking-for-update', () => sendUpdateStatus({ state: 'checking', message: 'Checking for updates…' }));
-  autoUpdater.on('update-available', (info) => sendUpdateStatus({ state: 'downloading', version: info.version, message: `Version ${info.version} is downloading…` }));
-  autoUpdater.on('update-not-available', () => sendUpdateStatus({ state: 'current', message: 'You have the latest version.' }));
-  autoUpdater.on('download-progress', (progress) => sendUpdateStatus({ state: 'downloading', percent: Math.round(progress.percent || 0), message: `Downloading update… ${Math.round(progress.percent || 0)}%` }));
-  autoUpdater.on('update-downloaded', (info) => sendUpdateStatus({ state: 'ready', version: info.version, message: `Version ${info.version} is ready to install.` }));
-  autoUpdater.on('error', (error) => {
-    diagnostics.record('UPDATE_FAILED', { error }).catch(() => {});
-    sendUpdateStatus({ state: 'error', message: 'The update check failed. You can try again from Settings.' });
+  updateService = new SafeUpdateService({
+    autoUpdater,
+    isPackaged: app.isPackaged,
+    getCurrentVersion: () => app.getVersion(),
+    sendStatus: sendUpdateStatus,
+    recordFailure: (error) => diagnostics.record('UPDATE_FAILED', { error }),
+    openExternal: (url) => shell.openExternal(url)
   });
+  updateService.configure();
 
   mainWindow.webContents.once('did-finish-load', () => {
-    sendUpdateStatus({ state: app.isPackaged ? 'idle' : 'development', version: app.getVersion(), message: app.isPackaged ? 'Updates are checked automatically.' : 'Updates are disabled in development mode.' });
-    if (app.isPackaged) setTimeout(() => autoUpdater.checkForUpdates().catch(() => {}), 4000);
+    updateService.scheduleAutomaticCheck();
   });
 }
 
@@ -352,17 +350,11 @@ function registerIpcHandlers() {
     return blocked || askLocalModel(question, currentState, currentState.settings.llmModel);
   });
   ipcMain.handle('update:check', async () => {
-    if (!app.isPackaged) return { state: 'development', message: 'Updates are disabled in development mode.', currentVersion: app.getVersion() };
-    await autoUpdater.checkForUpdates();
-    return { state: 'checking', message: 'Checking for updates…', currentVersion: app.getVersion() };
+    return updateService.check({ manual: true });
   });
-  ipcMain.handle('update:install', async () => {
-    const blocked = blockedMutationResult();
-    if (blocked) return blocked;
-    if (!app.isPackaged) return false;
-    await store.createAutomaticBackup('before-update');
-    setImmediate(() => autoUpdater.quitAndInstall(false, true));
-    return true;
+  ipcMain.handle('update:get-status', () => updateService.getStatus());
+  ipcMain.handle('update:open-release', async () => {
+    return updateService.openAvailableRelease();
   });
 
   ipcMain.handle('export:csv', async (_event, csv) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onestep-money",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",
@@ -53,6 +53,8 @@
       "renderer-app.js",
       "seed-data.json",
       "styles.css",
+      "update-service.js",
+      "update-ui.js",
       "package.json"
     ],
     "win": {

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -24,8 +24,9 @@ contextBridge.exposeInMainWorld('financeAPI', Object.freeze({
   exportDiagnostics: (token) => ipcRenderer.invoke('diagnostics:export', token),
   deleteDiagnostics: () => ipcRenderer.invoke('diagnostics:delete'),
   recordRendererFault: (eventName) => ipcRenderer.invoke('diagnostics:renderer-fault', eventName),
+  getUpdateStatus: () => ipcRenderer.invoke('update:get-status'),
   checkForUpdates: () => ipcRenderer.invoke('update:check'),
-  installUpdate: () => ipcRenderer.invoke('update:install'),
+  openAvailableUpdate: () => ipcRenderer.invoke('update:open-release'),
   onUpdateStatus: (callback) => {
     const listener = (_event, status) => callback(status);
     ipcRenderer.on('update:status', listener);

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -4,6 +4,10 @@ import {
   creditReportDebtStatus, creditReportStatusConflict, findDuplicateCandidates, findSavingsOpportunities, formatCurrency, formatDate,
   hasCompletedCheckIn, planCreditReportAccounts, syncStatementAccount
 } from './finance-core.js';
+import {
+  applyUpdateStatus, createUpdateUiState, dismissUpdateNotification as dismissUpdateUiNotification,
+  setInstalledVersion, updateUiView
+} from './update-ui.js';
 
 let state;
 let encryption;
@@ -17,6 +21,7 @@ let freshStartToken = null;
 let restoreToken = null;
 let restoreInProgress = false;
 let restoreCanCancel = true;
+let updateUiState = createUpdateUiState();
 let normalEventsBound = false;
 let recoveryEventsBound = false;
 let restoreEventsBound = false;
@@ -54,8 +59,8 @@ async function initialise() {
 }
 
 function renderAppVersion(value) {
-  const version = String(value || '').trim().replace(/^v/i, '');
-  byId('appVersion').textContent = version ? `v${version}` : 'Version unavailable';
+  updateUiState = setInstalledVersion(updateUiState, value);
+  renderUpdateUi();
 }
 
 function activateNormalMode(loaded) {
@@ -297,11 +302,13 @@ function bindEvents() {
   byId('createBackupButton').addEventListener('click', createBackup);
   byId('restoreBackupButton').addEventListener('click', restoreBackup);
   byId('checkUpdateButton').addEventListener('click', checkForUpdates);
-  byId('installUpdateButton').addEventListener('click', installUpdate);
+  byId('dismissUpdateNotificationButton').addEventListener('click', dismissUpdateNotification);
+  document.querySelectorAll('[data-view-update]').forEach((button) => button.addEventListener('click', openAvailableUpdate));
   byId('reviewDiagnosticsButton').addEventListener('click', reviewDiagnostics);
   byId('exportDiagnosticsButton').addEventListener('click', exportDiagnostics);
   byId('deleteDiagnosticsButton').addEventListener('click', deleteDiagnostics);
   window.financeAPI.onUpdateStatus(handleUpdateStatus);
+  window.financeAPI.getUpdateStatus().then(handleUpdateStatus).catch(() => {});
 }
 
 function bindRestoreEvents() {
@@ -1142,20 +1149,38 @@ function showRestoreOutcome(title, explanation) {
 async function checkForUpdates() {
   byId('updateStatus').textContent = 'Checking for updates…';
   try { handleUpdateStatus(await window.financeAPI.checkForUpdates()); }
-  catch (error) { handleUpdateStatus({ state: 'error', message: error.message }); }
+  catch { handleUpdateStatus({ state: 'unavailable', message: 'The update check couldn’t be completed.' }); }
 }
 
-async function installUpdate() {
-  byId('installUpdateButton').disabled = true;
-  byId('updateStatus').textContent = 'Creating a recovery backup, then restarting…';
-  try { await window.financeAPI.installUpdate(); }
-  catch (error) { byId('installUpdateButton').disabled = false; handleUpdateStatus({ state: 'error', message: error.message }); }
+async function openAvailableUpdate() {
+  try {
+    await window.financeAPI.openAvailableUpdate();
+  } catch {
+    byId('updateStatus').textContent = 'The trusted update page couldn’t be opened. Try again in a moment.';
+  }
 }
 
 function handleUpdateStatus(status = {}) {
-  byId('updateStatus').textContent = status.message || 'Update status unavailable.';
-  byId('installUpdateButton').hidden = status.state !== 'ready';
-  byId('checkUpdateButton').disabled = ['checking', 'downloading'].includes(status.state);
+  updateUiState = applyUpdateStatus(updateUiState, status);
+  renderUpdateUi();
+}
+
+function dismissUpdateNotification() {
+  updateUiState = dismissUpdateUiNotification(updateUiState);
+  renderUpdateUi();
+}
+
+function renderUpdateUi() {
+  const view = updateUiView(updateUiState);
+  const version = byId('appVersion');
+  version.textContent = view.versionLabel;
+  version.setAttribute('aria-label', view.versionAriaLabel);
+  byId('updateStatus').textContent = view.settingsStatus;
+  byId('checkUpdateButton').disabled = view.checkDisabled;
+  document.querySelectorAll('[data-view-update]').forEach((button) => { button.hidden = !view.viewUpdateVisible; });
+  byId('updateNotificationMessage').textContent = view.notificationMessage;
+  byId('updateNotificationRegion').hidden = !view.notificationVisible;
+  byId('appShell').classList.toggle('update-notification-visible', view.notificationVisible);
 }
 
 async function reviewDiagnostics() {

--- a/styles.css
+++ b/styles.css
@@ -134,6 +134,7 @@ h3 { margin-bottom: 0.25rem; font-size: 0.98rem; letter-spacing: -0.012em; }
 .recovery-destructive p { max-width: 530px; margin: 0; color: var(--muted); font-size: 0.82rem; line-height: 1.5; }
 
 .app-shell { min-height: 100vh; display: grid; grid-template-columns: 264px minmax(0, 1fr); }
+.app-shell.update-notification-visible { grid-template-columns: 264px minmax(0, 1fr) minmax(300px, 340px); }
 .sidebar {
   position: sticky;
   top: 0;
@@ -633,6 +634,70 @@ tr:last-child td { border-bottom: 0; }
 .restore-progress li.active::before { color: #fff; background: var(--teal); box-shadow: 0 0 0 4px var(--teal-soft); }
 .restore-progress li.complete { color: var(--teal-dark); }
 .restore-progress li.complete::before { content: '✓'; color: #fff; background: var(--teal-dark); }
+.update-notification-region {
+  position: sticky;
+  top: 0;
+  z-index: 8;
+  height: 100vh;
+  display: flex;
+  align-items: flex-end;
+  min-width: 0;
+  padding: 0 18px 18px 0;
+  pointer-events: none;
+}
+.update-notification {
+  position: relative;
+  width: 100%;
+  max-width: 340px;
+  padding: 1.05rem 3.1rem 1rem 1.05rem;
+  overflow: hidden;
+  color: #f5f9fd;
+  background: linear-gradient(135deg, rgba(7, 29, 67, 0.84), rgba(8, 57, 91, 0.82));
+  border: 1px solid rgba(124, 225, 210, 0.24);
+  border-radius: 16px;
+  box-shadow: 0 20px 54px rgba(3, 23, 52, 0.3);
+  backdrop-filter: blur(16px) saturate(115%);
+  animation: updateNoticeIn 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  pointer-events: auto;
+}
+.update-notification::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  content: '';
+  background: #55ddc5;
+}
+.update-notification-copy h2 { margin: 0 0 0.4rem; color: #fff; font-size: 0.98rem; letter-spacing: -0.015em; }
+.update-notification-copy p { margin: 0 0 0.72rem; color: rgba(236, 244, 251, 0.84); font-size: 0.79rem; line-height: 1.5; }
+.update-notification-close {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  color: rgba(242, 248, 253, 0.78);
+  background: rgba(255, 255, 255, 0.055);
+  border: 0;
+  border-radius: 10px;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+.update-notification-close:hover { color: #fff; background: rgba(255, 255, 255, 0.12); }
+.update-notification-action {
+  padding: 0.1rem 0;
+  color: #78ebd7;
+  background: transparent;
+  border: 0;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-decoration: underline;
+  text-decoration-color: rgba(120, 235, 215, 0.46);
+  text-underline-offset: 0.22rem;
+}
+.update-notification-action:hover { color: #a4f5e7; text-decoration-color: currentColor; }
 .toast { position: fixed; right: 1.2rem; bottom: 1.2rem; z-index: 10; max-width: 380px; padding: 0.82rem 1rem 0.82rem 2.7rem; color: #fff; background: linear-gradient(125deg, #071d43, #0b3e65); border: 1px solid rgba(91, 224, 200, 0.2); border-radius: 14px; box-shadow: 0 19px 50px rgba(4, 25, 56, 0.28); animation: toastIn 260ms cubic-bezier(0.2, 0.8, 0.2, 1) both; }
 .toast::before { position: absolute; top: 50%; left: 0.9rem; width: 21px; height: 21px; display: grid; place-items: center; content: "✓"; color: var(--navy-deep); background: #55ddc5; border-radius: 50%; font-size: 0.72rem; font-weight: 900; transform: translateY(-50%); }
 
@@ -640,6 +705,7 @@ tr:last-child td { border-bottom: 0; }
 @keyframes modalIn { from { opacity: 0; transform: translateY(14px) scale(0.985); } to { opacity: 1; transform: translateY(0) scale(1); } }
 @keyframes messageIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes toastIn { from { opacity: 0; transform: translateX(15px) translateY(8px); } to { opacity: 1; transform: translate(0); } }
+@keyframes updateNoticeIn { from { opacity: 0; transform: translateX(10px) translateY(7px); } to { opacity: 1; transform: translate(0); } }
 @keyframes floatRing { 0%, 100% { transform: translate3d(0, 0, 0) rotate(0); } 50% { transform: translate3d(12px, 8px, 0) rotate(4deg); } }
 @keyframes statusPulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.14); } }
 @keyframes focusComplete { 0% { opacity: 1; transform: translateY(0) scale(1); max-height: 260px; } 62% { opacity: 0; transform: translateY(-8px) scale(0.99); max-height: 260px; } 100% { opacity: 0; transform: translateY(-8px) scale(0.99); max-height: 0; min-height: 0; padding-block: 0; border-width: 0; } }
@@ -650,6 +716,9 @@ tr:last-child td { border-bottom: 0; }
 
 @media (max-width: 1120px) {
   .app-shell { grid-template-columns: 86px minmax(0, 1fr); }
+  .app-shell.update-notification-visible { grid-template-columns: 86px minmax(0, 1fr) minmax(300px, 330px); }
+  .update-notification-visible .metric-grid, .update-notification-visible .metric-grid.three { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .update-notification-visible .two-column, .update-notification-visible .settings-grid, .update-notification-visible .filter-bar { grid-template-columns: 1fr; }
   .sidebar { padding: 0.9rem 0.65rem; }
   .brand { justify-content: center; padding-inline: 0; }
   .brand-copy, .nav-label { display: none; }
@@ -666,6 +735,8 @@ tr:last-child td { border-bottom: 0; }
 
 @media (max-width: 840px) {
   .app-shell { display: block; }
+  .app-shell.update-notification-visible { display: block; }
+  .update-notification-region { position: fixed; inset: auto 18px 76px auto; width: min(340px, calc(100vw - 36px)); height: auto; padding: 0; }
   .sidebar { position: fixed; inset: auto 0 0 0; z-index: 6; width: 100%; height: auto; padding: 0.45rem; }
   .sidebar::before, .sidebar::after, .brand, .sidebar-footer { display: none; }
   .sidebar nav { grid-template-columns: repeat(9, minmax(58px, 1fr)); overflow-x: auto; }

--- a/tests/preload-bridge.test.js
+++ b/tests/preload-bridge.test.js
@@ -56,7 +56,10 @@ test('sandboxed preload exposes the complete desktop API', async () => {
   await exposed.api.exportDiagnostics('preview-token');
   await exposed.api.deleteDiagnostics();
   await exposed.api.recordRendererFault('RENDERER_UNHANDLED_ERROR');
+  await exposed.api.getUpdateStatus();
   await exposed.api.checkForUpdates();
+  await exposed.api.openAvailableUpdate();
+  assert.equal(exposed.api.installUpdate, undefined);
   assert.deepEqual(invocations, [
     ['app:version'],
     ['state:load'],
@@ -76,13 +79,15 @@ test('sandboxed preload exposes the complete desktop API', async () => {
     ['diagnostics:export', 'preview-token'],
     ['diagnostics:delete'],
     ['diagnostics:renderer-fault', 'RENDERER_UNHANDLED_ERROR'],
-    ['update:check']
+    ['update:get-status'],
+    ['update:check'],
+    ['update:open-release']
   ]);
 
   let updateStatus;
   const unsubscribe = exposed.api.onUpdateStatus((status) => { updateStatus = status; });
-  listeners.get('update:status')({}, { state: 'ready' });
-  assert.deepEqual(updateStatus, { state: 'ready' });
+  listeners.get('update:status')({}, { state: 'available', version: '2.1.11' });
+  assert.deepEqual(updateStatus, { state: 'available', version: '2.1.11' });
   unsubscribe();
   assert.equal(listeners.has('update:status'), false);
 

--- a/tests/update-service.test.js
+++ b/tests/update-service.test.js
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+import {
+  buildTrustedReleaseUrl, isTrustedReleaseUrl, SafeUpdateService
+} from '../update-service.js';
+
+test('updater is configured for stable availability checks without download or install', () => {
+  const harness = createHarness();
+  harness.service.configure();
+
+  assert.equal(harness.updater.autoDownload, false);
+  assert.equal(harness.updater.autoInstallOnAppQuit, false);
+  assert.equal(harness.updater.allowPrerelease, false);
+  assert.equal(harness.updater.downloadCalls, 0);
+  assert.equal(harness.updater.installCalls, 0);
+});
+
+test('automatic update availability is announced without downloading or staging an installer', async () => {
+  const harness = createHarness({
+    check: async (updater) => updater.emit('update-available', { version: '2.1.11' })
+  });
+  harness.service.configure();
+
+  const result = await harness.service.check({ manual: false });
+
+  assert.equal(result.state, 'available');
+  assert.equal(result.version, '2.1.11');
+  assert.deepEqual(harness.statuses, [{
+    state: 'available',
+    message: 'OneStep Money v2.1.11 is available.',
+    currentVersion: '2.1.10',
+    version: '2.1.11'
+  }]);
+  assert.equal(harness.updater.downloadCalls, 0);
+  assert.equal(harness.updater.installCalls, 0);
+});
+
+test('automatic current and failure results stay silent while manual checks receive calm feedback', async () => {
+  const current = createHarness({
+    check: async (updater) => updater.emit('update-not-available', { version: '2.1.10' })
+  });
+  current.service.configure();
+  assert.equal((await current.service.check({ manual: false })).state, 'current');
+  assert.deepEqual(current.statuses, []);
+
+  const failedAutomatic = createHarness({ check: async () => { throw new Error('offline'); } });
+  failedAutomatic.service.configure();
+  assert.equal((await failedAutomatic.service.check({ manual: false })).state, 'unavailable');
+  assert.deepEqual(failedAutomatic.statuses, []);
+  assert.equal(failedAutomatic.failures.length, 1);
+
+  const failedManual = createHarness({ check: async () => { throw new Error('offline'); } });
+  failedManual.service.configure();
+  assert.equal((await failedManual.service.check({ manual: true })).state, 'unavailable');
+  assert.deepEqual(failedManual.statuses.map((status) => status.state), ['checking', 'unavailable']);
+});
+
+test('manual current check reports completion and never uses download states', async () => {
+  const harness = createHarness({
+    check: async (updater) => updater.emit('update-not-available', { version: '2.1.10' })
+  });
+  harness.service.configure();
+
+  const result = await harness.service.check({ manual: true });
+
+  assert.equal(result.state, 'current');
+  assert.deepEqual(harness.statuses.map((status) => status.state), ['checking', 'current']);
+  assert.ok(harness.statuses.every((status) => !['downloading', 'ready'].includes(status.state)));
+});
+
+test('development builds neither schedule nor perform production update checks', async () => {
+  const harness = createHarness({ packaged: false });
+  harness.service.configure();
+  const scheduled = [];
+
+  assert.equal(harness.service.scheduleAutomaticCheck(4000, (...args) => scheduled.push(args)), false);
+  assert.equal((await harness.service.check({ manual: false })).state, 'development');
+  assert.equal(harness.updater.checkCalls, 0);
+  assert.equal(scheduled.length, 0);
+});
+
+test('packaged automatic check is scheduled once after the requested delay', async () => {
+  const harness = createHarness({
+    check: async (updater) => updater.emit('update-not-available', { version: '2.1.10' })
+  });
+  harness.service.configure();
+  let callback;
+  let delay;
+
+  assert.equal(harness.service.scheduleAutomaticCheck(4000, (next, wait) => { callback = next; delay = wait; }), true);
+  assert.equal(delay, 4000);
+  callback();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(harness.updater.checkCalls, 1);
+});
+
+test('prerelease metadata is rejected even if a provider emits it', async () => {
+  const harness = createHarness({
+    check: async (updater) => updater.emit('update-available', { version: '2.1.11-beta.1' })
+  });
+  harness.service.configure();
+
+  const result = await harness.service.check({ manual: true });
+
+  assert.equal(result.state, 'unavailable');
+  assert.equal(harness.service.availableVersion, null);
+  assert.deepEqual(harness.statuses.map((status) => status.state), ['checking', 'unavailable']);
+  assert.equal(harness.failures.length, 1);
+});
+
+test('release opening is built in the service and restricted to the trusted stable tag path', async () => {
+  const harness = createHarness();
+  harness.service.configure();
+  harness.updater.emit('update-available', { version: '2.1.11' });
+
+  const result = await harness.service.openAvailableRelease();
+
+  assert.deepEqual(result, { opened: true, version: '2.1.11' });
+  assert.deepEqual(harness.opened, ['https://github.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.11']);
+  assert.equal(buildTrustedReleaseUrl('v2.1.11'), harness.opened[0]);
+  for (const url of [
+    'http://github.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.11',
+    'https://example.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.11',
+    'file:///tmp/update.exe',
+    'javascript:alert(1)',
+    'https://github.com/cntintheslk-OneStepMoney/onestep-money/releases/download/v2.1.11/update.exe',
+    'https://github.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.11-beta.1'
+  ]) assert.equal(isTrustedReleaseUrl(url), false, url);
+});
+
+function createHarness({ packaged = true, check } = {}) {
+  const updater = new MockUpdater(check);
+  const statuses = [];
+  const failures = [];
+  const opened = [];
+  const service = new SafeUpdateService({
+    autoUpdater: updater,
+    isPackaged: packaged,
+    getCurrentVersion: () => '2.1.10',
+    sendStatus: (status) => statuses.push(status),
+    recordFailure: async (error) => failures.push(error),
+    openExternal: async (url) => opened.push(url)
+  });
+  return { service, updater, statuses, failures, opened };
+}
+
+class MockUpdater extends EventEmitter {
+  constructor(check) {
+    super();
+    this.check = check || (async (updater) => updater.emit('update-not-available', { version: '2.1.10' }));
+    this.checkCalls = 0;
+    this.downloadCalls = 0;
+    this.installCalls = 0;
+  }
+
+  async checkForUpdates() {
+    this.checkCalls += 1;
+    return this.check(this);
+  }
+
+  async downloadUpdate() {
+    this.downloadCalls += 1;
+  }
+
+  quitAndInstall() {
+    this.installCalls += 1;
+  }
+}

--- a/tests/update-ui.test.js
+++ b/tests/update-ui.test.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import {
+  applyUpdateStatus, createUpdateUiState, dismissUpdateNotification, setInstalledVersion, updateUiView
+} from '../update-ui.js';
+
+test('available update shows the popup and persistent installed-version reminder', () => {
+  let state = setInstalledVersion(createUpdateUiState(), '2.1.10');
+  state = applyUpdateStatus(state, { state: 'available', version: '2.1.11', message: 'OneStep Money v2.1.11 is available.' });
+  const view = updateUiView(state);
+
+  assert.equal(view.notificationVisible, true);
+  assert.equal(view.notificationMessage, 'OneStep Money v2.1.11 is available.');
+  assert.equal(view.versionLabel, 'v2.1.10 · Update available');
+  assert.equal(view.viewUpdateVisible, true);
+});
+
+test('dismissal lasts for the session and does not remove the version reminder', () => {
+  let state = setInstalledVersion(createUpdateUiState(), '2.1.10');
+  state = applyUpdateStatus(state, { state: 'available', version: '2.1.11', message: 'OneStep Money v2.1.11 is available.' });
+  state = dismissUpdateNotification(state);
+  state = applyUpdateStatus(state, { state: 'available', version: '2.1.11', message: 'OneStep Money v2.1.11 is available.' });
+  const view = updateUiView(state);
+
+  assert.equal(view.notificationVisible, false);
+  assert.equal(view.versionLabel, 'v2.1.10 · Update available');
+  assert.equal(view.viewUpdateVisible, true);
+});
+
+test('a new application session may show the same outstanding update again', () => {
+  let previousSession = applyUpdateStatus(createUpdateUiState(), { state: 'available', version: '2.1.11' });
+  previousSession = dismissUpdateNotification(previousSession);
+  assert.equal(updateUiView(previousSession).notificationVisible, false);
+
+  const nextSession = applyUpdateStatus(createUpdateUiState(), { state: 'available', version: '2.1.11' });
+  assert.equal(updateUiView(nextSession).notificationVisible, true);
+});
+
+test('no-update state leaves the installed version unchanged and failure preserves known availability', () => {
+  let state = setInstalledVersion(createUpdateUiState(), '2.1.10');
+  state = applyUpdateStatus(state, { state: 'current', message: 'You’re up to date.' });
+  assert.equal(updateUiView(state).notificationVisible, false);
+  assert.equal(updateUiView(state).versionLabel, 'v2.1.10');
+
+  state = applyUpdateStatus(state, { state: 'available', version: '2.1.11', message: 'Update available.' });
+  state = applyUpdateStatus(state, { state: 'unavailable', message: 'The update check couldn’t be completed.' });
+  assert.equal(updateUiView(state).versionLabel, 'v2.1.10 · Update available');
+});
+
+test('notification markup and styles preserve accessibility, minimum sizing and reduced motion', () => {
+  const html = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  const css = fs.readFileSync(new URL('../styles.css', import.meta.url), 'utf8');
+  const main = fs.readFileSync(new URL('../main-process.js', import.meta.url), 'utf8');
+
+  assert.match(html, /aria-label="Dismiss update notification"/);
+  assert.match(html, /role="status" aria-live="polite" aria-atomic="true"/);
+  assert.match(html, /data-view-update/);
+  assert.match(css, /padding: 0 18px 18px 0/);
+  assert.match(css, /max-width: 340px/);
+  assert.match(css, /rgba\(7, 29, 67, 0\.84\)/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+  assert.match(css, /\.app-shell\.update-notification-visible/);
+  assert.doesNotMatch(main, /quitAndInstall|downloadUpdate|update:install/);
+});

--- a/update-service.js
+++ b/update-service.js
@@ -1,0 +1,176 @@
+const RELEASE_ORIGIN = 'https://github.com';
+const RELEASE_PATH_PREFIX = '/cntintheslk-OneStepMoney/onestep-money/releases/tag/v';
+const STABLE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function normaliseStableVersion(value) {
+  const version = String(value || '').trim().replace(/^v/i, '');
+  return STABLE_VERSION_PATTERN.test(version) ? version : null;
+}
+
+export function buildTrustedReleaseUrl(value) {
+  const version = normaliseStableVersion(value);
+  if (!version) throw new TypeError('The available update version is not a stable semantic version.');
+  return `${RELEASE_ORIGIN}${RELEASE_PATH_PREFIX}${version}`;
+}
+
+export function isTrustedReleaseUrl(value) {
+  try {
+    const url = new URL(String(value));
+    if (url.protocol !== 'https:' || url.origin !== RELEASE_ORIGIN || url.username || url.password || url.search || url.hash) return false;
+    return new RegExp(`^${escapeRegExp(RELEASE_PATH_PREFIX)}${STABLE_VERSION_PATTERN.source.slice(1, -1)}$`).test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+export class SafeUpdateService {
+  constructor({ autoUpdater, isPackaged, getCurrentVersion, sendStatus, recordFailure, openExternal }) {
+    this.autoUpdater = autoUpdater;
+    this.isPackaged = Boolean(isPackaged);
+    this.getCurrentVersion = getCurrentVersion;
+    this.sendStatus = sendStatus;
+    this.recordFailure = recordFailure;
+    this.openExternal = openExternal;
+    this.activeCheck = null;
+    this.availableVersion = null;
+    this.lastKnownStatus = null;
+    this.configured = false;
+  }
+
+  configure() {
+    if (this.configured) return;
+    this.configured = true;
+    this.autoUpdater.autoDownload = false;
+    this.autoUpdater.autoInstallOnAppQuit = false;
+    this.autoUpdater.allowPrerelease = false;
+    this.autoUpdater.on('update-available', (info) => this.handleUpdateAvailable(info));
+    this.autoUpdater.on('update-not-available', () => this.handleUpdateNotAvailable());
+    this.autoUpdater.on('error', (error) => this.handleUpdateError(error));
+  }
+
+  scheduleAutomaticCheck(delay = 4000, schedule = setTimeout) {
+    if (!this.isPackaged) return false;
+    schedule(() => { this.check({ manual: false }).catch(() => {}); }, delay);
+    return true;
+  }
+
+  async check({ manual = false } = {}) {
+    if (!this.isPackaged) {
+      const status = this.status('development', 'Updates are disabled in development mode.');
+      this.lastKnownStatus = status;
+      if (manual) this.sendStatus(status);
+      return status;
+    }
+
+    if (this.activeCheck) {
+      if (manual && !this.activeCheck.manual) {
+        this.activeCheck.manual = true;
+        this.lastKnownStatus = this.status('checking', 'Checking for updates…');
+        this.sendStatus(this.lastKnownStatus);
+      }
+      return this.activeCheck.promise;
+    }
+
+    const check = { manual: Boolean(manual), result: null, failurePromise: null, promise: null };
+    this.activeCheck = check;
+    if (check.manual) {
+      this.lastKnownStatus = this.status('checking', 'Checking for updates…');
+      this.sendStatus(this.lastKnownStatus);
+    }
+
+    check.promise = (async () => {
+      try {
+        await this.autoUpdater.checkForUpdates();
+        const status = check.result || this.status('current', 'You’re up to date.');
+        if (!check.result) this.lastKnownStatus = status;
+        return status;
+      } catch (error) {
+        await this.recordCheckFailure(error, check);
+        const status = check.result?.state === 'unavailable'
+          ? check.result
+          : this.status('unavailable', 'The update check couldn’t be completed.');
+        check.result = status;
+        if (check.manual) {
+          this.lastKnownStatus = status;
+          this.sendStatus(status);
+        }
+        return status;
+      } finally {
+        if (this.activeCheck === check) this.activeCheck = null;
+      }
+    })();
+
+    return check.promise;
+  }
+
+  async openAvailableRelease() {
+    const url = buildTrustedReleaseUrl(this.availableVersion);
+    if (!isTrustedReleaseUrl(url)) throw new TypeError('The update release destination is not trusted.');
+    await this.openExternal(url);
+    return { opened: true, version: this.availableVersion };
+  }
+
+  getStatus() {
+    if (!this.isPackaged) return this.status('development', 'Updates are disabled in development mode.');
+    if (this.availableVersion) {
+      return this.status('available', `OneStep Money v${this.availableVersion} is available.`, { version: this.availableVersion });
+    }
+    return this.lastKnownStatus || this.status('idle', 'Updates are checked automatically. OneStep never downloads or installs them.');
+  }
+
+  handleUpdateAvailable(info = {}) {
+    const version = normaliseStableVersion(info.version);
+    if (!version) {
+      const error = new TypeError('Update metadata did not contain a stable semantic version.');
+      this.recordCheckFailure(error);
+      const status = this.status('unavailable', 'The update check couldn’t be completed.');
+      if (this.activeCheck) {
+        this.activeCheck.result = status;
+        if (this.activeCheck.manual) {
+          this.lastKnownStatus = status;
+          this.sendStatus(status);
+        }
+      }
+      return;
+    }
+
+    this.availableVersion = version;
+    const status = this.status('available', `OneStep Money v${version} is available.`, { version });
+    this.lastKnownStatus = status;
+    if (this.activeCheck) this.activeCheck.result = status;
+    this.sendStatus(status);
+  }
+
+  handleUpdateNotAvailable() {
+    this.availableVersion = null;
+    const status = this.status('current', 'You’re up to date.');
+    this.lastKnownStatus = status;
+    if (this.activeCheck) {
+      this.activeCheck.result = status;
+      if (this.activeCheck.manual) this.sendStatus(status);
+    }
+  }
+
+  handleUpdateError(error) {
+    this.recordCheckFailure(error);
+    if (this.activeCheck && !this.activeCheck.result) {
+      this.activeCheck.result = this.status('unavailable', 'The update check couldn’t be completed.');
+      if (this.activeCheck.manual) this.lastKnownStatus = this.activeCheck.result;
+    }
+  }
+
+  recordCheckFailure(error, check = this.activeCheck) {
+    if (check?.failurePromise) return check.failurePromise;
+    const failurePromise = Promise.resolve(this.recordFailure(error)).catch(() => {});
+    if (check) check.failurePromise = failurePromise;
+    return failurePromise;
+  }
+
+  status(state, message, extra = {}) {
+    return { state, message, currentVersion: this.getCurrentVersion(), ...extra };
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/update-ui.js
+++ b/update-ui.js
@@ -1,0 +1,56 @@
+const STABLE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function createUpdateUiState() {
+  return {
+    installedVersion: '',
+    availableVersion: '',
+    notificationDismissed: false,
+    statusState: 'idle',
+    statusMessage: 'Updates are checked automatically. OneStep never downloads or installs them.'
+  };
+}
+
+export function setInstalledVersion(state, value) {
+  const version = normaliseVersion(value);
+  return { ...state, installedVersion: version };
+}
+
+export function applyUpdateStatus(state, status = {}) {
+  const next = {
+    ...state,
+    statusState: String(status.state || 'idle'),
+    statusMessage: String(status.message || 'Update status unavailable.')
+  };
+
+  if (next.statusState === 'available') {
+    const version = normaliseVersion(status.version);
+    if (version) next.availableVersion = version;
+  } else if (next.statusState === 'current') {
+    next.availableVersion = '';
+  }
+
+  return next;
+}
+
+export function dismissUpdateNotification(state) {
+  return { ...state, notificationDismissed: true };
+}
+
+export function updateUiView(state) {
+  const hasUpdate = Boolean(state.availableVersion);
+  const installedLabel = state.installedVersion ? `v${state.installedVersion}` : 'Version unavailable';
+  return {
+    versionLabel: hasUpdate ? `${installedLabel} · Update available` : installedLabel,
+    versionAriaLabel: hasUpdate ? `OneStep Money ${installedLabel}. Update available.` : `OneStep Money ${installedLabel}.`,
+    notificationVisible: hasUpdate && !state.notificationDismissed,
+    notificationMessage: hasUpdate ? `OneStep Money v${state.availableVersion} is available.` : '',
+    settingsStatus: state.statusMessage,
+    checkDisabled: state.statusState === 'checking',
+    viewUpdateVisible: hasUpdate
+  };
+}
+
+function normaliseVersion(value) {
+  const version = String(value || '').trim().replace(/^v/i, '');
+  return STABLE_VERSION_PATTERN.test(version) ? version : '';
+}


### PR DESCRIPTION
### Purpose

OneStep previously configured `electron-updater` to download discovered updates automatically and install a downloaded update on quit. v2.1.10 replaces that behaviour with availability-only checking so the user controls every download and installation decision.

### Work completed

#### Updater behaviour
- Set `autoDownload = false`, `autoInstallOnAppQuit = false` and `allowPrerelease = false`.
- Added one delayed, non-blocking packaged-startup metadata check; development builds do not contact the production endpoint.
- Separated silent automatic failures from calm manual-check feedback.
- Removed download progress, downloaded/ready, backup-before-update and `quitAndInstall` paths.
- Added defensive stable-semver validation and cached status retrieval so startup events cannot be missed.

#### IPC and external navigation
- Removed `installUpdate` and `update:install`.
- Added read-only `update:get-status` and a no-argument `update:open-release`.
- The main process builds the URL from the validated available version and accepts only HTTPS, `github.com`, and the exact OneStep stable release-tag path with no credentials, query or fragment.
- The renderer cannot provide an arbitrary URL. Existing window-open/navigation restrictions, context isolation, sandboxing and `nodeIntegration: false` remain intact.

#### Renderer and Settings
- Replaced download/install states with idle, checking, current, available, unavailable and development states.
- Added the semi-transparent bottom-right update card in a reserved rail so financial content remains usable.
- Added the accessible top-right ×, persistent session-only dismissal, “View update”, subtle bottom-left update reminder, responsive minimum-window rules and reduced-motion support.
- Removed automatic timeouts, repeated animation, sound, flashing and focus stealing.
- Redesigned Settings around safe checking and external release viewing only.

#### Version, packaging and tests
- Updated package and lockfile versions from 2.1.9 to 2.1.10.
- Included the two new update modules in packaged builds.
- Kept `electron-updater ^6.8.9`; no dependency changed.
- Added updater, URL-security, preload/IPC, UI-state, session-dismissal, accessibility, responsive-layout and reduced-motion regressions.

### Files changed

- `index.html` — safe Settings controls and semantic notification markup.
- `main-process.js` — safe updater integration, status IPC and controlled external opening; removed installation.
- `package.json` — v2.1.10 and packaged update modules.
- `package-lock.json` — v2.1.10 root/application metadata only.
- `preload-bridge.cjs` — removed install API; added status and no-argument View update APIs.
- `renderer-app.js` — check-only state handling, session dismissal, notification and version reminder.
- `styles.css` — compact semi-transparent card, reserved safe area, accessibility, resizing and reduced motion.
- `update-service.js` — main-process availability-only controller and trusted release validation.
- `update-ui.js` — pure renderer presentation/session model.
- `tests/preload-bridge.test.js` — updated exposed API and event expectations.
- `tests/update-service.test.js` — updater policy, failure, development, prerelease and URL-security coverage.
- `tests/update-ui.test.js` — popup, dismissal, next launch, version, accessibility and layout coverage.

No files were renamed or deleted.

### User-facing changes

- Packaged OneStep checks once after startup without blocking financial access.
- A newer stable release shows a quiet bottom-right card with its version, top-right × and “View update”.
- Dismissal lasts for the current session; the subtle bottom-left update reminder remains.
- Manual checks report current/unavailable calmly.
- Offline and routine automatic failures remain silent.
- View update opens the trusted GitHub release page in the system browser.
- OneStep no longer downloads, stages, restarts into or installs updates.

### Technical changes

- Existing GitHub release metadata and `electron-updater` semantic-version behaviour are reused.
- Automatic checking is scheduled four seconds after renderer load only when `app.isPackaged`.
- The security boundary, not only the UI, has no renderer download/install capability.
- External opening uses `shell.openExternal` only after main-process validation.
- Minimal privacy-safe `UPDATE_FAILED` diagnostics may classify failures; successful checks and View update clicks are not logged.
- No telemetry, analytics, identifiers, financial data or document content enters the update path.
- No dependency changed.

### Testing and verification

- **Passed** — `npm test`: 91/91 tests, including updater, UI, preload/IPC, privacy, data-integrity, backup/restore, financial-safety, import and Windows `fsync` regressions.
- **Passed** — `npm run check`: syntax/project validation across 26 JavaScript files and public-seed validation.
- **Passed** — privacy validation across 40 files.
- **Passed** — `git diff --check`.
- **Passed** — `npx electron-builder --win --dir`: final v2.1.10 Windows x64 unpacked production package.
- **Passed** — packaged ASAR inspection: v2.1.10 metadata, unchanged updater dependency, new modules present, and all three safe updater flags present.
- **Failed / environment limitation** — `npm run dist:win`: packaging and NSIS archive preparation completed, but final installer generation failed at `spawn wine ENOENT` because Wine is unavailable. Partial ignored output was not committed.
- **Unavailable / environment limitation** — graphical Electron startup/capture: GTK could not create a display context in this headless environment.
- **Unavailable / environment limitation** — live packaged-Windows online/offline checks, visual minimum-size/resizing, keyboard, browser opening, quit and reduced-motion inspection require a Windows graphical runtime.
- **Unavailable / not configured** — dedicated lint and type-check scripts.
- **Unavailable / future release step** — final release installer, blockmap, `latest.yml`, source archives and release notes verification until the v2.1.10 release workflow runs.

Automated simulations cover the unavailable updater policies where practical. Only fictional/empty seed data was used.

### Data and migration impact

No financial-data or storage migration.

- Financial state, accounts, debts and transactions are unchanged.
- Document vault format is unchanged.
- Backup and restore formats are unchanged.
- Existing data remains compatible.
- Dismissal is not persisted.

### Known limitations

- Final NSIS generation and interactive Windows verification remain for a Windows/Wine-capable graphical environment.
- Live checks require valid existing GitHub release metadata.
- View update intentionally targets the repository’s exact stable release-tag path; moving hosts requires an explicit allowlist change.

### Excluded work

v2.1.10 excludes:
- Automatic downloads and automatic installation.
- Full Release Engineering.
- Document Deduplication.
- Statement Intelligence.
- Credit Report Intelligence.
- Dashboard roadmap work.
- Custom update servers, telemetry, analytics, code-signing redesign and installer redesign.

### Branch details

- Branch: `feature/safe-update-checking`
- Commit SHA: `12b5f752cec1b91ea34439bfcdb6fa01e6cdc878`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/13
- Target branch: `main`

### Confirmations

- No changes were committed or pushed directly to `main`.
- The pull request has not been merged.
- No personal financial data, imported documents, credentials, secrets or sensitive logs were committed.
- No analytics or telemetry was introduced.
- Only files relevant to v2.1.10 were changed.
