### PR TITLE
[v2.1.15][Bug] Budget and Payments synchronisation

### DIFF
--- a/finance-core.js
+++ b/finance-core.js
@@ -50,23 +50,130 @@ export function calculatePeriodSummary(state, month = state.settings?.selectedMo
   const plannedSpending = roundMoney((state.budgets || []).reduce((total, budget) => total + Number(budget.planned || 0), 0));
   const dependableIncome = Number(state.profile?.dependableIncome || 0);
   const plannedMargin = roundMoney(dependableIncome - plannedSpending);
+  const budget = calculateBudgetAnalysis(state, month);
   const overdrafts = sum(state.overdrafts, 'currentBalance');
   const debts = sum(state.debts, 'currentBalance');
   return {
     month, income, spending, netCashFlow: roundMoney(income - spending),
     grossPay, payrollDeductions, netPay, dependableIncome, plannedSpending, plannedMargin,
+    budgetActualSpending: budget.actual, budgetCategorisedSpending: budget.categorisedActual,
+    budgetUncategorisedSpending: budget.uncategorisedActual, budgetRemaining: budget.remaining,
     debts, overdrafts, totalOwed: roundMoney(debts + overdrafts), transactionCount: rows.length
   };
 }
 
 export function calculateBudgetRows(state, month = state.settings?.selectedMonth) {
-  const rows = periodTransactions(state.transactions, month).filter((transaction) => transaction.transferStatus !== 'confirmed');
-  return (state.budgets || []).map((budget) => {
-    const categories = (budget.categories?.length ? budget.categories : [budget.category]).map(normalise);
-    const terms = (budget.merchantTerms || []).map(normalise);
-    const actual = roundMoney(rows.filter((transaction) => transaction.outgoing > 0 && (categories.includes(normalise(transaction.category)) || terms.some((term) => normalise(transaction.description).includes(term)))).reduce((total, transaction) => total + transaction.outgoing, 0));
-    return { ...budget, actual, remaining: roundMoney(Number(budget.planned || 0) - actual) };
+  return calculateBudgetAnalysis(state, month).rows;
+}
+
+export function calculateBudgetAnalysis(state, month = state.settings?.selectedMonth) {
+  const budgets = state.budgets || [];
+  const transactions = periodTransactions(state.transactions, month);
+  const budgetsById = new Map(budgets.map((budget) => [String(budget.id), budget]));
+  const transactionsById = new Map(transactions.map((transaction) => [String(transaction.id), transaction]));
+  const actualPennies = new Map(budgets.map((budget) => [String(budget.id), 0]));
+  const contributions = new Map(budgets.map((budget) => [String(budget.id), []]));
+  const assignmentCache = new Map();
+  const uncategorisedTransactionIds = [];
+  let uncategorisedPennies = 0;
+  let categorisedGrossPennies = 0;
+  let eligibleGrossPennies = 0;
+
+  const assignedBudget = (transaction, visited = new Set()) => {
+    const transactionId = String(transaction?.id || '');
+    if (transactionId && assignmentCache.has(transactionId)) return assignmentCache.get(transactionId);
+    if (!transaction || visited.has(transactionId)) return null;
+    visited.add(transactionId);
+
+    const explicit = transaction.budgetCategoryId && budgetsById.get(String(transaction.budgetCategoryId));
+    if (explicit) {
+      if (transactionId) assignmentCache.set(transactionId, explicit);
+      return explicit;
+    }
+    if (transaction.categorySource === 'manual') {
+      if (transactionId) assignmentCache.set(transactionId, null);
+      return null;
+    }
+
+    const linkedId = transaction.refundOfTransactionId || transaction.reversalOfTransactionId;
+    const linked = linkedId ? transactionsById.get(String(linkedId)) : null;
+    if (linked) {
+      const linkedBudget = assignedBudget(linked, visited);
+      if (transactionId) assignmentCache.set(transactionId, linkedBudget);
+      return linkedBudget;
+    }
+
+    const category = normalise(transaction.category);
+    const description = normalise(transaction.description);
+    const matches = budgets.filter((budget) => {
+      const categories = (budget.categories?.length ? budget.categories : [budget.category]).map(normalise);
+      const terms = (budget.merchantTerms || []).map(normalise).filter(Boolean);
+      return (category && categories.includes(category)) || (Number(transaction.outgoing || 0) > 0 && terms.some((term) => description.includes(term)));
+    });
+    const match = matches.length === 1 ? matches[0] : null;
+    if (transactionId) assignmentCache.set(transactionId, match);
+    return match;
+  };
+
+  for (const transaction of transactions) {
+    if (!isBudgetTransactionActive(transaction)) continue;
+    const treatment = normaliseBudgetTreatment(transaction.budgetTreatment);
+    if (transaction.transferStatus === 'confirmed' || ['transfer', 'savings_transfer', 'ignored'].includes(treatment)) continue;
+
+    const outgoingPennies = Math.max(0, moneyToPennies(transaction.outgoing));
+    const incomingPennies = Math.max(0, moneyToPennies(transaction.incoming));
+    const budget = assignedBudget(transaction);
+    const isDebtPayment = treatment === 'debt_payment' || /^(?:debt|credit card|loan|finance) payment$/.test(normalise(transaction.category));
+    if (isDebtPayment && !budget) continue;
+
+    if (outgoingPennies > 0) {
+      eligibleGrossPennies += outgoingPennies;
+      if (budget) {
+        const id = String(budget.id);
+        actualPennies.set(id, (actualPennies.get(id) || 0) + outgoingPennies);
+        categorisedGrossPennies += outgoingPennies;
+        contributions.get(id).push(budgetContribution(transaction, outgoingPennies));
+      } else {
+        uncategorisedPennies += outgoingPennies;
+        uncategorisedTransactionIds.push(transaction.id);
+      }
+    }
+
+    const isRefund = ['refund', 'reversal'].includes(treatment)
+      || Boolean(transaction.refundOfTransactionId || transaction.reversalOfTransactionId)
+      || Boolean(budget && incomingPennies > 0);
+    if (incomingPennies > 0 && isRefund && budget) {
+      const id = String(budget.id);
+      actualPennies.set(id, (actualPennies.get(id) || 0) - incomingPennies);
+      contributions.get(id).push(budgetContribution(transaction, -incomingPennies));
+    }
+  }
+
+  const rows = budgets.map((budget) => {
+    const plannedPennies = moneyToPennies(budget.planned);
+    const actual = penniesToMoney(actualPennies.get(String(budget.id)) || 0);
+    const planned = penniesToMoney(plannedPennies);
+    const remaining = penniesToMoney(plannedPennies - moneyToPennies(actual));
+    return {
+      ...budget, planned, actual, remaining,
+      progressPercent: plannedPennies > 0 ? Math.max(0, Math.round(((actualPennies.get(String(budget.id)) || 0) / plannedPennies) * 100)) : null,
+      contributions: contributions.get(String(budget.id)) || []
+    };
   });
+  const plannedPennies = rows.reduce((total, row) => total + moneyToPennies(row.planned), 0);
+  const categorisedPennies = rows.reduce((total, row) => total + moneyToPennies(row.actual), 0);
+  const totalActualPennies = categorisedPennies + uncategorisedPennies;
+  return {
+    month,
+    rows,
+    planned: penniesToMoney(plannedPennies),
+    categorisedActual: penniesToMoney(categorisedPennies),
+    uncategorisedActual: penniesToMoney(uncategorisedPennies),
+    actual: penniesToMoney(totalActualPennies),
+    remaining: penniesToMoney(plannedPennies - totalActualPennies),
+    coveragePercent: eligibleGrossPennies > 0 ? Math.round((categorisedGrossPennies / eligibleGrossPennies) * 100) : 100,
+    uncategorisedTransactionIds
+  };
 }
 
 export function buildNextAction(state, now = new Date()) {
@@ -716,6 +823,35 @@ function csvCell(value) {
   let text = String(value ?? '');
   if (/^[=+\-@]/.test(text)) text = `'${text}`;
   return `"${text.replace(/"/g, '""')}"`;
+}
+
+function isBudgetTransactionActive(transaction) {
+  return !transaction.deletedAt
+    && transaction.ignored !== true
+    && transaction.valid !== false
+    && transaction.duplicateStatus !== 'exact';
+}
+
+function normaliseBudgetTreatment(value) {
+  const treatment = String(value || 'auto').trim().toLowerCase();
+  return ['auto', 'spending', 'refund', 'reversal', 'transfer', 'savings_transfer', 'debt_payment', 'ignored'].includes(treatment) ? treatment : 'auto';
+}
+
+function budgetContribution(transaction, pennies) {
+  return {
+    id: transaction.id,
+    date: transaction.date,
+    description: transaction.userDescription || transaction.description || 'Payment',
+    amount: penniesToMoney(pennies)
+  };
+}
+
+function moneyToPennies(value) {
+  return Math.round((Number(value || 0) + Number.EPSILON) * 100);
+}
+
+function penniesToMoney(value) {
+  return Number(value || 0) / 100;
 }
 
 function normalise(value) {

--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
             <label>Search<input id="transactionSearch" type="search" placeholder="Merchant, category or note" /></label>
             <label>Account<select id="transactionAccountFilter"><option value="all">All accounts</option></select></label>
             <label>Type<select id="transactionTypeFilter"><option value="all">All</option><option value="incoming">Incoming</option><option value="outgoing">Outgoing</option><option value="transfer">Transfers</option></select></label>
+            <label>Budget category<select id="transactionCategoryFilter"><option value="all">All categories</option><option value="uncategorised">Uncategorised</option></select></label>
           </div>
           <div class="table-wrap"><table><thead><tr><th>Date</th><th>Account</th><th>Description</th><th>Incoming</th><th>Outgoing</th><th>Balance</th><th>Notes</th><th><span class="sr-only">Edit</span></th></tr></thead><tbody id="transactionRows"></tbody></table></div>
           <p id="transactionCount" class="table-caption"></p>
@@ -135,7 +136,8 @@
 
         <section id="view-budget" class="view" hidden>
           <div class="section-actions"><div><h2>Simple monthly plan</h2><p>Dependable income first. Variable income stays separate until it arrives.</p></div><button class="primary-button" data-add="budget">Add budget item</button></div>
-          <article class="panel budget-summary"><div><span>Dependable income</span><strong id="budgetIncomeValue">£0.00</strong></div><div><span>Planned spending</span><strong id="plannedSpendingValue">£0.00</strong></div><div><span>Entered money left</span><strong id="budgetMarginValue">£0.00</strong></div></article>
+          <article class="panel budget-summary"><div><span>Dependable income</span><strong id="budgetIncomeValue">£0.00</strong></div><div><span>Planned</span><strong id="plannedSpendingValue">£0.00</strong></div><div><span>Spent</span><strong id="actualSpendingValue">£0.00</strong></div><div><span>Remaining plan</span><strong id="budgetRemainingValue">£0.00</strong></div></article>
+          <article id="uncategorisedBudgetNotice" class="panel budget-notice" hidden><div><strong><span id="uncategorisedBudgetValue">£0.00</span> needs categorising</strong><span id="budgetCoverageValue">100% of outgoing spending categorised</span></div><button id="reviewUncategorisedButton" class="secondary-button" type="button">Review payments</button></article>
           <div class="two-column budget-layout"><article class="panel"><h2>Plan versus actual</h2><div id="budgetRows" class="budget-list"></div></article><article class="panel"><h2>Penny-pinching ideas</h2><p class="muted">Based on your own imported spending. Review one item at a time.</p><div id="savingsIdeas" class="checks-list"></div></article></div>
         </section>
 

--- a/local-llm-service.js
+++ b/local-llm-service.js
@@ -1,4 +1,4 @@
-import { debtPlan } from './finance-core.js';
+import { calculateBudgetAnalysis, debtPlan } from './finance-core.js';
 
 const OLLAMA_URL = 'http://127.0.0.1:11434/api/chat';
 
@@ -45,7 +45,8 @@ function financialSnapshot(state) {
   const monthRows = (state.transactions || []).filter((item) => String(item.budgetMonth || item.date).startsWith(month) && item.transferStatus !== 'confirmed');
   const incoming = money(monthRows.reduce((sum, item) => sum + Number(item.incoming || 0), 0));
   const outgoing = money(monthRows.reduce((sum, item) => sum + Number(item.outgoing || 0), 0));
-  const budgets = (state.budgets || []).map((item) => `${item.category}: planned ${money(item.planned)}`).join('; ');
+  const budgetAnalysis = calculateBudgetAnalysis(state, month);
+  const budgets = budgetAnalysis.rows.map((item) => `${item.category}: planned ${money(item.planned)}, spent ${money(item.actual)}, remaining ${money(item.remaining)}`).join('; ');
   const debts = (state.debts || []).map((item) => `${item.name}: balance ${money(item.currentBalance)}, APR ${item.apr == null ? 'unknown' : `${(item.apr * 100).toFixed(2)}%`}, contractual payment ${knownMoney(item.contractualPayment)}, status ${item.status || 'unknown'}, arrangement ${item.arrangementStatus || 'unknown'}, arrangement payment ${knownMoney(item.arrangementPayment)}, status conflict ${item.statusConflict ? 'yes' : 'no'}, interest frozen ${item.interestFrozen ? 'yes' : 'no'}`).join('\n');
   const overdrafts = (state.overdrafts || []).map((item) => `${item.name}: used ${money(item.currentBalance)}, limit ${knownMoney(item.limit)}, APR ${item.apr == null ? 'unknown' : `${(item.apr * 100).toFixed(2)}%`}, contractual payment ${knownMoney(item.contractualPayment)}, status ${item.status || 'unknown'}, arrangement ${item.arrangementStatus || 'unknown'}, arrangement payment ${knownMoney(item.arrangementPayment)}, status conflict ${item.statusConflict ? 'yes' : 'no'}`).join('\n');
   return [
@@ -56,6 +57,7 @@ function financialSnapshot(state) {
     `Starter buffer: ${money(state.settings?.emergencyBufferBalance)} of ${money(state.settings?.emergencyBufferTarget)}`,
     `Planned extra debt payment: ${money(state.settings?.extraDebtPayment)}`,
     `Budgets: ${budgets}`,
+    `Uncategorised spending: ${money(budgetAnalysis.uncategorisedActual)}; categorisation coverage ${budgetAnalysis.coveragePercent}%.`,
     `Debts:\n${debts}`,
     `Overdrafts:\n${overdrafts}`,
     `Financial-safety result: ${plan.overpaymentStatus}; requested optional payment ${money(plan.requestedExtraPayment)}; safely included optional payment ${money(plan.safeExtraPayment)}.`,

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -1,5 +1,5 @@
 import {
-  availableReportingMonths, buildFallbackAnswer, buildFinancialChecks, buildNextAction, calculateBudgetRows,
+  availableReportingMonths, buildFallbackAnswer, buildFinancialChecks, buildNextAction, calculateBudgetAnalysis,
   calculatePeriodSummary, calculateStreak, createId, debtPlan, exportTransactionsCsv,
   findSavingsOpportunities, formatCurrency, formatDate, hasCompletedCheckIn
 } from './finance-core.js';
@@ -78,6 +78,7 @@ function activateNormalMode(loaded) {
   }
   populateMonthOptions();
   populateAccountOptions();
+  populateBudgetCategoryOptions();
   render();
   checkModel();
 }
@@ -284,12 +285,17 @@ function bindEvents() {
     const saved = await window.financeAPI.exportCsv(exportTransactionsCsv(state.transactions));
     if (saved) showToast('Payments exported safely.');
   });
-  [byId('transactionSearch'), byId('transactionAccountFilter'), byId('transactionTypeFilter')].forEach((element) => element.addEventListener('input', renderTransactions));
+  [byId('transactionSearch'), byId('transactionAccountFilter'), byId('transactionTypeFilter'), byId('transactionCategoryFilter')].forEach((element) => element.addEventListener('input', renderTransactions));
   document.querySelectorAll('[data-add]').forEach((button) => button.addEventListener('click', () => openEditor(button.dataset.add)));
   byId('transactionRows').addEventListener('click', handleEditClick);
   byId('debtCards').addEventListener('click', handleEditClick);
   byId('overdraftCards').addEventListener('click', handleEditClick);
   byId('budgetRows').addEventListener('click', handleEditClick);
+  byId('reviewUncategorisedButton').addEventListener('click', () => {
+    byId('transactionCategoryFilter').value = 'uncategorised';
+    selectView('transactions');
+    renderTransactions();
+  });
   byId('payslipList').addEventListener('click', handleEditClick);
   byId('documentCards').addEventListener('click', handleDocumentClick);
   byId('accountCards').addEventListener('click', handleEditClick);
@@ -338,6 +344,7 @@ function selectView(name) {
 
 function render() {
   populateMonthOptions();
+  populateBudgetCategoryOptions();
   const month = state.settings.selectedMonth;
   const summary = calculatePeriodSummary(state, month);
   pendingAction = buildNextAction(state);
@@ -405,12 +412,18 @@ function renderTransactions() {
   const search = byId('transactionSearch').value.trim().toLowerCase();
   const account = byId('transactionAccountFilter').value;
   const type = byId('transactionTypeFilter').value;
+  const category = byId('transactionCategoryFilter').value;
   const accountNames = new Map(state.accounts.map((item) => [item.id, item.name]));
+  const budgetAnalysis = calculateBudgetAnalysis(state);
+  const budgetByTransaction = new Map();
+  for (const budget of budgetAnalysis.rows) for (const contribution of budget.contributions) budgetByTransaction.set(contribution.id, budget);
+  const uncategorised = new Set(budgetAnalysis.uncategorisedTransactionIds);
   const rows = state.transactions
     .filter((item) => String(item.budgetMonth || item.date).startsWith(state.settings.selectedMonth))
     .filter((item) => account === 'all' || item.accountId === account)
     .filter((item) => type === 'all' || (type === 'incoming' && item.incoming > 0) || (type === 'outgoing' && item.outgoing > 0) || (type === 'transfer' && item.transferStatus !== 'no'))
-    .filter((item) => !search || [item.description, item.userDescription, item.category, item.notes].join(' ').toLowerCase().includes(search))
+    .filter((item) => category === 'all' || (category === 'uncategorised' ? uncategorised.has(item.id) : budgetByTransaction.get(item.id)?.id === category))
+    .filter((item) => !search || [item.description, item.userDescription, budgetByTransaction.get(item.id)?.category, item.category, item.notes].join(' ').toLowerCase().includes(search))
     .sort((left, right) => left.date.localeCompare(right.date) || Number(left.sourceRow || 0) - Number(right.sourceRow || 0));
   const body = byId('transactionRows');
   clear(body);
@@ -424,7 +437,7 @@ function renderTransactions() {
     if (item.userDescription) description.append(element('span', '', item.description));
     const badges = document.createElement('span');
     badges.className = 'note-preview';
-    badges.textContent = item.category;
+    badges.textContent = budgetByTransaction.get(item.id)?.category || (uncategorised.has(item.id) ? 'Uncategorised' : item.category || 'Not included in budget');
     if (item.transferStatus !== 'no') badges.textContent += ` · ${item.transferStatus} transfer`;
     description.append(badges);
     row.append(description);
@@ -536,21 +549,44 @@ function renderOverdrafts() {
 
 function renderBudget() {
   const summary = calculatePeriodSummary(state);
+  const analysis = calculateBudgetAnalysis(state);
   byId('budgetIncomeValue').textContent = formatCurrency(summary.dependableIncome);
-  byId('plannedSpendingValue').textContent = formatCurrency(summary.plannedSpending);
-  byId('budgetMarginValue').textContent = formatCurrency(summary.plannedMargin);
+  byId('plannedSpendingValue').textContent = formatCurrency(analysis.planned);
+  byId('actualSpendingValue').textContent = formatCurrency(analysis.actual);
+  byId('budgetRemainingValue').textContent = analysis.remaining < 0 ? `${formatCurrency(Math.abs(analysis.remaining))} over` : formatCurrency(analysis.remaining);
+  byId('budgetCoverageValue').textContent = `${analysis.coveragePercent}% of outgoing spending categorised`;
+  byId('uncategorisedBudgetValue').textContent = formatCurrency(analysis.uncategorisedActual);
+  byId('uncategorisedBudgetNotice').hidden = analysis.uncategorisedActual <= 0;
   const list = byId('budgetRows'); clear(list);
   if (!state.budgets.length) {
     const empty = element('div', 'empty-inline', 'No budget items yet. Add essentials first, then minimum debt payments.');
     list.append(empty);
   }
-  for (const item of calculateBudgetRows(state)) {
+  for (const item of analysis.rows) {
     const row = element('div', 'budget-item');
     const line = element('div', 'budget-line');
     const button = element('button', '', item.category); button.type = 'button'; button.dataset.edit = 'budget'; button.dataset.id = item.id;
-    append(line, button, element('span', '', `${formatCurrency(item.actual)} / ${formatCurrency(item.planned)}`));
-    const track = element('div', 'budget-bar'); const bar = document.createElement('span'); bar.style.width = `${Math.min(100, item.planned ? (item.actual / item.planned) * 100 : item.actual ? 100 : 0)}%`; track.append(bar);
-    append(row, line, track); list.append(row);
+    append(line, button, element('span', '', `${formatCurrency(item.actual)} spent of ${formatCurrency(item.planned)}`));
+    const status = item.actual < 0
+      ? `${formatCurrency(Math.abs(item.actual))} net refund`
+      : item.remaining < 0
+        ? `${formatCurrency(Math.abs(item.remaining))} over plan`
+        : item.remaining === 0 ? 'Budget used' : `${formatCurrency(item.remaining)} remaining`;
+    const track = element('div', `budget-bar${item.remaining < 0 ? ' over' : ''}`);
+    const bar = document.createElement('span'); bar.style.width = `${Math.min(100, item.progressPercent ?? (item.actual ? 100 : 0))}%`; track.append(bar);
+    append(row, line, element('span', 'budget-status', status), track);
+    if (item.contributions.length) {
+      const details = element('details', 'budget-contributions');
+      details.append(element('summary', '', `Why? ${item.contributions.length} payment${item.contributions.length === 1 ? '' : 's'}`));
+      const payments = element('div', 'budget-contribution-list');
+      for (const contribution of item.contributions) {
+        const payment = element('div', 'budget-contribution');
+        append(payment, element('span', '', `${formatDate(contribution.date)} · ${contribution.description}`), element('strong', contribution.amount < 0 ? 'incoming' : '', formatCurrency(contribution.amount)), actionButton('transaction', contribution.id, 'Edit'));
+        payments.append(payment);
+      }
+      details.append(payments); row.append(details);
+    }
+    list.append(row);
   }
   const ideas = byId('savingsIdeas'); clear(ideas);
   for (const item of findSavingsOpportunities(state).slice(0, 4)) {
@@ -922,10 +958,13 @@ function openEditor(type, id = '') {
   editorContext = { type, id };
   const collection = collectionFor(type);
   const item = id ? state[collection].find((entry) => entry.id === id) : null;
+  const editorItem = type === 'transaction' && item && !item.budgetCategoryId && item.categorySource !== 'manual'
+    ? { ...item, budgetCategoryId: legacyBudgetIdForTransaction(item) }
+    : item;
   byId('editEyebrow').textContent = item ? 'EDIT' : 'ADD';
   byId('editTitle').textContent = `${item ? 'Edit' : 'Add'} ${type === 'account' ? 'bank account' : type}`;
   const fields = byId('editFields'); clear(fields);
-  for (const definition of editorDefinitions(type)) fields.append(buildField(definition, item));
+  for (const definition of editorDefinitions(type)) fields.append(buildField(definition, editorItem));
   if (item) {
     const deleteButton = element('button', 'danger-button wide-field', `Delete ${type}`); deleteButton.type = 'button'; deleteButton.addEventListener('click', () => deleteEditedItem(type, id)); fields.append(deleteButton);
   }
@@ -943,8 +982,11 @@ function editorDefinitions(type) {
   if (type === 'transaction') return [
     ['accountId', 'Account', 'select', state.accounts.map((account) => [account.id, account.name])], ['date', 'Date', 'date'],
     ['description', 'Statement / payment description', 'text', 'Required', 'wide-field'], ['userDescription', 'Your description', 'text', 'Optional clearer name', 'wide-field'],
-    ['incoming', 'Incoming', 'number'], ['outgoing', 'Outgoing', 'number'], ['runningBalance', 'Running balance', 'number'], ['category', 'Category', 'text'],
-    ['transferStatus', 'Internal transfer', 'select', [['no','No'],['possible','Possible'],['confirmed','Confirmed']]], ['recurring', 'Recurring payment', 'checkbox'], ['notes', 'Notes', 'textarea', '', 'wide-field']
+    ['incoming', 'Incoming', 'number'], ['outgoing', 'Outgoing', 'number'], ['runningBalance', 'Running balance', 'number'],
+    ['budgetCategoryId', 'Budget category', 'select', [['','Uncategorised'], ...state.budgets.map((budget) => [budget.id, budget.category])]],
+    ['category', 'Statement category label', 'text'],
+    ['budgetTreatment', 'Budget treatment', 'select', [['auto','Automatic'],['spending','Spending'],['refund','Refund'],['reversal','Reversal'],['transfer','Internal transfer'],['savings_transfer','Savings transfer'],['debt_payment','Debt payment'],['ignored','Do not include']]],
+    ['transferStatus', 'Internal transfer match', 'select', [['no','No'],['possible','Possible'],['confirmed','Confirmed']]], ['recurring', 'Recurring payment', 'checkbox'], ['notes', 'Notes', 'textarea', '', 'wide-field']
   ];
   if (type === 'payslip') return [['notes', 'Notes', 'textarea', '', 'wide-field']];
   if (type === 'budget') return [['section','Section','select',[['Essentials','Essentials'],['Debt minimums','Debt minimums'],['Flexible','Flexible'],['Goals','Goals']]], ['category','Category','text'], ['planned','Planned monthly amount','number'], ['notes','Notes','textarea','','wide-field']];
@@ -982,6 +1024,7 @@ async function saveEditor(event) {
   const { type, id } = editorContext;
   const collection = collectionFor(type);
   let item = id ? state[collection].find((entry) => entry.id === id) : null;
+  const previousBudgetCategory = type === 'budget' ? item?.category : '';
   if (!item) { item = { id: createId(type) }; state[collection].push(item); }
   for (const definition of editorDefinitions(type)) {
     const [name, , fieldType] = definition; const input = byId('editFields').querySelector(`[name="${name}"]`);
@@ -990,11 +1033,23 @@ async function saveEditor(event) {
     if (name === 'aprPercent') item.apr = value === null ? null : value / 100;
     else item[name] = value;
   }
-  if (type === 'transaction') { item.budgetMonth = item.date?.slice(0, 7) || state.settings.selectedMonth; item.source ||= 'manual'; item.cleared ??= true; item.incoming = Number(item.incoming || 0); item.outgoing = Number(item.outgoing || 0); }
+  if (type === 'transaction') {
+    item.budgetMonth = item.date?.slice(0, 7) || state.settings.selectedMonth;
+    item.source ||= 'manual'; item.cleared ??= true; item.incoming = Number(item.incoming || 0); item.outgoing = Number(item.outgoing || 0);
+    item.categorySource = 'manual';
+    const budget = state.budgets.find((entry) => entry.id === item.budgetCategoryId);
+    if (budget) item.category = budget.category;
+  }
+  if (type === 'budget' && previousBudgetCategory && previousBudgetCategory !== item.category) {
+    for (const transaction of state.transactions) {
+      if (!transaction.budgetCategoryId && transaction.categorySource !== 'manual' && normalisedText(transaction.category) === normalisedText(previousBudgetCategory)) transaction.budgetCategoryId = item.id;
+    }
+  }
   if (type === 'debt' || type === 'overdraft') { item.updatedAt = new Date().toISOString(); item.planPriority ??= 999; item.arrangementConfirmed = item.arrangementStatus === 'confirmed'; }
   if (type === 'account') { item.name ||= 'Unnamed account'; item.active ??= true; }
   await saveState();
   if (type === 'account') populateAccountOptions();
+  if (type === 'budget') populateBudgetCategoryOptions();
   if (type === 'transaction' || type === 'payslip') populateMonthOptions();
   byId('editDialog').close(); editorContext = null; render(); showToast('Saved.');
 }
@@ -1005,9 +1060,16 @@ async function deleteEditedItem(type, id) {
     return;
   }
   if (!window.confirm(`Delete this ${type}? This can be recovered only from a backup.`)) return;
+  if (type === 'budget') {
+    for (const transaction of state.transactions.filter((entry) => entry.budgetCategoryId === id)) {
+      transaction.budgetCategoryId = '';
+      transaction.categorySource = 'manual';
+    }
+  }
   const collection = collectionFor(type); state[collection] = state[collection].filter((item) => item.id !== id);
   await saveState();
   if (type === 'account') populateAccountOptions();
+  if (type === 'budget') populateBudgetCategoryOptions();
   byId('editDialog').close(); editorContext = null; render(); showToast('Deleted.');
 }
 
@@ -1350,6 +1412,30 @@ function populateAccountOptions() {
     for (const account of state.accounts.filter((item) => item.active !== false)) { const option = document.createElement('option'); option.value = account.id; option.textContent = account.name; select.append(option); }
   }
 }
+
+function populateBudgetCategoryOptions() {
+  const select = byId('transactionCategoryFilter');
+  if (!select) return;
+  const selected = select.value || 'all';
+  clear(select);
+  for (const [value, label] of [['all', 'All categories'], ['uncategorised', 'Uncategorised'], ...state.budgets.map((budget) => [budget.id, budget.category])]) {
+    const option = document.createElement('option'); option.value = value; option.textContent = label; select.append(option);
+  }
+  select.value = [...select.options].some((option) => option.value === selected) ? selected : 'all';
+}
+
+function legacyBudgetIdForTransaction(transaction) {
+  const category = normalisedText(transaction.category);
+  const description = normalisedText(transaction.description);
+  const matches = state.budgets.filter((budget) => {
+    const categories = (budget.categories?.length ? budget.categories : [budget.category]).map(normalisedText);
+    const merchantTerms = (budget.merchantTerms || []).map(normalisedText).filter(Boolean);
+    return (category && categories.includes(category)) || (Number(transaction.outgoing || 0) > 0 && merchantTerms.some((term) => description.includes(term)));
+  });
+  return matches.length === 1 ? matches[0].id : '';
+}
+
+function normalisedText(value) { return String(value || '').trim().toLowerCase().replace(/\s+/g, ' '); }
 
 function collectionFor(type) { return ({ account: 'accounts', transaction: 'transactions', payslip: 'payslips', debt: 'debts', overdraft: 'overdrafts', budget: 'budgets' })[type]; }
 

--- a/styles.css
+++ b/styles.css
@@ -518,7 +518,7 @@ input, select, textarea {
 input:hover, select:hover, textarea:hover { border-color: #acc2d5; }
 input:focus, select:focus, textarea:focus { background: #fff; border-color: #61cdbc; box-shadow: 0 0 0 4px rgba(24, 185, 158, 0.09); }
 textarea { resize: vertical; line-height: 1.48; }
-.filter-bar { display: grid; grid-template-columns: minmax(240px, 1fr) 180px 170px; gap: 0.7rem; margin: 1rem 0; padding: 0.78rem; background: rgba(255, 255, 255, 0.68); border: 1px solid rgba(223, 231, 240, 0.85); border-radius: 15px; }
+.filter-bar { display: grid; grid-template-columns: minmax(220px, 1fr) repeat(3, minmax(150px, 0.55fr)); gap: 0.7rem; margin: 1rem 0; padding: 0.78rem; background: rgba(255, 255, 255, 0.68); border: 1px solid rgba(223, 231, 240, 0.85); border-radius: 15px; }
 .table-wrap { width: 100%; overflow: auto; background: rgba(255, 255, 255, 0.95); border: 1px solid var(--line); border-radius: 15px; box-shadow: var(--shadow-sm); }
 table { width: 100%; border-collapse: collapse; font-size: 0.84rem; }
 th { position: sticky; top: 0; z-index: 1; color: #64758b; background: #f4f8fb; font-size: 0.68rem; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; }
@@ -567,7 +567,7 @@ tr:last-child td { border-bottom: 0; }
 .line-item-list { display: grid; gap: 0.38rem; }
 .line-item { display: flex; justify-content: space-between; gap: 1rem; color: #52647a; font-size: 0.82rem; }
 
-.budget-summary { display: grid; grid-template-columns: repeat(3, 1fr); margin-bottom: 1rem; padding: 0.8rem; }
+.budget-summary { display: grid; grid-template-columns: repeat(4, 1fr); margin-bottom: 1rem; padding: 0.8rem; }
 .budget-summary div { display: grid; gap: 0.3rem; padding: 0.4rem 1rem; border-right: 1px solid var(--line); }
 .budget-summary div:last-child { border-right: 0; }
 .budget-summary strong { color: var(--navy); font-size: 1.3rem; font-variant-numeric: tabular-nums; }
@@ -575,8 +575,20 @@ tr:last-child td { border-bottom: 0; }
 .budget-item { display: grid; gap: 0.4rem; }
 .budget-line { display: flex; align-items: center; justify-content: space-between; gap: 0.8rem; font-size: 0.83rem; }
 .budget-line button { padding: 0; color: var(--ink); background: none; border: 0; font-weight: 760; text-align: left; }
+.budget-status { color: var(--muted); font-size: 0.76rem; }
 .budget-bar { height: 7px; overflow: hidden; background: #e8eef3; border-radius: 999px; }
 .budget-bar span { max-width: 100%; height: 100%; display: block; background: linear-gradient(90deg, #0c8878, #2acbb0); border-radius: inherit; transition: width 650ms cubic-bezier(0.2, 0.8, 0.2, 1); }
+.budget-bar.over span { background: linear-gradient(90deg, #c76a3b, #e5965e); }
+.budget-notice { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.budget-notice div { display: grid; gap: 0.2rem; }
+.budget-notice div > span { color: var(--muted); font-size: 0.78rem; }
+.budget-contributions { padding: 0.15rem 0 0.25rem; }
+.budget-contributions summary { color: var(--teal-dark); font-size: 0.76rem; font-weight: 760; cursor: pointer; }
+.budget-contribution-list { display: grid; gap: 0.35rem; margin-top: 0.45rem; }
+.budget-contribution { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 0.55rem; padding: 0.45rem 0.55rem; background: #f7fafc; border-radius: 9px; font-size: 0.76rem; }
+.budget-contribution > span { overflow-wrap: anywhere; color: var(--muted); }
+.budget-contribution strong { font-variant-numeric: tabular-nums; }
+.budget-contribution strong.incoming { color: var(--green); }
 
 .prompt-chips { display: flex; flex-wrap: wrap; gap: 0.55rem; margin: 1rem 0; }
 .prompt-chips button { padding: 0.55rem 0.74rem; color: var(--teal-dark); background: var(--teal-soft); border: 1px solid #c0e8e0; }

--- a/tests/backup-transaction.test.js
+++ b/tests/backup-transaction.test.js
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { FinanceDataStore, PersistenceBusyError, RecoveryModeError } from '../data-store.js';
+import { calculateBudgetAnalysis } from '../finance-core.js';
 
 const seedPath = new URL('../seed-data.json', import.meta.url);
 const passphrase = 'fictional-password';
@@ -93,6 +94,26 @@ test('recovery mode restores a validated automatic backup with its matching docu
   assert.equal(restored.status, 'normal');
   assert.equal(restored.state.profile.name, state.profile.name);
   assert.equal((await harness.store.readDocument(restored.state.documents[0].id, restored.state.documents)).bytes.toString(), 'recovery document');
+});
+
+test('portable backup and restore preserve budget categorisation relationships', async (t) => {
+  const harness = await createHarness(t);
+  let state = (await harness.store.loadState()).state;
+  state.settings.selectedMonth = '2026-08';
+  state.budgets.push({ id: 'fictional-groceries', category: 'Groceries', planned: 200 });
+  state.transactions.push({
+    id: crypto.randomUUID(), date: '2026-08-08', budgetMonth: '2026-08', description: 'Fictional supermarket',
+    incoming: 0, outgoing: 45, transferStatus: 'no', budgetCategoryId: 'fictional-groceries', categorySource: 'manual', budgetTreatment: 'spending'
+  });
+  state = await harness.store.saveState(state);
+  const source = path.join(harness.directory, 'budget-categorisation.osmb');
+  await harness.store.createPortableBackup(source, passphrase, state);
+
+  await harness.store.saveState({ ...state, transactions: [], budgets: [] });
+  const restored = await harness.store.restorePortableBackup(source, passphrase);
+  assert.equal(restored.state.transactions[0].budgetCategoryId, 'fictional-groceries');
+  assert.equal(restored.state.transactions[0].categorySource, 'manual');
+  assert.equal(calculateBudgetAnalysis(restored.state).actual, 45);
 });
 
 test('portable restore stages a new encrypted vault key without altering a keyless live dataset first', async (t) => {

--- a/tests/budget-payment-sync.test.js
+++ b/tests/budget-payment-sync.test.js
@@ -1,0 +1,176 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateBudgetAnalysis, calculateBudgetRows, calculatePeriodSummary } from '../finance-core.js';
+
+function state(overrides = {}) {
+  return {
+    profile: { dependableIncome: 2000 },
+    settings: { selectedMonth: '2026-08' },
+    accounts: [], payslips: [], debts: [], overdrafts: [], scheduledPayments: [],
+    budgets: [{ id: 'groceries', category: 'Groceries', planned: 200 }],
+    transactions: [],
+    ...overrides
+  };
+}
+
+function outgoing(id, amount, overrides = {}) {
+  return { id, date: '2026-08-08', budgetMonth: '2026-08', incoming: 0, outgoing: amount, transferStatus: 'no', description: `Fictional payment ${id}`, ...overrides };
+}
+
+test('categorised imported and manual payments become one budget actual for the selected month', () => {
+  const input = state({ transactions: [
+    outgoing('imported', 50, { source: 'fictional.csv', category: 'Groceries' }),
+    outgoing('manual', 30, { source: 'manual', budgetCategoryId: 'groceries', categorySource: 'manual' }),
+    outgoing('previous', 100, { budgetMonth: '2026-07', date: '2026-07-31', category: 'Groceries' })
+  ] });
+  const analysis = calculateBudgetAnalysis(input);
+  assert.equal(analysis.rows[0].actual, 80);
+  assert.equal(analysis.rows[0].remaining, 120);
+  assert.equal(analysis.rows[0].contributions.length, 2);
+  assert.equal(analysis.actual, 80);
+});
+
+test('overspending is retained above 100 percent and reported as a negative remaining plan', () => {
+  const analysis = calculateBudgetAnalysis(state({ transactions: [outgoing('large', 130, { category: 'Groceries' })], budgets: [{ id: 'groceries', category: 'Groceries', planned: 100 }] }));
+  assert.equal(analysis.rows[0].actual, 130);
+  assert.equal(analysis.rows[0].remaining, -30);
+  assert.equal(analysis.rows[0].progressPercent, 130);
+});
+
+test('confirmed internal transfers and explicit savings transfers do not count as spending', () => {
+  const input = state({ transactions: [
+    outgoing('transfer-out', 300, { transferStatus: 'confirmed', category: 'Groceries' }),
+    { id: 'transfer-in', date: '2026-08-08', budgetMonth: '2026-08', incoming: 300, outgoing: 0, transferStatus: 'confirmed' },
+    outgoing('savings', 200, { budgetTreatment: 'savings_transfer' })
+  ] });
+  const analysis = calculateBudgetAnalysis(input);
+  assert.equal(analysis.actual, 0);
+  assert.equal(analysis.uncategorisedActual, 0);
+});
+
+test('debt repayments are excluded unless assigned to an explicit commitment budget', () => {
+  const input = state({
+    budgets: [
+      { id: 'groceries', category: 'Groceries', planned: 200 },
+      { id: 'debt', category: 'Debt commitment', section: 'Debt minimums', planned: 100 }
+    ],
+    transactions: [
+      outgoing('unassigned-debt', 50, { category: 'Debt payment', budgetTreatment: 'debt_payment' }),
+      outgoing('assigned-debt', 75, { category: 'Debt payment', budgetTreatment: 'debt_payment', budgetCategoryId: 'debt', categorySource: 'manual' })
+    ]
+  });
+  const analysis = calculateBudgetAnalysis(input);
+  assert.equal(analysis.rows.find((row) => row.id === 'debt').actual, 75);
+  assert.equal(analysis.uncategorisedActual, 0);
+  assert.equal(analysis.actual, 75);
+});
+
+test('scheduled commitments do not double count an actual payment', () => {
+  const input = state({
+    scheduledPayments: [{ id: 'phone-plan', amount: 30, dueDate: '2026-08-09' }],
+    budgets: [{ id: 'phone', category: 'Phone', planned: 30 }],
+    transactions: [outgoing('phone-paid', 30, { budgetCategoryId: 'phone', categorySource: 'manual' })]
+  });
+  assert.equal(calculateBudgetAnalysis(input).actual, 30);
+});
+
+test('a categorised refund and full reversal reduce the original category in pennies', () => {
+  const input = state({ transactions: [
+    outgoing('purchase', 80, { category: 'Groceries' }),
+    { id: 'refund', date: '2026-08-09', budgetMonth: '2026-08', incoming: 30, outgoing: 0, transferStatus: 'no', refundOfTransactionId: 'purchase', budgetTreatment: 'refund' },
+    outgoing('reversed-payment', 42, { category: 'Groceries' }),
+    { id: 'reversal', date: '2026-08-10', budgetMonth: '2026-08', incoming: 42, outgoing: 0, transferStatus: 'no', reversalOfTransactionId: 'reversed-payment', budgetTreatment: 'reversal' }
+  ] });
+  const row = calculateBudgetRows(input)[0];
+  assert.equal(row.actual, 50);
+  assert.equal(row.remaining, 150);
+});
+
+test('a refund larger than spending remains accurate without a negative progress value', () => {
+  const input = state({ transactions: [
+    outgoing('purchase', 10, { budgetCategoryId: 'groceries', categorySource: 'manual' }),
+    { id: 'refund', date: '2026-08-09', budgetMonth: '2026-08', incoming: 20, outgoing: 0, transferStatus: 'no', budgetCategoryId: 'groceries', categorySource: 'manual', budgetTreatment: 'refund' }
+  ] });
+  const row = calculateBudgetRows(input)[0];
+  assert.equal(row.actual, -10);
+  assert.equal(row.remaining, 210);
+  assert.equal(row.progressPercent, 0);
+});
+
+test('uncategorised spending is explicit and reconciles with category totals', () => {
+  const analysis = calculateBudgetAnalysis(state({ transactions: [
+    outgoing('known', 50, { category: 'Groceries' }),
+    outgoing('unknown', 25, { category: '' })
+  ] }));
+  assert.equal(analysis.categorisedActual, 50);
+  assert.equal(analysis.uncategorisedActual, 25);
+  assert.equal(analysis.actual, 75);
+  assert.equal(analysis.remaining, 125);
+  assert.equal(analysis.coveragePercent, 67);
+  assert.deepEqual(analysis.uncategorisedTransactionIds, ['unknown']);
+});
+
+test('a manual uncategorised override wins over an imported category label', () => {
+  const analysis = calculateBudgetAnalysis(state({ transactions: [
+    outgoing('manual-override', 40, { category: 'Groceries', budgetCategoryId: '', categorySource: 'manual' })
+  ] }));
+  assert.equal(analysis.rows[0].actual, 0);
+  assert.equal(analysis.uncategorisedActual, 40);
+});
+
+test('exact duplicates are excluded while legitimate same-value payments both count', () => {
+  const input = state({ transactions: [
+    outgoing('first', 20, { category: 'Groceries' }),
+    outgoing('second', 20, { category: 'Groceries' }),
+    outgoing('duplicate', 20, { category: 'Groceries', duplicateStatus: 'exact' })
+  ] });
+  assert.equal(calculateBudgetAnalysis(input).actual, 40);
+});
+
+test('stable budget identifiers preserve relationships across a category rename', () => {
+  const input = state({
+    budgets: [{ id: 'food', category: 'Food and groceries', planned: 250 }],
+    transactions: [outgoing('tesco', 45, { category: 'Groceries', budgetCategoryId: 'food', categorySource: 'manual' })]
+  });
+  assert.equal(calculateBudgetRows(input)[0].actual, 45);
+});
+
+test('a deleted category leaves its transaction intact and explicitly uncategorised', () => {
+  const transaction = outgoing('preserved', 45, { category: 'Old category', budgetCategoryId: '', categorySource: 'manual' });
+  const analysis = calculateBudgetAnalysis(state({ budgets: [], transactions: [transaction] }));
+  assert.equal(analysis.rows.length, 0);
+  assert.equal(analysis.uncategorisedActual, 45);
+  assert.equal(transaction.outgoing, 45);
+});
+
+test('edited amount, date and planned amount are derived without cached actuals', () => {
+  const input = state({ transactions: [outgoing('editable', 40, { category: 'Groceries' })] });
+  assert.equal(calculateBudgetAnalysis(input).rows[0].remaining, 160);
+  input.transactions[0].outgoing = 45;
+  assert.equal(calculateBudgetAnalysis(input).rows[0].actual, 45);
+  input.transactions[0].budgetMonth = '2026-07';
+  assert.equal(calculateBudgetAnalysis(input).rows[0].actual, 0);
+  input.transactions[0].budgetMonth = '2026-08';
+  input.budgets[0].planned = 250;
+  assert.equal(calculateBudgetAnalysis(input).rows[0].remaining, 205);
+});
+
+test('zero plans and penny arithmetic remain safe', () => {
+  const input = state({
+    budgets: [{ id: 'groceries', category: 'Groceries', planned: 0 }],
+    transactions: [outgoing('one', 0.1, { category: 'Groceries' }), outgoing('two', 0.2, { category: 'Groceries' })]
+  });
+  const row = calculateBudgetRows(input)[0];
+  assert.equal(row.actual, 0.3);
+  assert.equal(row.remaining, -0.3);
+  assert.equal(row.progressPercent, null);
+});
+
+test('period summary exposes the same shared budget totals used by the budget rows', () => {
+  const input = state({ transactions: [outgoing('known', 50, { category: 'Groceries' }), outgoing('unknown', 25)] });
+  const summary = calculatePeriodSummary(input);
+  assert.equal(summary.budgetCategorisedSpending, 50);
+  assert.equal(summary.budgetUncategorisedSpending, 25);
+  assert.equal(summary.budgetActualSpending, 75);
+  assert.equal(summary.budgetRemaining, 125);
+});


### PR DESCRIPTION
### Purpose

Synchronise Budget with real Payment activity for v2.1.15 so the Budget screen no longer remains at £0 spent when qualifying transactions already exist. Transactions remain the authoritative source of actual spending, while totals stay explainable, penny-accurate, local-first, and conservative around transfers, debt payments, refunds, duplicates, and uncertain classifications.

The branch was rebased cleanly onto the merged v2.1.14 Credit Report Intelligence release, then merged through PR #17 at 2026-08-08 22:31:50 UTC. GitHub tag `v2.1.15` now points to the resulting merge commit.

### Work completed

#### Shared budget calculations

- Added one reusable `calculateBudgetAnalysis` path in `finance-core.js`.
- Derives planned, categorised actual, uncategorised actual, overall actual, remaining plan, categorisation coverage, category progress, and contributing transactions.
- Uses integer pennies for budget aggregation.
- Preserves selected reporting-month boundaries.
- Excludes confirmed internal transfers, explicit savings transfers, ignored records, invalid/deleted records, and exact duplicates.
- Excludes unassigned debt repayments from ordinary spending while allowing explicitly assigned debt-commitment budgets.
- Nets categorised refunds and reversals against their related category.
- Leaves scheduled commitments outside actual spending so an actual transaction is counted once.

#### Category relationships and editing

- Added optional stable `budgetCategoryId`, `categorySource`, and `budgetTreatment` transaction metadata without a schema migration.
- Preserved conservative unique legacy category and merchant-term matching.
- Made manual uncategorised choices authoritative.
- Preserved stable relationships when a budget is renamed.
- Clears only the category relationship when a budget is deleted; the financial transaction remains intact.
- Added transaction budget-category and treatment controls.
- Added a Budget category filter to Payments.

#### Budget and Payments UI

- Replaced the ambiguous budget ratio with clear Planned, Spent, Remaining, and over-plan/net-refund wording.
- Added an explicit uncategorised-spending notice and one-step “Review payments” action.
- Added categorisation coverage.
- Added expandable contributing-payment rows so every category actual can be explained and edited.
- Added calm overspending styling.
- Payments now show the effective Budget category or explain that a payment is uncategorised or not included.

#### Shared consumers

- Added shared Budget totals to the period summary.
- Updated the private local Guide snapshot to use the same derived Budget rows and uncategorised total.
- No transaction descriptions or financial information are sent externally.

#### Tests

- Added dedicated regression coverage for imported and manual payments, month boundaries, overspending, internal transfers, savings transfers, debt repayments, scheduled payments, refunds, reversals, uncategorised spending, manual overrides, duplicates, stable IDs, category deletion, edits, zero plans, penny arithmetic, and shared period summaries.
- Added backup and restore coverage for optional category-relationship metadata.
- Rebased the implementation onto v2.1.14 without conflict or manual conflict resolution.

### Files changed

- `finance-core.js` — added the authoritative shared Budget analysis and period-summary outputs.
- `renderer-app.js` — added category editing and filtering, real-time rendering, stable rename/delete handling, uncategorised review, and explainable Budget rows.
- `index.html` — added the category filter, corrected Budget summary, and uncategorised notice.
- `styles.css` — added the responsive four-column summary, contribution rows, notice styling, and calm over-plan treatment.
- `local-llm-service.js` — changed the local-only Guide snapshot to consume shared derived Budget totals.
- `tests/budget-payment-sync.test.js` — added the v2.1.15 calculation and classification regression suite.
- `tests/backup-transaction.test.js` — added category-link backup and restore verification.

No files were renamed or deleted.

### User-facing changes

- Budget actuals update from qualifying Payments in the selected month.
- Imported and manual payments can affect Budget without duplicate entry.
- Users can assign or remove a payment’s Budget category and choose its financial treatment.
- Budget shows planned, spent, remaining, over-plan, uncategorised, and coverage figures.
- Users can expand a category to see which payments produced its actual.
- Refunds and reversals reduce a linked category.
- Confirmed transfers and explicit savings transfers do not inflate normal spending.
- Debt repayments require an explicit commitment-category assignment before they count in Budget.

### Technical changes

- Transactions remain the source of actual spending.
- Budget actuals are derived rather than persisted or cached.
- Stable Budget IDs are optional metadata; legacy records retain conservative unique label and merchant matching.
- Calculations aggregate in integer pennies and convert to currency only at the boundary.
- Reporting uses the existing selected month.
- Scheduled payments are not summed as actual transactions.
- The branch is now based directly on v2.1.14 commit `0fc629d92799812669a747171aa33006df6b62e0`.
- The clean rebase changed no feature files beyond the seven listed above.
- No dependencies were added, removed, or updated.
- No telemetry, analytics, cloud categorisation, remote AI, network, logging, or diagnostic changes were added.
- Financial Safety remains authoritative and was not replaced or weakened.

### Testing and verification

#### Automated

- **Passed:** `npm test` after the v2.1.14 rebase — 192/192 tests.
- **Passed:** all 15 dedicated Budget and Payment scenarios.
- **Passed:** backup and restore category-link regression.
- **Passed:** existing Credit Report Intelligence, Statement Intelligence, document deduplication, transfer, Financial Safety, recovery, updater, PDF, preload, diagnostics, and Windows-fsync regressions within the full suite.
- **Passed:** `npm run check` — project check and privacy check.
- **Passed:** `node --check renderer-app.js`.
- **Passed:** `node --check finance-core.js`.
- **Passed:** `node --check local-llm-service.js`.
- **Passed:** `git diff --check origin/main...HEAD`.
- **Passed:** pre-merge branch ancestry verification — one commit ahead and zero behind the v2.1.14 `origin/main`.
- **Passed:** remote tree verification — the published branch and merged `main` tree exactly match the locally tested rebased tree.
- **Unavailable:** lint — no lint script is configured.
- **Unavailable:** type check — no type-check script is configured.
- **Unavailable:** dedicated production build — no separate build script is configured.
- **Failed / environment limitation on the earlier packaging attempt:** `npm run dist:win` packaged the Windows x64 application and reached NSIS creation, then stopped because Wine is not installed (`spawn wine ENOENT`). No source failure was reported before that dependency.
- **Unavailable:** Electron visual startup — the capture run reached application state creation, but the container has no display/GTK connection (`Can't create a GtkStyleContext without a display connection`).

#### Manual Electron verification

Manual desktop verification remains unavailable in this container because Electron cannot open a display. The following checks remain required before release:

1. Existing and newly added/imported Payments update the correct Budget category.
2. The original £0-spent bug is resolved.
3. Category, amount, and date edits update totals and reporting periods immediately.
4. Transfers, savings transfers, debt repayments, scheduled payments, refunds, and reversals receive the intended treatment.
5. Uncategorised and overspent states are clear and calm.
6. Category rename/delete behaviour preserves financial transactions and valid relationships.
7. Budget, Payments, dashboard/shared consumers, restart, backup/restore, recovery, and diagnostics remain consistent and safe.
8. A complete Windows installer build and launch succeeds on a Windows-capable environment.

### Data and migration impact

- No schema-version change or automatic migration.
- Existing transaction values, dates, account relationships, balances, budgets, scheduled payments, imports, documents, debts, and overdrafts are not rewritten on installation.
- Optional category-link and treatment metadata is saved only when relevant records are edited or a legacy relationship is preserved during rename.
- Historical records with no reliable category remain valid and explicitly uncategorised.
- Backup and transactional restore preserve the optional metadata through the existing protected dataset.
- No import or export file format was changed.
- The merged and tagged tree still reports application version v2.1.14; no v2.1.15 package-version bump was included.

### Known limitations

- **Release metadata mismatch:** tag `v2.1.15` exists, but the package and lockfile still report v2.1.14. A separate authorised corrective release is required if the visible application/package version must match the tag.
- Refunds and reversals net automatically only when a category or original-transaction relationship is available; unrelated incoming payments are not guessed.
- Cash withdrawals remain uncategorised until the user chooses a treatment or category.
- Savings transfers are excluded from ordinary spending; savings-progress tracking is not added.
- Debt repayments count only when explicitly assigned to a commitment Budget.
- Scheduled-payment-to-transaction matching is not expanded; double counting is avoided by deriving actuals only from transactions.
- Historical category inference remains conservative and local; bulk rules and learning are not included.
- Manual Electron and complete Windows installer verification remain outstanding.

### Excluded work

- v2.1.15 package-version correction and any follow-up release packaging.
- Dashboard chart redesign.
- Night Mode.
- Action Lifecycle.
- Next Move.
- Payday automation.
- Browser Demo.
- Cloud categorisation or Open Banking.
- Major budgeting-methodology redesign.
- Bulk categorisation or rules engine.
- AI Companion.

### Branch details

- Branch: `fix/budget-payment-sync`
- Commit SHA: `6b841e6fded4196cc899369b7f57b7b41880c48c`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/17
- Target branch: `main`
- Merge commit: `4cc1f03b59e92a479ce9ec6430b208f953fc1ab0`
- Release tag observed: `v2.1.15`

### Confirmations

- No changes were committed or pushed directly to `main`; the change reached `main` through PR #17.
- The pull request was merged at 2026-08-08 22:31:50 UTC. No merge action was performed through this workflow.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs were committed.
- No telemetry, analytics, cloud financial processing, or external categorisation was introduced.
- Only files relevant to the draft v2.1.15 Budget and Payment Synchronisation work were changed.
