### PR TITLE
[v2.1.17][Feature] All-time financial overview

### DIFF
--- a/data-store.js
+++ b/data-store.js
@@ -1876,7 +1876,7 @@ function currentMonth() {
 }
 
 const SETTING_NORMALISERS = Object.freeze({
-  selectedMonth: (value) => /^\d{4}-(0[1-9]|1[0-2])$/.test(String(value || '')) ? String(value) : currentMonth(),
+  selectedMonth: (value) => value === 'all' || /^\d{4}-(0[1-9]|1[0-2])$/.test(String(value || '')) ? String(value) : currentMonth(),
   extraDebtPayment: (value) => finiteNumber(value, 0),
   emergencyBufferTarget: (value) => finiteNumber(value, 500),
   emergencyBufferBalance: (value) => finiteNumber(value, 0),

--- a/finance-core.js
+++ b/finance-core.js
@@ -1,6 +1,7 @@
 import { localFinancialMonthKey } from './date-utils.js';
 
 export const SCHEMA_VERSION = 7;
+export const ALL_TIME_PERIOD = 'all';
 
 export function formatCurrency(value, options = {}) {
   return new Intl.NumberFormat('en-GB', {
@@ -37,28 +38,31 @@ export function availableReportingMonths(state = {}, fallbackMonth = state.setti
 }
 
 export function periodTransactions(transactions, month) {
-  return (transactions || []).filter((transaction) => String(transaction.budgetMonth || transaction.date || '').slice(0, 7) === month
+  return (transactions || []).filter((transaction) => (month === ALL_TIME_PERIOD
+    || String(transaction.budgetMonth || transaction.date || '').slice(0, 7) === month)
     && isTransactionFinanciallyActive(transaction));
 }
 
 export function calculatePeriodSummary(state, month = state.settings?.selectedMonth) {
+  const monthCount = reportingPeriodMonthCount(state, month);
   const rows = periodTransactions(state.transactions, month);
   const external = rows.filter(isExternalCashflowTransaction);
   const income = sum(external, 'incoming');
   const spending = sum(external, 'outgoing');
-  const payslips = (state.payslips || []).filter((payslip) => payslip.period === month);
+  const payslips = (state.payslips || []).filter((payslip) => month === ALL_TIME_PERIOD || payslip.period === month);
   const grossPay = sum(payslips, 'grossPay');
   const payrollDeductions = sum(payslips, 'totalDeductions');
   const netPay = sum(payslips, 'netPay');
-  const plannedSpending = roundMoney((state.budgets || []).reduce((total, budget) => total + Number(budget.planned || 0), 0));
-  const dependableIncome = Number(state.profile?.dependableIncome || 0);
-  const plannedMargin = roundMoney(dependableIncome - plannedSpending);
   const budget = calculateBudgetAnalysis(state, month);
+  const plannedSpending = budget.planned;
+  const dependableMonthlyIncome = Number(state.profile?.dependableIncome || 0);
+  const dependableIncome = roundMoney(dependableMonthlyIncome * monthCount);
+  const plannedMargin = roundMoney(dependableIncome - plannedSpending);
   const overdrafts = sum(state.overdrafts, 'currentBalance');
   const debts = sum(state.debts, 'currentBalance');
   return {
-    month, income, spending, netCashFlow: roundMoney(income - spending),
-    grossPay, payrollDeductions, netPay, dependableIncome, plannedSpending, plannedMargin,
+    month, monthCount, income, spending, netCashFlow: roundMoney(income - spending),
+    grossPay, payrollDeductions, netPay, dependableMonthlyIncome, dependableIncome, plannedSpending, plannedMargin,
     budgetActualSpending: budget.actual, budgetCategorisedSpending: budget.categorisedActual,
     budgetUncategorisedSpending: budget.uncategorisedActual, budgetRemaining: budget.remaining,
     debts, overdrafts, totalOwed: roundMoney(debts + overdrafts), transactionCount: rows.length
@@ -84,6 +88,7 @@ export function removeBudgetCategory(state, budgetId) {
 
 export function calculateBudgetAnalysis(state, month = state.settings?.selectedMonth) {
   const budgets = state.budgets || [];
+  const monthCount = reportingPeriodMonthCount(state, month);
   const transactions = periodTransactions(state.transactions, month);
   const budgetsById = new Map(budgets.map((budget) => [String(budget.id), budget]));
   const transactionsById = new Map((state.transactions || []).map((transaction) => [String(transaction.id), transaction]));
@@ -165,12 +170,13 @@ export function calculateBudgetAnalysis(state, month = state.settings?.selectedM
   }
 
   const rows = budgets.map((budget) => {
-    const plannedPennies = moneyToPennies(budget.planned);
+    const monthlyPlanned = penniesToMoney(moneyToPennies(budget.planned));
+    const plannedPennies = moneyToPennies(monthlyPlanned) * monthCount;
     const actual = penniesToMoney(actualPennies.get(String(budget.id)) || 0);
     const planned = penniesToMoney(plannedPennies);
     const remaining = penniesToMoney(plannedPennies - moneyToPennies(actual));
     return {
-      ...budget, planned, actual, remaining,
+      ...budget, monthlyPlanned, planned, actual, remaining,
       progressPercent: plannedPennies > 0 ? Math.max(0, Math.round(((actualPennies.get(String(budget.id)) || 0) / plannedPennies) * 100)) : null,
       contributions: contributions.get(String(budget.id)) || []
     };
@@ -180,6 +186,7 @@ export function calculateBudgetAnalysis(state, month = state.settings?.selectedM
   const totalActualPennies = categorisedPennies + uncategorisedPennies;
   return {
     month,
+    monthCount,
     rows,
     planned: penniesToMoney(plannedPennies),
     categorisedActual: penniesToMoney(categorisedPennies),
@@ -189,6 +196,21 @@ export function calculateBudgetAnalysis(state, month = state.settings?.selectedM
     coveragePercent: eligibleGrossPennies > 0 ? Math.round((categorisedGrossPennies / eligibleGrossPennies) * 100) : 100,
     uncategorisedTransactionIds
   };
+}
+
+export function reportingPeriodMonthCount(state, month = state.settings?.selectedMonth) {
+  if (month !== ALL_TIME_PERIOD) return 1;
+  const months = new Set();
+  for (const transaction of state.transactions || []) {
+    if (!isTransactionFinanciallyActive(transaction)) continue;
+    const reportingPeriod = reportingMonth(transaction.budgetMonth) || reportingMonth(transaction.date);
+    if (reportingPeriod) months.add(reportingPeriod);
+  }
+  for (const payslip of state.payslips || []) {
+    const reportingPeriod = reportingMonth(payslip.period) || reportingMonth(payslip.payDate);
+    if (reportingPeriod) months.add(reportingPeriod);
+  }
+  return Math.max(1, months.size);
 }
 
 function compareBudgetUsageDescending(left, right) {
@@ -640,7 +662,8 @@ export function buildFallbackAnswer(question, state) {
       : ` No unsafe extra payment is included. ${plan.explanations[0] || 'OneStep does not have enough confirmed information to recommend one safely.'}`;
     return `Your recorded debt and overdrafts total ${formatCurrency(summary.totalOwed)}.${safetyMessage} The payoff forecast is provisional while ${plan.unknownApr.length} rate${plan.unknownApr.length === 1 ? ' is' : 's are'} unknown.`;
   }
-  return `Your selected month shows ${formatCurrency(summary.income)} external money in and ${formatCurrency(summary.spending)} out. The safest next move is: ${next.title}.`;
+  const periodLabel = summary.month === ALL_TIME_PERIOD ? `Across all ${summary.monthCount} months held` : 'Your selected month';
+  return `${periodLabel} shows ${formatCurrency(summary.income)} external money in and ${formatCurrency(summary.spending)} out. The safest next move is: ${next.title}.`;
 }
 
 function priorityOrder(items, balances, strategy) {

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
         <header class="topbar">
           <div class="title-stack"><p class="eyebrow" id="viewEyebrow">ONE CLEAR MOVE</p><h1 id="viewTitle">Today</h1></div>
           <div class="topbar-actions">
-            <label class="compact-field">Month<select id="monthSelect" aria-label="Reporting month"></select></label>
+            <label class="compact-field">Period<select id="monthSelect" aria-label="Reporting period"></select></label>
             <div class="streak-chip" title="Weeks with a completed check-in"><span class="streak-icon" aria-hidden="true">◆</span><span><strong id="streakValue">0</strong> week streak</span></div>
           </div>
         </header>
@@ -117,7 +117,7 @@
 
         <section id="view-pay" class="view" hidden>
           <div class="section-actions"><div><h2>Pay and deductions</h2><p>Gross pay, allowances, tax, National Insurance and net pay are tracked without double-counting your bank income.</p></div><button id="importPayslipButton" class="primary-button">Import payslip</button></div>
-          <div class="metric-grid three"><article class="metric-card"><span>Gross pay</span><strong id="grossPayValue">£0.00</strong><small>Selected month</small></article><article class="metric-card"><span>Payroll deductions</span><strong id="deductionsValue">£0.00</strong><small>Tax, NI and other deductions</small></article><article class="metric-card"><span>Net pay</span><strong id="netPayValue">£0.00</strong><small>Amount paid by payroll</small></article></div>
+          <div class="metric-grid three"><article class="metric-card"><span>Gross pay</span><strong id="grossPayValue">£0.00</strong><small id="grossPayHint">Selected month</small></article><article class="metric-card"><span>Payroll deductions</span><strong id="deductionsValue">£0.00</strong><small id="deductionsHint">Tax, NI and other deductions</small></article><article class="metric-card"><span>Net pay</span><strong id="netPayValue">£0.00</strong><small id="netPayHint">Amount paid by payroll</small></article></div>
           <div id="payslipList" class="card-list"></div>
         </section>
 
@@ -135,8 +135,8 @@
         </section>
 
         <section id="view-budget" class="view" hidden>
-          <div class="section-actions"><div><h2>Simple monthly plan</h2><p>Dependable income first. Variable income stays separate until it arrives.</p></div><button class="primary-button" data-add="budget">Add budget item</button></div>
-          <article class="panel budget-summary"><div><span>Dependable income</span><strong id="budgetIncomeValue">£0.00</strong></div><div><span>Planned</span><strong id="plannedSpendingValue">£0.00</strong></div><div><span>Spent</span><strong id="actualSpendingValue">£0.00</strong></div><div><span>Remaining plan</span><strong id="budgetRemainingValue">£0.00</strong></div></article>
+          <div class="section-actions"><div><h2 id="budgetPeriodHeading">Simple monthly plan</h2><p id="budgetPeriodDescription">Dependable income first. Variable income stays separate until it arrives.</p></div><button class="primary-button" data-add="budget">Add budget item</button></div>
+          <article class="panel budget-summary"><div><span id="budgetIncomeLabel">Dependable income</span><strong id="budgetIncomeValue">£0.00</strong></div><div><span id="plannedSpendingLabel">Planned</span><strong id="plannedSpendingValue">£0.00</strong></div><div><span id="actualSpendingLabel">Spent</span><strong id="actualSpendingValue">£0.00</strong></div><div><span id="budgetRemainingLabel">Remaining plan</span><strong id="budgetRemainingValue">£0.00</strong></div></article>
           <article id="uncategorisedBudgetNotice" class="panel budget-notice" hidden><div><strong><span id="uncategorisedBudgetValue">£0.00</span> needs categorising</strong><span id="budgetCoverageValue">100% of outgoing spending categorised</span></div><button id="reviewUncategorisedButton" class="secondary-button" type="button">Review payments</button></article>
           <div class="two-column budget-layout"><article class="panel"><h2>Plan versus actual</h2><div id="budgetRows" class="budget-list"></div></article><article class="panel"><h2>Penny-pinching ideas</h2><p class="muted">Based on your own imported spending. Review one item at a time.</p><div id="savingsIdeas" class="checks-list"></div></article></div>
         </section>

--- a/local-llm-service.js
+++ b/local-llm-service.js
@@ -1,4 +1,4 @@
-import { calculateBudgetAnalysis, calculatePeriodSummary, debtPlan } from './finance-core.js';
+import { ALL_TIME_PERIOD, calculateBudgetAnalysis, calculatePeriodSummary, debtPlan } from './finance-core.js';
 
 const OLLAMA_URL = 'http://127.0.0.1:11434/api/chat';
 
@@ -43,17 +43,17 @@ export function financialSnapshot(state) {
   const plan = debtPlan(state, 'hybrid');
   const month = state.settings?.selectedMonth || '';
   const summary = calculatePeriodSummary(state, month);
-  const incoming = money(summary.income);
-  const outgoing = money(summary.spending);
   const budgetAnalysis = calculateBudgetAnalysis(state, month);
+  const periodLabel = month === ALL_TIME_PERIOD ? `All time (${summary.monthCount} months held)` : `Selected month: ${month}`;
   const budgets = budgetAnalysis.rows.map((item) => `${item.category}: planned ${money(item.planned)}, spent ${money(item.actual)}, remaining ${money(item.remaining)}`).join('; ');
   const debts = (state.debts || []).map((item) => `${item.name}: balance ${money(item.currentBalance)}, APR ${item.apr == null ? 'unknown' : `${(item.apr * 100).toFixed(2)}%`}, contractual payment ${knownMoney(item.contractualPayment)}, status ${item.status || 'unknown'}, arrangement ${item.arrangementStatus || 'unknown'}, arrangement payment ${knownMoney(item.arrangementPayment)}, status conflict ${item.statusConflict ? 'yes' : 'no'}, interest frozen ${item.interestFrozen ? 'yes' : 'no'}`).join('\n');
   const overdrafts = (state.overdrafts || []).map((item) => `${item.name}: used ${money(item.currentBalance)}, limit ${knownMoney(item.limit)}, APR ${item.apr == null ? 'unknown' : `${(item.apr * 100).toFixed(2)}%`}, contractual payment ${knownMoney(item.contractualPayment)}, status ${item.status || 'unknown'}, arrangement ${item.arrangementStatus || 'unknown'}, arrangement payment ${knownMoney(item.arrangementPayment)}, status conflict ${item.statusConflict ? 'yes' : 'no'}`).join('\n');
   return [
     'VERIFIED LOCAL FINANCIAL SNAPSHOT',
-    `Selected month: ${month}`,
+    `Reporting period: ${periodLabel}`,
     `Dependable monthly bank income: ${money(state.profile?.dependableIncome)}`,
-    `External cash flow: ${incoming} in; ${outgoing} out; ${money(incoming - outgoing)} net`,
+    `Dependable income for reporting period: ${money(summary.dependableIncome)}`,
+    `External cash flow: ${money(summary.income)} in; ${money(summary.spending)} out; ${money(summary.netCashFlow)} net`,
     `Starter buffer: ${money(state.settings?.emergencyBufferBalance)} of ${money(state.settings?.emergencyBufferTarget)}`,
     `Planned extra debt payment: ${money(state.settings?.extraDebtPayment)}`,
     `Budgets: ${budgets}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onestep-money",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.16",
+      "version": "2.1.17",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -1,7 +1,7 @@
 import {
-  availableReportingMonths, buildFallbackAnswer, buildFinancialChecks, buildNextAction, calculateBudgetAnalysis,
+  ALL_TIME_PERIOD, availableReportingMonths, buildFallbackAnswer, buildFinancialChecks, buildNextAction, calculateBudgetAnalysis,
   calculatePeriodSummary, calculateStreak, createId, debtPlan, exportTransactionsCsv,
-  findSavingsOpportunities, formatCurrency, formatDate, hasCompletedCheckIn, removeBudgetCategory,
+  findSavingsOpportunities, formatCurrency, formatDate, hasCompletedCheckIn, removeBudgetCategory, reportingPeriodMonthCount,
   resolvePossibleDuplicate
 } from './finance-core.js';
 import { applyCreditReportImportPlan, buildCreditReportImportPlan } from './credit-report-intelligence.js';
@@ -357,11 +357,18 @@ function render() {
   renderDailyCompletion();
   byId('marginValue').textContent = formatCurrency(summary.plannedMargin);
   byId('cashFlowValue').textContent = formatCurrency(summary.netCashFlow);
+  const allTime = month === ALL_TIME_PERIOD;
+  const periodHint = allTime ? `All trusted data · ${summary.monthCount} month${summary.monthCount === 1 ? '' : 's'}` : monthLabel(month);
+  byId('marginHint').textContent = allTime ? `${summary.monthCount} × monthly safety margin` : `Plan for ${periodHint}`;
+  byId('cashFlowHint').textContent = periodHint;
   byId('todayDebtValue').textContent = formatCurrency(summary.debts);
   byId('todayOverdraftValue').textContent = formatCurrency(summary.overdrafts);
   byId('grossPayValue').textContent = formatCurrency(summary.grossPay);
   byId('deductionsValue').textContent = formatCurrency(summary.payrollDeductions);
   byId('netPayValue').textContent = formatCurrency(summary.netPay);
+  byId('grossPayHint').textContent = periodHint;
+  byId('deductionsHint').textContent = allTime ? periodHint : 'Tax, NI and other deductions';
+  byId('netPayHint').textContent = allTime ? periodHint : 'Amount paid by payroll';
   byId('streakValue').textContent = calculateStreak(state.checkIns);
   renderChecks();
   renderMomentum();
@@ -420,7 +427,7 @@ function renderTransactions() {
   for (const budget of budgetAnalysis.rows) for (const contribution of budget.contributions) budgetByTransaction.set(contribution.id, budget);
   const uncategorised = new Set(budgetAnalysis.uncategorisedTransactionIds);
   const rows = state.transactions
-    .filter((item) => String(item.budgetMonth || item.date).startsWith(state.settings.selectedMonth))
+    .filter((item) => state.settings.selectedMonth === ALL_TIME_PERIOD || String(item.budgetMonth || item.date).startsWith(state.settings.selectedMonth))
     .filter((item) => account === 'all' || item.accountId === account)
     .filter((item) => type === 'all' || (type === 'incoming' && item.incoming > 0) || (type === 'outgoing' && item.outgoing > 0) || (type === 'transfer' && item.transferStatus !== 'no'))
     .filter((item) => category === 'all' || (category === 'uncategorised' ? uncategorised.has(item.id) : budgetByTransaction.get(item.id)?.id === category))
@@ -557,6 +564,16 @@ function renderOverdrafts() {
 function renderBudget() {
   const summary = calculatePeriodSummary(state);
   const analysis = calculateBudgetAnalysis(state);
+  const allTime = analysis.month === ALL_TIME_PERIOD;
+  const monthWord = analysis.monthCount === 1 ? 'month' : 'months';
+  byId('budgetPeriodHeading').textContent = allTime ? 'All-time plan versus actual' : 'Simple monthly plan';
+  byId('budgetPeriodDescription').textContent = allTime
+    ? `${analysis.monthCount} ${monthWord} of trusted data. Every monthly budget quantity and dependable income amount is multiplied by ${analysis.monthCount}.`
+    : `Plan versus actual for ${monthLabel(analysis.month)}. Dependable income first; variable income stays separate until it arrives.`;
+  byId('budgetIncomeLabel').textContent = allTime ? `Dependable income · ${analysis.monthCount} ${monthWord}` : 'Dependable income';
+  byId('plannedSpendingLabel').textContent = allTime ? `Planned · ${analysis.monthCount} ${monthWord}` : 'Planned';
+  byId('actualSpendingLabel').textContent = allTime ? 'Spent · all time' : 'Spent';
+  byId('budgetRemainingLabel').textContent = allTime ? 'Remaining · all time' : 'Remaining plan';
   byId('budgetIncomeValue').textContent = formatCurrency(summary.dependableIncome);
   byId('plannedSpendingValue').textContent = formatCurrency(analysis.planned);
   byId('actualSpendingValue').textContent = formatCurrency(analysis.actual);
@@ -582,11 +599,12 @@ function renderBudget() {
     remove.setAttribute('aria-label', `Remove ${item.category} from budget`);
     append(actions, edit, remove);
     append(line, summary, actions);
-    const status = item.actual < 0
+    let status = item.actual < 0
       ? `${formatCurrency(Math.abs(item.actual))} net refund`
       : item.remaining < 0
         ? `${formatCurrency(Math.abs(item.remaining))} over plan`
         : item.remaining === 0 ? 'Budget used' : `${formatCurrency(item.remaining)} remaining`;
+    if (allTime) status += ` · ${formatCurrency(item.monthlyPlanned)} per month × ${analysis.monthCount}`;
     const track = element('div', `budget-bar${item.remaining < 0 ? ' over' : ''}`);
     const bar = document.createElement('span'); bar.style.width = `${Math.min(100, item.progressPercent ?? (item.actual ? 100 : 0))}%`; track.append(bar);
     append(row, line, element('span', 'budget-status', status), track);
@@ -1454,13 +1472,18 @@ async function saveState(nextState = state) {
 function populateMonthOptions() {
   const months = synchroniseSelectedMonth();
   const select = byId('monthSelect'); clear(select);
+  const allTime = document.createElement('option');
+  const monthCount = reportingPeriodMonthCount(state, ALL_TIME_PERIOD);
+  allTime.value = ALL_TIME_PERIOD;
+  allTime.textContent = `All time · ${monthCount} month${monthCount === 1 ? '' : 's'}`;
+  select.append(allTime);
   for (const month of months) { const option = document.createElement('option'); option.value = month; option.textContent = monthLabel(month); select.append(option); }
   select.value = state.settings.selectedMonth;
 }
 
 function synchroniseSelectedMonth(targetState = state) {
   const months = availableReportingMonths(targetState);
-  if (!months.includes(targetState.settings.selectedMonth)) targetState.settings.selectedMonth = months[0];
+  if (targetState.settings.selectedMonth !== ALL_TIME_PERIOD && !months.includes(targetState.settings.selectedMonth)) targetState.settings.selectedMonth = months[0];
   return months;
 }
 

--- a/tests/budget-payment-sync.test.js
+++ b/tests/budget-payment-sync.test.js
@@ -288,3 +288,47 @@ test('period summary exposes the same shared budget totals used by the budget ro
   assert.equal(summary.budgetActualSpending, 75);
   assert.equal(summary.budgetRemaining, 125);
 });
+
+test('all-time reporting multiplies monthly plans by trusted months held and totals every active payment', () => {
+  const input = state({
+    settings: { selectedMonth: 'all' },
+    budgets: [{ id: 'groceries', category: 'Groceries', planned: 200 }],
+    payslips: [{ id: 'july-pay', period: '2026-07', grossPay: 2500, totalDeductions: 500, netPay: 2000 }],
+    transactions: [
+      outgoing('august', 80, { category: 'Groceries' }),
+      outgoing('june', 45, { budgetMonth: '2026-06', date: '2026-06-12', category: 'Groceries' }),
+      outgoing('pending-may', 999, {
+        budgetMonth: '2026-05', date: '2026-05-10', category: 'Groceries',
+        duplicateStatus: 'possible', reviewStatus: 'pending', financiallyActive: false
+      })
+    ]
+  });
+
+  const analysis = calculateBudgetAnalysis(input);
+  const summary = calculatePeriodSummary(input);
+
+  assert.equal(analysis.monthCount, 3);
+  assert.equal(analysis.rows[0].monthlyPlanned, 200);
+  assert.equal(analysis.rows[0].planned, 600);
+  assert.equal(analysis.rows[0].actual, 125);
+  assert.equal(analysis.rows[0].remaining, 475);
+  assert.equal(analysis.rows[0].progressPercent, 21);
+  assert.equal(summary.dependableMonthlyIncome, 2000);
+  assert.equal(summary.dependableIncome, 6000);
+  assert.equal(summary.plannedSpending, 600);
+  assert.equal(summary.spending, 125);
+  assert.equal(summary.grossPay, 2500);
+  assert.equal(summary.transactionCount, 2);
+  assert.match(financialSnapshot(input), /Reporting period: All time \(3 months held\)/);
+  assert.match(financialSnapshot(input), /External cash flow: £0\.00 in; £125\.00 out; -£125\.00 net/);
+});
+
+test('all-time reporting controls and multiplier explanation are visible in the desktop UI', () => {
+  const html = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  const renderer = fs.readFileSync(new URL('../renderer-app.js', import.meta.url), 'utf8');
+  assert.match(html, /aria-label="Reporting period"/);
+  assert.match(html, /id="budgetPeriodDescription"/);
+  assert.match(renderer, /allTime\.textContent = `All time · \$\{monthCount\} month/);
+  assert.match(renderer, /Every monthly budget quantity and dependable income amount is multiplied by/);
+  assert.match(renderer, /state\.settings\.selectedMonth === ALL_TIME_PERIOD/);
+});

--- a/tests/state-integrity.test.js
+++ b/tests/state-integrity.test.js
@@ -90,6 +90,19 @@ test('generated-action snoozes survive save, restart and encrypted backup restor
   assert.equal(buildNextAction(cleaned).id, 'generated-first-account');
 });
 
+test('the all-time reporting selection survives saves and restarts', async (t) => {
+  const harness = await createHarness(t);
+  let state = (await harness.store.loadState()).state;
+  state.settings.selectedMonth = 'all';
+  state = await harness.store.saveState(state);
+  assert.equal(state.settings.selectedMonth, 'all');
+
+  const restarted = new FinanceDataStore(harness.directory, seedPath, null, { secureStorage: secureStorage() });
+  await restarted.initialise();
+  const loaded = (await restarted.loadState()).state;
+  assert.equal(loaded.settings.selectedMonth, 'all');
+});
+
 async function createHarness(t) {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-integrity-'));
   t.after(() => fs.rm(directory, { recursive: true, force: true }));


### PR DESCRIPTION
### Purpose

Create an all-time financial reporting view so users can judge performance across every trusted month held, instead of being limited to one month at a time. In all-time mode, recurring monthly budget quantities and dependable monthly income are multiplied by the number of distinct trusted months represented, giving plan-versus-actual totals on the same time basis.

### Work completed

#### All-time reporting

- Added an **All time** option to the reporting-period selector while preserving every existing monthly option.
- Included every financially active transaction and every recorded payslip in all-time totals.
- Counted distinct represented months from trusted, financially active transactions and payslips.
- Kept unresolved, excluded, or financially inactive transactions out of totals and out of the month multiplier.
- Counted only months actually represented by trusted data; gaps in the calendar are not invented.
- Preserved the selected all-time period across saves and restarts.

#### Budget and income scaling

- Multiplied each monthly budget quantity by the reporting-period month count in all-time mode.
- Multiplied dependable monthly income by the same month count.
- Calculated plan, actual, remaining amount, usage percentage, and planned margin from those period-aligned values.
- Preserved the original monthly amount on each budget row so the UI can explain the calculation as monthly amount × months held.
- Left single-month calculations unchanged.
- Retained descending budget sorting by percentage used.

#### Desktop UI

- Renamed the top-bar selector label from **Month** to **Period** and updated its accessible label.
- Added an **All time · N months** selector option.
- Updated Today, Pay, Transactions, and Budget views to reflect the selected all-time period.
- Added explicit all-time budget headings, labels, and multiplier explanations.
- Displayed each all-time budget row's monthly quantity and multiplier.
- Allowed the transaction table to draw from all represented months when all-time is selected.
- Added period-specific hints to pay totals and dashboard cash-flow/margin cards.

#### Private local guide

- Added the reporting-period label and period-scaled dependable income to the summary supplied to the private local guide.
- Used the authoritative calculated net cash-flow value rather than subtracting already-formatted currency strings.
- Kept raw documents and transaction descriptions out of the local-guide snapshot as before.

#### Release metadata

- Updated the application version from **2.1.16** to **2.1.17**.
- No dependencies were added, removed, or updated.

### Files changed

- **data-store.js** — permits the special `all` reporting-period value in persisted settings while retaining month-format validation.
- **finance-core.js** — adds the all-time period constant, trusted month counting, all-time transaction and payslip aggregation, scaled budgets and dependable income, period metadata, and period-aware fallback guidance.
- **index.html** — changes the Month control to Period and adds dynamic labels/hints required by all-time Pay and Budget views.
- **local-llm-service.js** — makes the private financial snapshot period-aware and uses the authoritative net cash-flow calculation.
- **package.json** — bumps the application version to 2.1.17.
- **package-lock.json** — keeps root package metadata aligned at version 2.1.17; dependency versions are unchanged.
- **renderer-app.js** — wires the all-time selector, persistence, period-aware summaries, transaction filtering, Pay hints, Budget explanations, and monthly-quantity multiplier display into the Electron renderer.
- **tests/budget-payment-sync.test.js** — tests trusted month counting, budget/income multiplication, all-time transaction and payslip totals, inactive-review exclusion, snapshot output, and desktop UI wiring.
- **tests/state-integrity.test.js** — tests that the all-time selection survives save and restart.

No files were added, renamed, or deleted.

### User-facing changes

Users can select **All time** from the reporting-period control to see totals across all trusted data held. In that mode, a monthly budget of £200 over three represented months is compared as a £600 plan, and dependable monthly income is scaled in the same way. The UI states the number of months used and shows the monthly quantity × month-count calculation. Existing monthly reporting continues to work as before.

### Technical changes

- All-time month count is derived from distinct valid month keys on financially active transactions and payslips.
- A transaction awaiting review or explicitly excluded from financial totals cannot add a month or affect all-time totals.
- Period budget arithmetic continues to use integer pennies.
- The persisted settings allowlist now accepts `selectedMonth: "all"`; no schema-version increase or storage-format rewrite is required.
- Existing concurrency, state-revision, encryption, import-review, and local-first behaviour is unchanged.
- No telemetry, analytics, cloud storage, external financial-data service, or new network access was introduced.
- No dependency changes were made.

### Testing and verification

- **Passed — automated tests:** `npm test`; 209 tests passed, 0 failed.
- **Passed — project validation:** project structure and release/version checks completed successfully.
- **Passed — privacy scan:** no prohibited sensitive data, telemetry, or unsafe logging patterns detected.
- **Passed — feature verification:** all-time aggregation, trusted-month multiplier, monthly-plan preservation, income scaling, inactive-review exclusion, UI wiring, settings persistence, local-guide snapshot, and existing budget percentage sorting are covered by automated tests.
- **Passed — Windows packaging (partial environment coverage):** electron-builder successfully produced the unpacked Windows application/executable stage.
- **Unavailable — Windows NSIS installer completion:** this Linux runner does not have Wine, which electron-builder requires to finish the NSIS installer.
- **Unavailable — Electron visual startup:** this runner has no graphical display server, so an Electron desktop window could not be opened for visual confirmation.

### Data and migration impact

No database schema, encrypted vault format, import document format, backup format, or export format changes are required. Existing monthly selections remain valid. The new `all` settings value is safely normalised and persists through save/restart. Existing financial records are not rewritten. All-time totals are calculated from current trusted records at render time.

### Known limitations

- The existing transaction-table display cap of 300 rows remains; all-time calculations still include all financially active transactions.
- The app currently stores the present monthly budget amount rather than historical budget revisions, so all-time planning applies the current monthly quantity across the trusted month count.
- Calendar gaps are intentionally not counted; the multiplier represents distinct months with trusted transaction or payslip data.
- Full NSIS creation and graphical Electron startup remain to be confirmed on a Windows desktop-capable environment.

### Excluded work

- No historical month-by-month budget revision system was added.
- No new trend chart or year/month comparison chart was added.
- No database migration, import/export format change, dependency update, installer release, or automatic merge was performed.

### Branch details

- Branch: `feature/all-time-financial-overview`
- Commit SHA: `a5e3701173d7b196fb0aecc34c3a0ea9fdac9d43`
- Approved local source commit: `a33281b8c613f72859c06bfcd97d84fa5214ccb9`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/21
- Target branch: `main`

The GitHub app generated a new remote commit identity because Git HTTPS credentials were unavailable in the runner. Its parent, commit message, nine file blobs, and complete tree SHA (`dbd1ce828140ce445e65371e90ebb0473d80489f`) exactly match the approved local commit.

### Confirmations

- No changes were committed or pushed directly to `main`.
- The pull request has not been merged.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs were committed.
- Only files relevant to the requested work were changed.
