### PR TITLE
[v2.1.13][Feature] Controlled in-app updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
             <article class="panel"><h2>Planning</h2><label>Dependable monthly income<input id="dependableIncomeInput" type="number" min="0" step="0.01" /></label><label>Extra debt-payment target<input id="extraPaymentInput" type="number" min="0" step="10" /></label><label>Emergency-buffer target<input id="bufferTargetInput" type="number" min="0" step="50" /></label><label>Current emergency buffer<input id="bufferBalanceInput" type="number" min="0" step="1" /></label><button id="saveSettingsButton" class="primary-button">Save settings</button></article>
             <article class="panel"><h2>Local model</h2><label>Ollama model<input id="llmModelInput" type="text" value="qwen2.5:1.5b" /></label><p class="muted">Recommended small model: qwen2.5:1.5b. The app connects only to Ollama on 127.0.0.1.</p><button id="checkModelButton" class="secondary-button">Check model</button></article>
             <article class="panel"><h2>Encrypted backup</h2><p class="muted">A portable backup includes one verified snapshot of your financial data and encrypted document vault. Use a password you will remember.</p><label>Backup password<input id="backupPassphrase" type="password" minlength="8" autocomplete="new-password" /></label><div class="button-row"><button id="createBackupButton" class="primary-button">Create backup</button><button id="restoreBackupButton" class="secondary-button">Restore backup</button></div><p id="backupStatus" class="muted" aria-live="polite"></p></article>
-            <article class="panel"><h2>Updates</h2><p id="updateStatus" class="muted" aria-live="polite">Updates are checked automatically. OneStep never downloads or installs them.</p><div class="button-row"><button id="checkUpdateButton" class="secondary-button">Check for updates</button><button class="primary-button" data-view-update hidden>View update</button></div></article>
+            <article class="panel"><h2>Updates</h2><p id="updateStatus" class="muted" aria-live="polite">Updates are checked automatically. Downloads and installation only start when you choose.</p><progress id="settingsUpdateProgress" class="update-progress" max="100" value="0" aria-label="Update download 0% complete" hidden></progress><div class="button-row"><button id="checkUpdateButton" class="secondary-button">Check for updates</button><button class="primary-button" data-download-update hidden>Download update</button><button class="primary-button" data-restart-update hidden>Restart and install</button><button class="secondary-button" data-view-update hidden>View on GitHub</button></div></article>
             <article class="panel"><h2>Diagnostics</h2><p class="muted">Fault codes and basic device details stay on this device. Financial data, document contents, names, amounts, notes, filenames and paths are never logged.</p><p class="muted">Detailed entries are encrypted, kept for up to 14 days and never uploaded automatically. Review the report before choosing where to share it.</p><div class="button-row"><button id="reviewDiagnosticsButton" class="primary-button">Review &amp; export</button><button id="deleteDiagnosticsButton" class="danger-button">Delete diagnostics</button></div><p id="diagnosticsStatus" class="muted" aria-live="polite"></p></article>
             <article class="panel"><h2>Privacy</h2><p id="privacyDetails" class="muted"></p><p class="muted">No cloud sync, analytics or external AI. Imported files are checksum-checked, encrypted and never served by the preview server.</p></article>
           </div>
@@ -171,7 +171,12 @@
           <div class="update-notification-copy">
             <h2 id="updateNotificationTitle">Update available</h2>
             <p id="updateNotificationMessage"></p>
-            <button class="update-notification-action" type="button" data-view-update>View update</button>
+            <progress class="update-progress update-notification-progress" max="100" value="0" aria-label="Update download 0% complete" data-update-progress hidden></progress>
+            <div class="update-notification-actions">
+              <button class="update-notification-primary" type="button" data-download-update>Download update</button>
+              <button class="update-notification-primary" type="button" data-restart-update hidden>Restart and install</button>
+              <button class="update-notification-action" type="button" data-view-update>View on GitHub</button>
+            </div>
           </div>
         </aside>
       </div>

--- a/main-process.js
+++ b/main-process.js
@@ -58,7 +58,7 @@ app.whenReady().then(async () => {
   registerVaultProtocol();
   registerIpcHandlers();
   createWindow();
-  configureAutoUpdater();
+  await configureAutoUpdater();
   await diagnostics.record('APP_READY');
 
   app.on('activate', () => {
@@ -111,20 +111,37 @@ function createWindow() {
   }
 }
 
-function configureAutoUpdater() {
+async function configureAutoUpdater() {
+  const updateMarkerPath = path.join(app.getPath('userData'), 'pending-update.json');
   updateService = new SafeUpdateService({
     autoUpdater,
     isPackaged: app.isPackaged,
     getCurrentVersion: () => app.getVersion(),
     sendStatus: sendUpdateStatus,
     recordFailure: (error) => diagnostics.record('UPDATE_FAILED', { error }),
-    openExternal: (url) => shell.openExternal(url)
+    openExternal: (url) => shell.openExternal(url),
+    previouslyDownloadedVersion: await readDownloadedUpdateMarker(updateMarkerPath),
+    rememberDownloadedVersion: (version) => fs.writeFile(updateMarkerPath, JSON.stringify({ version }), { encoding: 'utf8', mode: 0o600 }),
+    forgetDownloadedVersion: () => fs.unlink(updateMarkerPath).catch((error) => {
+      if (error.code !== 'ENOENT') throw error;
+    })
   });
   updateService.configure();
 
-  mainWindow.webContents.once('did-finish-load', () => {
+  if (mainWindow.webContents.isLoadingMainFrame()) {
+    mainWindow.webContents.once('did-finish-load', () => updateService.scheduleAutomaticCheck());
+  } else {
     updateService.scheduleAutomaticCheck();
-  });
+  }
+}
+
+async function readDownloadedUpdateMarker(updateMarkerPath) {
+  try {
+    const marker = JSON.parse(await fs.readFile(updateMarkerPath, 'utf8'));
+    return typeof marker.version === 'string' ? marker.version : null;
+  } catch {
+    return null;
+  }
 }
 
 function sendUpdateStatus(status) {
@@ -344,6 +361,12 @@ function registerIpcHandlers() {
     return updateService.check({ manual: true });
   });
   ipcMain.handle('update:get-status', () => updateService.getStatus());
+  ipcMain.handle('update:download', async () => {
+    return updateService.downloadAvailableUpdate();
+  });
+  ipcMain.handle('update:restart-and-install', () => {
+    return updateService.restartAndInstall();
+  });
   ipcMain.handle('update:open-release', async () => {
     return updateService.openAvailableRelease();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onestep-money",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -26,6 +26,8 @@ contextBridge.exposeInMainWorld('financeAPI', Object.freeze({
   recordRendererFault: (eventName) => ipcRenderer.invoke('diagnostics:renderer-fault', eventName),
   getUpdateStatus: () => ipcRenderer.invoke('update:get-status'),
   checkForUpdates: () => ipcRenderer.invoke('update:check'),
+  downloadAvailableUpdate: () => ipcRenderer.invoke('update:download'),
+  restartAndInstallUpdate: () => ipcRenderer.invoke('update:restart-and-install'),
   openAvailableUpdate: () => ipcRenderer.invoke('update:open-release'),
   onUpdateStatus: (callback) => {
     const listener = (_event, status) => callback(status);

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -305,6 +305,8 @@ function bindEvents() {
   byId('restoreBackupButton').addEventListener('click', restoreBackup);
   byId('checkUpdateButton').addEventListener('click', checkForUpdates);
   byId('dismissUpdateNotificationButton').addEventListener('click', dismissUpdateNotification);
+  document.querySelectorAll('[data-download-update]').forEach((button) => button.addEventListener('click', downloadAvailableUpdate));
+  document.querySelectorAll('[data-restart-update]').forEach((button) => button.addEventListener('click', restartAndInstallUpdate));
   document.querySelectorAll('[data-view-update]').forEach((button) => button.addEventListener('click', openAvailableUpdate));
   byId('reviewDiagnosticsButton').addEventListener('click', reviewDiagnostics);
   byId('exportDiagnosticsButton').addEventListener('click', exportDiagnostics);
@@ -1247,6 +1249,30 @@ async function openAvailableUpdate() {
   }
 }
 
+async function downloadAvailableUpdate() {
+  try {
+    handleUpdateStatus(await window.financeAPI.downloadAvailableUpdate());
+  } catch {
+    handleUpdateStatus({
+      state: 'available',
+      version: updateUiState.availableVersion,
+      message: 'The update couldn’t be downloaded. Check your connection and try again.'
+    });
+  }
+}
+
+async function restartAndInstallUpdate() {
+  try {
+    handleUpdateStatus(await window.financeAPI.restartAndInstallUpdate());
+  } catch {
+    handleUpdateStatus({
+      state: 'ready',
+      version: updateUiState.availableVersion,
+      message: 'OneStep could not restart into the update. Your data is safe; try again when ready.'
+    });
+  }
+}
+
 function handleUpdateStatus(status = {}) {
   updateUiState = applyUpdateStatus(updateUiState, status);
   renderUpdateUi();
@@ -1264,7 +1290,21 @@ function renderUpdateUi() {
   version.setAttribute('aria-label', view.versionAriaLabel);
   byId('updateStatus').textContent = view.settingsStatus;
   byId('checkUpdateButton').disabled = view.checkDisabled;
+  document.querySelectorAll('[data-download-update]').forEach((button) => {
+    button.hidden = !view.downloadVisible;
+    button.disabled = view.downloadDisabled;
+  });
+  document.querySelectorAll('[data-restart-update]').forEach((button) => {
+    button.hidden = !view.installVisible;
+    button.disabled = view.installDisabled;
+  });
   document.querySelectorAll('[data-view-update]').forEach((button) => { button.hidden = !view.viewUpdateVisible; });
+  document.querySelectorAll('[data-update-progress], #settingsUpdateProgress').forEach((progress) => {
+    progress.hidden = !view.progressVisible;
+    progress.value = view.progressValue;
+    progress.setAttribute('aria-label', view.progressLabel);
+  });
+  byId('updateNotificationTitle').textContent = view.notificationTitle;
   byId('updateNotificationMessage').textContent = view.notificationMessage;
   byId('updateNotificationRegion').hidden = !view.notificationVisible;
   byId('appShell').classList.toggle('update-notification-visible', view.notificationVisible);

--- a/styles.css
+++ b/styles.css
@@ -673,6 +673,21 @@ tr:last-child td { border-bottom: 0; }
 }
 .update-notification-copy h2 { margin: 0 0 0.4rem; color: #fff; font-size: 0.98rem; letter-spacing: -0.015em; }
 .update-notification-copy p { margin: 0 0 0.72rem; color: rgba(236, 244, 251, 0.84); font-size: 0.79rem; line-height: 1.5; }
+.update-progress {
+  width: min(100%, 420px);
+  height: 7px;
+  margin: 0.72rem 0 0.15rem;
+  overflow: hidden;
+  accent-color: var(--teal);
+  border: 0;
+  border-radius: 999px;
+}
+.update-progress::-webkit-progress-bar { background: rgba(11, 61, 98, 0.12); border-radius: 999px; }
+.update-progress::-webkit-progress-value { background: var(--teal); border-radius: 999px; transition: width 160ms ease; }
+.update-notification-progress { width: 100%; margin: 0 0 0.8rem; accent-color: #55ddc5; }
+.update-notification-progress::-webkit-progress-bar { background: rgba(255, 255, 255, 0.13); }
+.update-notification-progress::-webkit-progress-value { background: #55ddc5; }
+.update-notification-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 0.55rem 0.85rem; }
 .update-notification-close {
   position: absolute;
   top: 0.55rem;
@@ -690,6 +705,17 @@ tr:last-child td { border-bottom: 0; }
   line-height: 1;
 }
 .update-notification-close:hover { color: #fff; background: rgba(255, 255, 255, 0.12); }
+.update-notification-primary {
+  min-height: 34px;
+  padding: 0.45rem 0.72rem;
+  color: #06223b;
+  background: #78ebd7;
+  border: 0;
+  border-radius: 9px;
+  font-size: 0.76rem;
+  font-weight: 820;
+}
+.update-notification-primary:hover { background: #a4f5e7; transform: translateY(-1px); }
 .update-notification-action {
   padding: 0.1rem 0;
   color: #78ebd7;

--- a/tests/preload-bridge.test.js
+++ b/tests/preload-bridge.test.js
@@ -58,8 +58,10 @@ test('sandboxed preload exposes the complete desktop API', async () => {
   await exposed.api.recordRendererFault('RENDERER_UNHANDLED_ERROR');
   await exposed.api.getUpdateStatus();
   await exposed.api.checkForUpdates();
+  await exposed.api.downloadAvailableUpdate();
+  await exposed.api.restartAndInstallUpdate();
   await exposed.api.openAvailableUpdate();
-  assert.equal(exposed.api.installUpdate, undefined);
+  assert.equal(exposed.api.openExternalUrl, undefined);
   assert.deepEqual(invocations, [
     ['app:version'],
     ['state:load'],
@@ -81,6 +83,8 @@ test('sandboxed preload exposes the complete desktop API', async () => {
     ['diagnostics:renderer-fault', 'RENDERER_UNHANDLED_ERROR'],
     ['update:get-status'],
     ['update:check'],
+    ['update:download'],
+    ['update:restart-and-install'],
     ['update:open-release']
   ]);
 

--- a/tests/update-service.test.js
+++ b/tests/update-service.test.js
@@ -5,7 +5,7 @@ import {
   buildTrustedReleaseUrl, isTrustedReleaseUrl, SafeUpdateService
 } from '../update-service.js';
 
-test('updater is configured for stable availability checks without download or install', () => {
+test('updater keeps automatic download and install-on-quit disabled', () => {
   const harness = createHarness();
   harness.service.configure();
 
@@ -16,29 +16,116 @@ test('updater is configured for stable availability checks without download or i
   assert.equal(harness.updater.installCalls, 0);
 });
 
-test('automatic update availability is announced without downloading or staging an installer', async () => {
+test('automatic availability check announces an update without downloading it', async () => {
   const harness = createHarness({
-    check: async (updater) => updater.emit('update-available', { version: '2.1.11' })
+    check: async (updater) => updater.emit('update-available', { version: '2.1.14' })
   });
   harness.service.configure();
 
   const result = await harness.service.check({ manual: false });
 
   assert.equal(result.state, 'available');
-  assert.equal(result.version, '2.1.11');
+  assert.equal(result.version, '2.1.14');
   assert.deepEqual(harness.statuses, [{
     state: 'available',
-    message: 'OneStep Money v2.1.11 is available.',
-    currentVersion: '2.1.10',
-    version: '2.1.11'
+    message: 'OneStep Money v2.1.14 is available.',
+    currentVersion: '2.1.13',
+    version: '2.1.14'
   }]);
   assert.equal(harness.updater.downloadCalls, 0);
   assert.equal(harness.updater.installCalls, 0);
 });
 
+test('download starts only after explicit action and reports progress before becoming ready', async () => {
+  const harness = createHarness({
+    download: async (updater) => {
+      updater.emit('download-progress', { percent: 47.6 });
+      updater.emit('update-downloaded', { version: '2.1.14', downloadedFile: '/private/cache/update.exe' });
+      return ['/private/cache/update.exe'];
+    }
+  });
+  harness.service.configure();
+  harness.updater.emit('update-available', { version: '2.1.14' });
+  harness.statuses.length = 0;
+
+  const result = await harness.service.downloadAvailableUpdate();
+
+  assert.equal(harness.updater.downloadCalls, 1);
+  assert.deepEqual(harness.statuses.map((status) => status.state), ['downloading', 'downloading', 'ready']);
+  assert.equal(harness.statuses[1].percent, 47.6);
+  assert.equal(result.state, 'ready');
+  assert.equal(result.version, '2.1.14');
+  assert.equal('downloadedFile' in result, false);
+  assert.equal(harness.updater.installCalls, 0);
+});
+
+test('restart and install is unreachable until the explicit download finishes', async () => {
+  const harness = createHarness({
+    download: async (updater) => updater.emit('update-downloaded', { version: '2.1.14' })
+  });
+  harness.service.configure();
+  harness.updater.emit('update-available', { version: '2.1.14' });
+
+  await assert.rejects(harness.service.restartAndInstall(), /not finished downloading/);
+  assert.equal(harness.updater.installCalls, 0);
+
+  await harness.service.downloadAvailableUpdate();
+  const result = await harness.service.restartAndInstall();
+
+  assert.equal(result.state, 'installing');
+  assert.deepEqual(harness.updater.installArguments, [[false, true]]);
+  assert.equal(harness.updater.installCalls, 1);
+});
+
+test('a previously downloaded update is remembered and cache-validated before later installation', async () => {
+  const harness = createHarness({
+    previouslyDownloadedVersion: '2.1.14',
+    download: async (updater) => updater.emit('update-downloaded', { version: '2.1.14' })
+  });
+  harness.service.configure();
+  harness.updater.emit('update-available', { version: '2.1.14' });
+
+  assert.equal(harness.service.getStatus().state, 'ready');
+  assert.equal(harness.updater.downloadCalls, 0);
+  assert.equal(harness.updater.installCalls, 0);
+
+  const result = await harness.service.restartAndInstall();
+
+  assert.equal(result.state, 'installing');
+  assert.equal(harness.updater.downloadCalls, 1);
+  assert.equal(harness.updater.installCalls, 1);
+  assert.deepEqual(harness.remembered, ['2.1.14']);
+});
+
+test('normal app quit remains unrelated to update installation', async () => {
+  const harness = createHarness();
+  harness.service.configure();
+  harness.updater.emit('update-available', { version: '2.1.14' });
+
+  harness.updater.emit('app-quit');
+
+  assert.equal(harness.updater.autoInstallOnAppQuit, false);
+  assert.equal(harness.updater.installCalls, 0);
+});
+
+test('download failure keeps the available update actionable and records only technical failure detail', async () => {
+  const harness = createHarness({ download: async () => { throw new Error('offline'); } });
+  harness.service.configure();
+  harness.updater.emit('update-available', { version: '2.1.14' });
+  harness.statuses.length = 0;
+
+  await assert.rejects(harness.service.downloadAvailableUpdate(), /offline/);
+
+  assert.equal(harness.updater.downloadCalls, 1);
+  assert.equal(harness.service.getStatus().state, 'available');
+  assert.match(harness.service.getStatus().message, /couldn’t be downloaded/);
+  assert.equal(harness.failures.length, 1);
+  assert.equal(harness.updater.installCalls, 0);
+});
+
 test('automatic current and failure results stay silent while manual checks receive calm feedback', async () => {
   const current = createHarness({
-    check: async (updater) => updater.emit('update-not-available', { version: '2.1.10' })
+    check: async (updater) => updater.emit('update-not-available', { version: '2.1.13' })
   });
   current.service.configure();
   assert.equal((await current.service.check({ manual: false })).state, 'current');
@@ -56,9 +143,9 @@ test('automatic current and failure results stay silent while manual checks rece
   assert.deepEqual(failedManual.statuses.map((status) => status.state), ['checking', 'unavailable']);
 });
 
-test('manual current check reports completion and never uses download states', async () => {
+test('manual current check reports completion without downloading', async () => {
   const harness = createHarness({
-    check: async (updater) => updater.emit('update-not-available', { version: '2.1.10' })
+    check: async (updater) => updater.emit('update-not-available', { version: '2.1.13' })
   });
   harness.service.configure();
 
@@ -66,23 +153,26 @@ test('manual current check reports completion and never uses download states', a
 
   assert.equal(result.state, 'current');
   assert.deepEqual(harness.statuses.map((status) => status.state), ['checking', 'current']);
-  assert.ok(harness.statuses.every((status) => !['downloading', 'ready'].includes(status.state)));
+  assert.equal(harness.updater.downloadCalls, 0);
 });
 
-test('development builds neither schedule nor perform production update checks', async () => {
+test('development builds neither schedule nor perform production update work', async () => {
   const harness = createHarness({ packaged: false });
   harness.service.configure();
   const scheduled = [];
 
   assert.equal(harness.service.scheduleAutomaticCheck(4000, (...args) => scheduled.push(args)), false);
   assert.equal((await harness.service.check({ manual: false })).state, 'development');
+  await assert.rejects(harness.service.downloadAvailableUpdate(), /development mode/);
+  await assert.rejects(harness.service.restartAndInstall(), /development mode/);
   assert.equal(harness.updater.checkCalls, 0);
+  assert.equal(harness.updater.downloadCalls, 0);
   assert.equal(scheduled.length, 0);
 });
 
 test('packaged automatic check is scheduled once after the requested delay', async () => {
   const harness = createHarness({
-    check: async (updater) => updater.emit('update-not-available', { version: '2.1.10' })
+    check: async (updater) => updater.emit('update-not-available', { version: '2.1.13' })
   });
   harness.service.configure();
   let callback;
@@ -93,11 +183,12 @@ test('packaged automatic check is scheduled once after the requested delay', asy
   callback();
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(harness.updater.checkCalls, 1);
+  assert.equal(harness.updater.downloadCalls, 0);
 });
 
 test('prerelease metadata is rejected even if a provider emits it', async () => {
   const harness = createHarness({
-    check: async (updater) => updater.emit('update-available', { version: '2.1.11-beta.1' })
+    check: async (updater) => updater.emit('update-available', { version: '2.1.14-beta.1' })
   });
   harness.service.configure();
 
@@ -107,51 +198,59 @@ test('prerelease metadata is rejected even if a provider emits it', async () => 
   assert.equal(harness.service.availableVersion, null);
   assert.deepEqual(harness.statuses.map((status) => status.state), ['checking', 'unavailable']);
   assert.equal(harness.failures.length, 1);
+  assert.equal(harness.updater.downloadCalls, 0);
 });
 
-test('release opening is built in the service and restricted to the trusted stable tag path', async () => {
+test('release opening remains optional and restricted to the trusted stable tag path', async () => {
   const harness = createHarness();
   harness.service.configure();
-  harness.updater.emit('update-available', { version: '2.1.11' });
+  harness.updater.emit('update-available', { version: '2.1.14' });
 
   const result = await harness.service.openAvailableRelease();
 
-  assert.deepEqual(result, { opened: true, version: '2.1.11' });
-  assert.deepEqual(harness.opened, ['https://github.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.11']);
-  assert.equal(buildTrustedReleaseUrl('v2.1.11'), harness.opened[0]);
+  assert.deepEqual(result, { opened: true, version: '2.1.14' });
+  assert.deepEqual(harness.opened, ['https://github.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.14']);
+  assert.equal(buildTrustedReleaseUrl('v2.1.14'), harness.opened[0]);
   for (const url of [
-    'http://github.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.11',
-    'https://example.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.11',
+    'http://github.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.14',
+    'https://example.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.14',
     'file:///tmp/update.exe',
     'javascript:alert(1)',
-    'https://github.com/cntintheslk-OneStepMoney/onestep-money/releases/download/v2.1.11/update.exe',
-    'https://github.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.11-beta.1'
+    'https://github.com/cntintheslk-OneStepMoney/onestep-money/releases/download/v2.1.14/update.exe',
+    'https://github.com/cntintheslk-OneStepMoney/onestep-money/releases/tag/v2.1.14-beta.1'
   ]) assert.equal(isTrustedReleaseUrl(url), false, url);
 });
 
-function createHarness({ packaged = true, check } = {}) {
-  const updater = new MockUpdater(check);
+function createHarness({ packaged = true, check, download, previouslyDownloadedVersion } = {}) {
+  const updater = new MockUpdater({ check, download });
   const statuses = [];
   const failures = [];
   const opened = [];
+  const remembered = [];
+  let forgotten = 0;
   const service = new SafeUpdateService({
     autoUpdater: updater,
     isPackaged: packaged,
-    getCurrentVersion: () => '2.1.10',
+    getCurrentVersion: () => '2.1.13',
     sendStatus: (status) => statuses.push(status),
     recordFailure: async (error) => failures.push(error),
-    openExternal: async (url) => opened.push(url)
+    openExternal: async (url) => opened.push(url),
+    previouslyDownloadedVersion,
+    rememberDownloadedVersion: async (version) => remembered.push(version),
+    forgetDownloadedVersion: async () => { forgotten += 1; }
   });
-  return { service, updater, statuses, failures, opened };
+  return { service, updater, statuses, failures, opened, remembered, get forgotten() { return forgotten; } };
 }
 
 class MockUpdater extends EventEmitter {
-  constructor(check) {
+  constructor({ check, download }) {
     super();
-    this.check = check || (async (updater) => updater.emit('update-not-available', { version: '2.1.10' }));
+    this.check = check || (async (updater) => updater.emit('update-not-available', { version: '2.1.13' }));
+    this.download = download || (async (updater) => updater.emit('update-downloaded', { version: '2.1.14' }));
     this.checkCalls = 0;
     this.downloadCalls = 0;
     this.installCalls = 0;
+    this.installArguments = [];
   }
 
   async checkForUpdates() {
@@ -161,9 +260,11 @@ class MockUpdater extends EventEmitter {
 
   async downloadUpdate() {
     this.downloadCalls += 1;
+    return this.download(this);
   }
 
-  quitAndInstall() {
+  quitAndInstall(...args) {
     this.installCalls += 1;
+    this.installArguments.push(args);
   }
 }

--- a/tests/update-ui.test.js
+++ b/tests/update-ui.test.js
@@ -5,61 +5,103 @@ import {
   applyUpdateStatus, createUpdateUiState, dismissUpdateNotification, setInstalledVersion, updateUiView
 } from '../update-ui.js';
 
-test('available update shows the popup and persistent installed-version reminder', () => {
-  let state = setInstalledVersion(createUpdateUiState(), '2.1.10');
-  state = applyUpdateStatus(state, { state: 'available', version: '2.1.11', message: 'OneStep Money v2.1.11 is available.' });
+test('available update offers a deliberate download and keeps the GitHub option', () => {
+  let state = setInstalledVersion(createUpdateUiState(), '2.1.13');
+  state = applyUpdateStatus(state, { state: 'available', version: '2.1.14', message: 'OneStep Money v2.1.14 is available.' });
   const view = updateUiView(state);
 
   assert.equal(view.notificationVisible, true);
-  assert.equal(view.notificationMessage, 'OneStep Money v2.1.11 is available.');
-  assert.equal(view.versionLabel, 'v2.1.10 · Update available');
+  assert.equal(view.notificationTitle, 'Update available');
+  assert.equal(view.notificationMessage, 'OneStep Money v2.1.14 is available.');
+  assert.equal(view.versionLabel, 'v2.1.13 · Update available');
+  assert.equal(view.downloadVisible, true);
+  assert.equal(view.installVisible, false);
   assert.equal(view.viewUpdateVisible, true);
+  assert.equal(view.progressVisible, false);
 });
 
-test('dismissal lasts for the session and does not remove the version reminder', () => {
-  let state = setInstalledVersion(createUpdateUiState(), '2.1.10');
-  state = applyUpdateStatus(state, { state: 'available', version: '2.1.11', message: 'OneStep Money v2.1.11 is available.' });
+test('downloading state shows progress and does not expose installation early', () => {
+  let state = setInstalledVersion(createUpdateUiState(), '2.1.13');
+  state = applyUpdateStatus(state, { state: 'available', version: '2.1.14' });
+  state = applyUpdateStatus(state, { state: 'downloading', version: '2.1.14', percent: 63.4, message: 'Downloading…' });
+  const view = updateUiView(state);
+
+  assert.equal(view.notificationTitle, 'Downloading update');
+  assert.equal(view.downloadVisible, false);
+  assert.equal(view.installVisible, false);
+  assert.equal(view.progressVisible, true);
+  assert.equal(view.progressValue, 63.4);
+  assert.equal(view.progressLabel, 'Update download 63% complete');
+});
+
+test('downloaded update stays ready until the user deliberately restarts and installs', () => {
+  let state = setInstalledVersion(createUpdateUiState(), '2.1.13');
+  state = applyUpdateStatus(state, { state: 'available', version: '2.1.14' });
+  state = applyUpdateStatus(state, { state: 'ready', version: '2.1.14', message: 'OneStep Money v2.1.14 is ready to install.' });
+  const view = updateUiView(state);
+
+  assert.equal(view.notificationTitle, 'Ready to install');
+  assert.match(view.notificationMessage, /Restart when you’re ready/);
+  assert.equal(view.versionLabel, 'v2.1.13 · Update ready');
+  assert.equal(view.downloadVisible, false);
+  assert.equal(view.installVisible, true);
+  assert.equal(view.installDisabled, false);
+  assert.equal(view.progressVisible, false);
+});
+
+test('dismissal lasts for the session and does not remove the version reminder or settings actions', () => {
+  let state = setInstalledVersion(createUpdateUiState(), '2.1.13');
+  state = applyUpdateStatus(state, { state: 'available', version: '2.1.14' });
   state = dismissUpdateNotification(state);
-  state = applyUpdateStatus(state, { state: 'available', version: '2.1.11', message: 'OneStep Money v2.1.11 is available.' });
+  state = applyUpdateStatus(state, { state: 'ready', version: '2.1.14' });
   const view = updateUiView(state);
 
   assert.equal(view.notificationVisible, false);
-  assert.equal(view.versionLabel, 'v2.1.10 · Update available');
+  assert.equal(view.versionLabel, 'v2.1.13 · Update ready');
+  assert.equal(view.installVisible, true);
   assert.equal(view.viewUpdateVisible, true);
 });
 
 test('a new application session may show the same outstanding update again', () => {
-  let previousSession = applyUpdateStatus(createUpdateUiState(), { state: 'available', version: '2.1.11' });
+  let previousSession = applyUpdateStatus(createUpdateUiState(), { state: 'available', version: '2.1.14' });
   previousSession = dismissUpdateNotification(previousSession);
   assert.equal(updateUiView(previousSession).notificationVisible, false);
 
-  const nextSession = applyUpdateStatus(createUpdateUiState(), { state: 'available', version: '2.1.11' });
+  const nextSession = applyUpdateStatus(createUpdateUiState(), { state: 'available', version: '2.1.14' });
   assert.equal(updateUiView(nextSession).notificationVisible, true);
 });
 
-test('no-update state leaves the installed version unchanged and failure preserves known availability', () => {
-  let state = setInstalledVersion(createUpdateUiState(), '2.1.10');
+test('no-update state clears actions while failure preserves known availability', () => {
+  let state = setInstalledVersion(createUpdateUiState(), '2.1.13');
   state = applyUpdateStatus(state, { state: 'current', message: 'You’re up to date.' });
   assert.equal(updateUiView(state).notificationVisible, false);
-  assert.equal(updateUiView(state).versionLabel, 'v2.1.10');
+  assert.equal(updateUiView(state).versionLabel, 'v2.1.13');
 
-  state = applyUpdateStatus(state, { state: 'available', version: '2.1.11', message: 'Update available.' });
+  state = applyUpdateStatus(state, { state: 'available', version: '2.1.14', message: 'Update available.' });
   state = applyUpdateStatus(state, { state: 'unavailable', message: 'The update check couldn’t be completed.' });
-  assert.equal(updateUiView(state).versionLabel, 'v2.1.10 · Update available');
+  assert.equal(updateUiView(state).versionLabel, 'v2.1.13 · Update available');
+  assert.equal(updateUiView(state).downloadVisible, true);
 });
 
 test('notification markup and styles preserve accessibility, minimum sizing and reduced motion', () => {
   const html = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
   const css = fs.readFileSync(new URL('../styles.css', import.meta.url), 'utf8');
   const main = fs.readFileSync(new URL('../main-process.js', import.meta.url), 'utf8');
+  const service = fs.readFileSync(new URL('../update-service.js', import.meta.url), 'utf8');
 
   assert.match(html, /aria-label="Dismiss update notification"/);
   assert.match(html, /role="status" aria-live="polite" aria-atomic="true"/);
+  assert.match(html, /data-download-update/);
+  assert.match(html, /data-restart-update/);
   assert.match(html, /data-view-update/);
+  assert.match(html, /<progress[^>]+max="100"/);
   assert.match(css, /padding: 0 18px 18px 0/);
   assert.match(css, /max-width: 340px/);
   assert.match(css, /rgba\(7, 29, 67, 0\.84\)/);
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
   assert.match(css, /\.app-shell\.update-notification-visible/);
-  assert.doesNotMatch(main, /quitAndInstall|downloadUpdate|update:install/);
+  assert.match(main, /update:download/);
+  assert.match(main, /update:restart-and-install/);
+  assert.match(service, /autoDownload = false/);
+  assert.match(service, /autoInstallOnAppQuit = false/);
 });

--- a/update-service.js
+++ b/update-service.js
@@ -24,16 +24,33 @@ export function isTrustedReleaseUrl(value) {
 }
 
 export class SafeUpdateService {
-  constructor({ autoUpdater, isPackaged, getCurrentVersion, sendStatus, recordFailure, openExternal }) {
+  constructor({
+    autoUpdater,
+    isPackaged,
+    getCurrentVersion,
+    sendStatus,
+    recordFailure,
+    openExternal,
+    previouslyDownloadedVersion,
+    rememberDownloadedVersion = () => {},
+    forgetDownloadedVersion = () => {}
+  }) {
     this.autoUpdater = autoUpdater;
     this.isPackaged = Boolean(isPackaged);
     this.getCurrentVersion = getCurrentVersion;
     this.sendStatus = sendStatus;
     this.recordFailure = recordFailure;
     this.openExternal = openExternal;
+    this.previouslyDownloadedVersion = normaliseStableVersion(previouslyDownloadedVersion);
+    this.rememberDownloadedVersion = rememberDownloadedVersion;
+    this.forgetDownloadedVersion = forgetDownloadedVersion;
     this.activeCheck = null;
+    this.activeDownload = null;
     this.availableVersion = null;
+    this.downloadedVersion = null;
+    this.installerPrepared = false;
     this.lastKnownStatus = null;
+    this.installRequested = false;
     this.configured = false;
   }
 
@@ -45,6 +62,8 @@ export class SafeUpdateService {
     this.autoUpdater.allowPrerelease = false;
     this.autoUpdater.on('update-available', (info) => this.handleUpdateAvailable(info));
     this.autoUpdater.on('update-not-available', () => this.handleUpdateNotAvailable());
+    this.autoUpdater.on('download-progress', (progress) => this.handleDownloadProgress(progress));
+    this.autoUpdater.on('update-downloaded', (info) => this.handleUpdateDownloaded(info));
     this.autoUpdater.on('error', (error) => this.handleUpdateError(error));
   }
 
@@ -85,7 +104,7 @@ export class SafeUpdateService {
         if (!check.result) this.lastKnownStatus = status;
         return status;
       } catch (error) {
-        await this.recordCheckFailure(error, check);
+        await this.recordOperationFailure(error, check);
         const status = check.result?.state === 'unavailable'
           ? check.result
           : this.status('unavailable', 'The update check couldn’t be completed.');
@@ -103,6 +122,75 @@ export class SafeUpdateService {
     return check.promise;
   }
 
+  async downloadAvailableUpdate() {
+    if (!this.isPackaged) throw new Error('Updates cannot be downloaded in development mode.');
+    if (!this.availableVersion) throw new Error('There is no available update to download.');
+    if (this.downloadedVersion === this.availableVersion) return this.getStatus();
+    if (this.activeDownload) return this.activeDownload.promise;
+
+    const download = { failurePromise: null, result: null, promise: null };
+    this.activeDownload = download;
+    this.lastKnownStatus = this.status('downloading', `Downloading OneStep Money v${this.availableVersion}…`, {
+      version: this.availableVersion,
+      percent: 0
+    });
+    this.sendStatus(this.lastKnownStatus);
+
+    download.promise = (async () => {
+      try {
+        await this.autoUpdater.downloadUpdate();
+        if (this.downloadedVersion !== this.availableVersion) {
+          this.handleUpdateDownloaded({ version: this.availableVersion });
+        }
+        return this.lastKnownStatus;
+      } catch (error) {
+        await this.recordOperationFailure(error, download);
+        if (!download.result) this.finishDownloadFailure(download);
+        throw error;
+      } finally {
+        if (this.activeDownload === download) this.activeDownload = null;
+      }
+    })();
+
+    return download.promise;
+  }
+
+  async restartAndInstall() {
+    if (!this.isPackaged) throw new Error('Updates cannot be installed in development mode.');
+    if (!this.availableVersion || this.downloadedVersion !== this.availableVersion) {
+      throw new Error('The update has not finished downloading.');
+    }
+    if (this.installRequested) return this.lastKnownStatus;
+
+    this.installRequested = true;
+    if (!this.installerPrepared) {
+      this.lastKnownStatus = this.status('downloading', `Preparing OneStep Money v${this.availableVersion} for installation…`, {
+        version: this.availableVersion,
+        percent: 100
+      });
+      this.sendStatus(this.lastKnownStatus);
+      try {
+        await this.autoUpdater.downloadUpdate();
+        if (!this.installerPrepared) throw new Error('The cached update could not be prepared for installation.');
+      } catch (error) {
+        this.installRequested = false;
+        await this.recordOperationFailure(error);
+        this.lastKnownStatus = this.status('ready', 'The downloaded update could not be prepared. Choose Restart and install to try again.', {
+          version: this.availableVersion
+        });
+        this.sendStatus(this.lastKnownStatus);
+        throw error;
+      }
+    }
+
+    this.lastKnownStatus = this.status('installing', `Restarting to install OneStep Money v${this.availableVersion}…`, {
+      version: this.availableVersion
+    });
+    this.sendStatus(this.lastKnownStatus);
+    this.autoUpdater.quitAndInstall(false, true);
+    return this.lastKnownStatus;
+  }
+
   async openAvailableRelease() {
     const url = buildTrustedReleaseUrl(this.availableVersion);
     if (!isTrustedReleaseUrl(url)) throw new TypeError('The update release destination is not trusted.');
@@ -112,17 +200,25 @@ export class SafeUpdateService {
 
   getStatus() {
     if (!this.isPackaged) return this.status('development', 'Updates are disabled in development mode.');
+    if (['downloading', 'installing'].includes(this.lastKnownStatus?.state) && this.lastKnownStatus.version === this.availableVersion) {
+      return this.lastKnownStatus;
+    }
+    if (this.downloadedVersion && this.downloadedVersion === this.availableVersion) {
+      if (this.lastKnownStatus?.state === 'ready' && this.lastKnownStatus.version === this.downloadedVersion) return this.lastKnownStatus;
+      return this.status('ready', `OneStep Money v${this.downloadedVersion} is ready to install.`, { version: this.downloadedVersion });
+    }
     if (this.availableVersion) {
+      if (this.lastKnownStatus?.state === 'available' && this.lastKnownStatus.version === this.availableVersion) return this.lastKnownStatus;
       return this.status('available', `OneStep Money v${this.availableVersion} is available.`, { version: this.availableVersion });
     }
-    return this.lastKnownStatus || this.status('idle', 'Updates are checked automatically. OneStep never downloads or installs them.');
+    return this.lastKnownStatus || this.status('idle', 'Updates are checked automatically. Downloads and installation only start when you choose.');
   }
 
   handleUpdateAvailable(info = {}) {
     const version = normaliseStableVersion(info.version);
     if (!version) {
       const error = new TypeError('Update metadata did not contain a stable semantic version.');
-      this.recordCheckFailure(error);
+      this.recordOperationFailure(error, this.activeCheck);
       const status = this.status('unavailable', 'The update check couldn’t be completed.');
       if (this.activeCheck) {
         this.activeCheck.result = status;
@@ -134,8 +230,15 @@ export class SafeUpdateService {
       return;
     }
 
+    if (this.availableVersion !== version) {
+      this.downloadedVersion = this.previouslyDownloadedVersion === version ? version : null;
+      this.installerPrepared = false;
+      if (this.previouslyDownloadedVersion && this.previouslyDownloadedVersion !== version) this.forgetRememberedDownload();
+    }
     this.availableVersion = version;
-    const status = this.status('available', `OneStep Money v${version} is available.`, { version });
+    const status = this.downloadedVersion === version
+      ? this.status('ready', `OneStep Money v${version} is ready to install.`, { version })
+      : this.status('available', `OneStep Money v${version} is available.`, { version });
     this.lastKnownStatus = status;
     if (this.activeCheck) this.activeCheck.result = status;
     this.sendStatus(status);
@@ -143,6 +246,9 @@ export class SafeUpdateService {
 
   handleUpdateNotAvailable() {
     this.availableVersion = null;
+    this.downloadedVersion = null;
+    this.installerPrepared = false;
+    this.forgetRememberedDownload();
     const status = this.status('current', 'You’re up to date.');
     this.lastKnownStatus = status;
     if (this.activeCheck) {
@@ -151,24 +257,78 @@ export class SafeUpdateService {
     }
   }
 
+  handleDownloadProgress(progress = {}) {
+    if (!this.activeDownload || !this.availableVersion) return;
+    const percent = clampPercent(progress.percent);
+    this.lastKnownStatus = this.status('downloading', `Downloading OneStep Money v${this.availableVersion}… ${Math.round(percent)}%`, {
+      version: this.availableVersion,
+      percent
+    });
+    this.sendStatus(this.lastKnownStatus);
+  }
+
+  handleUpdateDownloaded(info = {}) {
+    const version = normaliseStableVersion(info.version) || this.availableVersion;
+    if (!version || version !== this.availableVersion) return;
+    this.downloadedVersion = version;
+    this.installerPrepared = true;
+    this.previouslyDownloadedVersion = version;
+    Promise.resolve(this.rememberDownloadedVersion(version)).catch(() => {});
+    const status = this.status('ready', `OneStep Money v${version} is ready to install.`, { version });
+    this.lastKnownStatus = status;
+    if (this.activeDownload) this.activeDownload.result = status;
+    this.sendStatus(status);
+  }
+
   handleUpdateError(error) {
-    this.recordCheckFailure(error);
+    const operation = this.activeDownload || this.activeCheck;
+    this.recordOperationFailure(error, operation);
+    if (this.activeDownload && !this.activeDownload.result) {
+      this.finishDownloadFailure(this.activeDownload);
+      return;
+    }
+    if (this.installRequested && this.availableVersion) {
+      this.installRequested = false;
+      this.lastKnownStatus = this.status('ready', 'The update could not be installed. You can try again when ready.', { version: this.availableVersion });
+      this.sendStatus(this.lastKnownStatus);
+      return;
+    }
     if (this.activeCheck && !this.activeCheck.result) {
       this.activeCheck.result = this.status('unavailable', 'The update check couldn’t be completed.');
       if (this.activeCheck.manual) this.lastKnownStatus = this.activeCheck.result;
     }
   }
 
-  recordCheckFailure(error, check = this.activeCheck) {
-    if (check?.failurePromise) return check.failurePromise;
+  finishDownloadFailure(download) {
+    const status = this.status('available', 'The update couldn’t be downloaded. Check your connection and try again.', {
+      version: this.availableVersion
+    });
+    download.result = status;
+    this.lastKnownStatus = status;
+    this.sendStatus(status);
+  }
+
+  recordOperationFailure(error, operation) {
+    if (operation?.failurePromise) return operation.failurePromise;
     const failurePromise = Promise.resolve(this.recordFailure(error)).catch(() => {});
-    if (check) check.failurePromise = failurePromise;
+    if (operation) operation.failurePromise = failurePromise;
     return failurePromise;
+  }
+
+  forgetRememberedDownload() {
+    this.previouslyDownloadedVersion = null;
+    Promise.resolve(this.forgetDownloadedVersion()).catch(() => {});
   }
 
   status(state, message, extra = {}) {
     return { state, message, currentVersion: this.getCurrentVersion(), ...extra };
   }
+}
+
+function clampPercent(value) {
+  const percent = Number(value);
+  if (!Number.isFinite(percent)) return 0;
+  return Math.min(100, Math.max(0, percent));
 }
 
 function escapeRegExp(value) {

--- a/update-ui.js
+++ b/update-ui.js
@@ -4,9 +4,11 @@ export function createUpdateUiState() {
   return {
     installedVersion: '',
     availableVersion: '',
+    downloadedVersion: '',
+    downloadPercent: 0,
     notificationDismissed: false,
     statusState: 'idle',
-    statusMessage: 'Updates are checked automatically. OneStep never downloads or installs them.'
+    statusMessage: 'Updates are checked automatically. Downloads and installation only start when you choose.'
   };
 }
 
@@ -16,17 +18,29 @@ export function setInstalledVersion(state, value) {
 }
 
 export function applyUpdateStatus(state, status = {}) {
+  const statusState = String(status.state || 'idle');
   const next = {
     ...state,
-    statusState: String(status.state || 'idle'),
+    statusState,
     statusMessage: String(status.message || 'Update status unavailable.')
   };
 
-  if (next.statusState === 'available') {
+  if (['available', 'downloading', 'ready', 'installing'].includes(statusState)) {
     const version = normaliseVersion(status.version);
-    if (version) next.availableVersion = version;
-  } else if (next.statusState === 'current') {
+    if (version && version !== next.availableVersion) {
+      next.availableVersion = version;
+      next.downloadedVersion = '';
+      next.downloadPercent = 0;
+    }
+    if (statusState === 'downloading') next.downloadPercent = clampPercent(status.percent);
+    if (statusState === 'ready' && version) {
+      next.downloadedVersion = version;
+      next.downloadPercent = 100;
+    }
+  } else if (statusState === 'current') {
     next.availableVersion = '';
+    next.downloadedVersion = '';
+    next.downloadPercent = 0;
   }
 
   return next;
@@ -38,19 +52,47 @@ export function dismissUpdateNotification(state) {
 
 export function updateUiView(state) {
   const hasUpdate = Boolean(state.availableVersion);
+  const updateReady = hasUpdate && state.downloadedVersion === state.availableVersion;
+  const downloading = hasUpdate && state.statusState === 'downloading';
+  const installing = hasUpdate && state.statusState === 'installing';
   const installedLabel = state.installedVersion ? `v${state.installedVersion}` : 'Version unavailable';
+  const versionSuffix = updateReady ? 'Update ready' : hasUpdate ? 'Update available' : '';
+  const notificationTitle = installing ? 'Restarting to install' : updateReady ? 'Ready to install' : downloading ? 'Downloading update' : 'Update available';
+
   return {
-    versionLabel: hasUpdate ? `${installedLabel} · Update available` : installedLabel,
-    versionAriaLabel: hasUpdate ? `OneStep Money ${installedLabel}. Update available.` : `OneStep Money ${installedLabel}.`,
+    versionLabel: versionSuffix ? `${installedLabel} · ${versionSuffix}` : installedLabel,
+    versionAriaLabel: versionSuffix ? `OneStep Money ${installedLabel}. ${versionSuffix}.` : `OneStep Money ${installedLabel}.`,
     notificationVisible: hasUpdate && !state.notificationDismissed,
-    notificationMessage: hasUpdate ? `OneStep Money v${state.availableVersion} is available.` : '',
+    notificationTitle,
+    notificationMessage: hasUpdate
+      ? installing
+        ? `OneStep is restarting to install v${state.availableVersion}.`
+        : updateReady
+        ? `OneStep Money v${state.availableVersion} has downloaded. Restart when you’re ready to install it.`
+        : downloading
+          ? `OneStep Money v${state.availableVersion} is downloading. You can keep using the app.`
+          : `OneStep Money v${state.availableVersion} is available.`
+      : '',
     settingsStatus: state.statusMessage,
-    checkDisabled: state.statusState === 'checking',
-    viewUpdateVisible: hasUpdate
+    checkDisabled: ['checking', 'downloading', 'installing'].includes(state.statusState),
+    downloadVisible: hasUpdate && !updateReady && !downloading,
+    downloadDisabled: installing,
+    installVisible: updateReady,
+    installDisabled: installing,
+    viewUpdateVisible: hasUpdate,
+    progressVisible: downloading,
+    progressValue: state.downloadPercent,
+    progressLabel: `Update download ${Math.round(state.downloadPercent)}% complete`
   };
 }
 
 function normaliseVersion(value) {
   const version = String(value || '').trim().replace(/^v/i, '');
   return STABLE_VERSION_PATTERN.test(version) ? version : '';
+}
+
+function clampPercent(value) {
+  const percent = Number(value);
+  if (!Number.isFinite(percent)) return 0;
+  return Math.min(100, Math.max(0, percent));
 }


### PR DESCRIPTION
### Purpose

The v2.1.10 updater deliberately stopped all in-app downloading and installation, leaving GitHub as the only route to obtain an update. This branch adds a user-controlled in-app update path for v2.1.13 while preserving the local-first safety boundary: OneStep may check automatically, but downloading begins only after an explicit user action and installation begins only after a separate Restart and install action.

### Work completed

#### User-controlled update lifecycle

- Retained automatic stable-release availability checking after application startup.
- Kept `autoUpdater.autoDownload = false`, `autoUpdater.autoInstallOnAppQuit = false`, and `allowPrerelease = false`.
- Added an explicit Download update action that invokes `autoUpdater.downloadUpdate()` only after the user selects it.
- Added download-progress handling with bounded percentage values and calm failure recovery.
- Added a ready state after the matching stable version has downloaded.
- Added a separate Restart and install action that remains unreachable until the matching update is ready.
- Added duplicate-action guards so repeated clicks cannot start concurrent downloads or installations.
- Kept an ordinary application quit unrelated to update installation.
- Retained View on GitHub as an optional alternative using the existing trusted stable release URL.

#### Restart persistence

- Added a minimal local `pending-update.json` marker in Electron userData after a completed download.
- The marker contains only the stable version string; it contains no financial or identifying data.
- On a later launch, OneStep revalidates/prepares the cached update through electron-updater before installation.
- Stale markers are removed when the release is no longer available or a different stable version supersedes it.

#### Renderer and Settings UI

- Added Download update and Restart and install controls to the existing update notification and Settings panel.
- Added an accessible progress element to both locations.
- Changed notification copy and the bottom-left version indicator across available, downloading, ready, and installing states.
- Preserved session-only popup dismissal while keeping update actions available in Settings.
- Kept the existing semi-transparent, responsive notification safe area and reduced-motion behaviour.

#### IPC and security

- Added narrow, argument-free `update:download` and `update:restart-and-install` IPC routes.
- Exposed only matching no-argument preload methods.
- Did not expose updater objects, filesystem paths, installer paths, or arbitrary external URLs to the renderer.
- Retained the trusted HTTPS GitHub stable-tag validation for View on GitHub.

#### Tests

- Extended updater service tests for explicit-download gating, progress, ready state, install gating, restart persistence, failure recovery, normal quit behaviour, automatic-check silence, prerelease rejection, development mode, and trusted release navigation.
- Extended preload tests for the two narrow IPC methods.
- Extended UI tests for download/progress/ready/install states, dismissal, Settings availability, accessibility, responsive styling, and reduced motion.

### Files changed

- `index.html` — adds update download, progress, restart/install, and GitHub controls to the notification and Settings panel.
- `main-process.js` — wires the version-only pending-update marker and the narrow download/install IPC handlers.
- `package.json` — updates the application version from 2.1.12 to 2.1.13.
- `package-lock.json` — updates the root package and lockfile version to 2.1.13.
- `preload-bridge.cjs` — exposes argument-free download and restart/install updater methods.
- `renderer-app.js` — handles user actions, progress/error states, and renders the expanded updater state.
- `styles.css` — styles accessible progress and action controls within the existing responsive notification.
- `update-service.js` — implements explicit download, progress, ready, restart/install, persistence, concurrency, and error handling.
- `update-ui.js` — expands the renderer state model to available, downloading, ready, and installing.
- `tests/preload-bridge.test.js` — verifies the new preload routes and continued absence of arbitrary external navigation.
- `tests/update-service.test.js` — adds updater lifecycle and safety regressions.
- `tests/update-ui.test.js` — adds UI state, accessibility, dismissal, and responsive regressions.

No files were added, renamed, or deleted.

### User-facing changes

- OneStep still checks quietly for a newer stable version after startup.
- An available update now offers both Download update and View on GitHub.
- Downloading starts only after Download update is selected.
- Progress is shown inside OneStep while the app remains usable.
- After completion, the action changes to Restart and install.
- Installation and restart occur only after that separate action is selected.
- Closing OneStep normally never installs a downloaded update.
- Automatic check failures remain silent; explicit check or download failures receive restrained feedback.
- A downloaded update can remain ready across an application restart.

### Technical changes

- electron-updater remains at `^6.8.9`; no dependency was added, removed, or upgraded.
- Automatic download and install-on-quit remain disabled.
- The updater state model is now `idle | checking | current | available | unavailable | development | downloading | ready | installing`.
- Main-process IPC remains narrow and renderer arguments are not accepted for download, installation, or release navigation.
- The external release destination remains constructed and validated in the main process.
- Downloaded installer paths are never sent to the renderer.
- Update traffic remains limited to existing trusted release metadata and user-requested release artefacts.
- No telemetry, analytics, cloud storage, tracking identifier, or financial-data networking was introduced.

### Testing and verification

- **Passed** — `npm test`: 141/141 tests, including updater, preload/IPC, UI, Statement Intelligence, document deduplication, data integrity, backup/restore, financial safety, imports, diagnostics, privacy, and Windows fsync regressions.
- **Passed** — `npm run check`: project validation across 30 JavaScript files; package/version validation reported 2.1.13.
- **Passed** — privacy validation across 44 files.
- **Passed** — `node --check` for updater service, renderer, main process, and updater tests.
- **Passed** — `git diff --check origin/main...HEAD`.
- **Passed** — committed-content secret-pattern scan; no credentials or private keys found.
- **Passed** — Windows x64 unpacked production build via `electron-builder --win dir --x64`.
- **Passed** — packaged ASAR inspection: version is 2.1.13 and packaged updater source matches the tested source with automatic download/install disabled.
- **Failed (environment)** — full NSIS installer generation reached installer creation but `wine` is unavailable in this Linux environment (`spawn wine ENOENT`).
- **Unavailable (environment)** — graphical Electron capture/live UI interaction; GTK cannot create a display connection in this headless container. Electron initialised local storage and reached window creation before the display boundary.
- **Unavailable (environment)** — live Windows execution, online release download, offline packaged startup, actual installer restart, minimum-window interaction, and system-browser opening require a Windows graphical environment and a newer published test release.
- **Unavailable (not configured)** — separate lint and type-check scripts are not present in the project.

### Data and migration impact

No financial-data or storage-schema migration.

- Financial state, accounts, debts, overdrafts, transactions, import batches, document vaults, backups, and restores are unchanged.
- Existing v2.1.12 data remains compatible.
- The only new runtime file is an optional version-only `pending-update.json` marker in Electron userData after a successful user-requested download.
- The marker contains no financial data and is not included in the financial state or backup format.

### Known limitations

- Final NSIS generation and live Windows updater installation could not be exercised in this Linux environment because Wine and a Windows graphical runtime are unavailable.
- End-to-end update download/install must be verified from an installed v2.1.13 build after a newer stable release with valid GitHub release metadata is published.
- The updater continues to depend on the existing GitHub release metadata and electron-updater cache behaviour.

### Excluded work

- Automatic update downloads.
- Automatic installation or install-on-quit.
- Silent restart.
- Prerelease/development channel updates.
- Custom update servers.
- Telemetry or analytics.
- Code signing and broader release-engineering redesign.
- Financial-data, document, backup, restore, Statement Intelligence, Credit Report Intelligence, dashboard, and roadmap changes.

### Branch details

- Branch: `feature/in-app-updates`
- Commit SHA: `acc406efae72fc4ba579a974a0b090a04a91a6b9`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/16
- Target branch: `main`

### Confirmations

- No changes were committed or pushed directly to `main`.
- The pull request has not been merged.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs were committed.
- No analytics or telemetry was introduced.
- Only files relevant to v2.1.13 user-controlled in-app updates were changed.
