### PR TITLE
[v2.1.18][QOL] Income payment categorisation

### DIFF
--- a/finance-core.js
+++ b/finance-core.js
@@ -2,6 +2,7 @@ import { localFinancialMonthKey } from './date-utils.js';
 
 export const SCHEMA_VERSION = 7;
 export const ALL_TIME_PERIOD = 'all';
+export const INCOME_PAYMENT_CATEGORY = 'Income';
 
 export function formatCurrency(value, options = {}) {
   return new Intl.NumberFormat('en-GB', {
@@ -87,7 +88,7 @@ export function removeBudgetCategory(state, budgetId) {
 }
 
 export function calculateBudgetAnalysis(state, month = state.settings?.selectedMonth) {
-  const budgets = state.budgets || [];
+  const budgets = (state.budgets || []).filter((budget) => !isIncomeCategory(budget.category));
   const monthCount = reportingPeriodMonthCount(state, month);
   const transactions = periodTransactions(state.transactions, month);
   const budgetsById = new Map(budgets.map((budget) => [String(budget.id), budget]));
@@ -139,6 +140,7 @@ export function calculateBudgetAnalysis(state, month = state.settings?.selectedM
   for (const transaction of transactions) {
     const treatment = normaliseBudgetTreatment(transaction.budgetTreatment);
     if (transaction.transferStatus === 'confirmed' || ['transfer', 'savings_transfer', 'ignored'].includes(treatment)) continue;
+    if (isIncomePayment(transaction)) continue;
 
     const outgoingPennies = Math.max(0, moneyToPennies(transaction.outgoing));
     const incomingPennies = Math.max(0, moneyToPennies(transaction.incoming));
@@ -196,6 +198,10 @@ export function calculateBudgetAnalysis(state, month = state.settings?.selectedM
     coveragePercent: eligibleGrossPennies > 0 ? Math.round((categorisedGrossPennies / eligibleGrossPennies) * 100) : 100,
     uncategorisedTransactionIds
   };
+}
+
+export function isIncomePayment(transaction = {}) {
+  return isIncomeCategory(transaction.category);
 }
 
 export function reportingPeriodMonthCount(state, month = state.settings?.selectedMonth) {
@@ -947,6 +953,10 @@ function penniesToMoney(value) {
 
 function normalise(value) {
   return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function isIncomeCategory(value) {
+  return normalise(value) === normalise(INCOME_PAYMENT_CATEGORY);
 }
 
 function sum(rows = [], field) {

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
             <label>Search<input id="transactionSearch" type="search" placeholder="Merchant, category or note" /></label>
             <label>Account<select id="transactionAccountFilter"><option value="all">All accounts</option></select></label>
             <label>Type<select id="transactionTypeFilter"><option value="all">All</option><option value="incoming">Incoming</option><option value="outgoing">Outgoing</option><option value="transfer">Transfers</option></select></label>
-            <label>Budget category<select id="transactionCategoryFilter"><option value="all">All categories</option><option value="uncategorised">Uncategorised</option></select></label>
+            <label>Payment category<select id="transactionCategoryFilter"><option value="all">All categories</option><option value="uncategorised">Uncategorised</option></select></label>
           </div>
           <div class="table-wrap"><table><thead><tr><th>Date</th><th>Account</th><th>Description</th><th>Incoming</th><th>Outgoing</th><th>Balance</th><th>Notes</th><th><span class="sr-only">Edit</span></th></tr></thead><tbody id="transactionRows"></tbody></table></div>
           <p id="transactionCount" class="table-caption"></p>

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -1,8 +1,8 @@
 import {
   ALL_TIME_PERIOD, availableReportingMonths, buildFallbackAnswer, buildFinancialChecks, buildNextAction, calculateBudgetAnalysis,
   calculatePeriodSummary, calculateStreak, createId, debtPlan, exportTransactionsCsv,
-  findSavingsOpportunities, formatCurrency, formatDate, hasCompletedCheckIn, removeBudgetCategory, reportingPeriodMonthCount,
-  resolvePossibleDuplicate
+  findSavingsOpportunities, formatCurrency, formatDate, hasCompletedCheckIn, INCOME_PAYMENT_CATEGORY, isIncomePayment,
+  removeBudgetCategory, reportingPeriodMonthCount, resolvePossibleDuplicate
 } from './finance-core.js';
 import { applyCreditReportImportPlan, buildCreditReportImportPlan } from './credit-report-intelligence.js';
 import { applyStatementImportPlan, buildStatementImportPlan } from './statement-intelligence.js';
@@ -27,6 +27,7 @@ let updateUiState = createUpdateUiState();
 let normalEventsBound = false;
 let recoveryEventsBound = false;
 let restoreEventsBound = false;
+const INCOME_PAYMENT_CATEGORY_VALUE = 'payment-category:income';
 
 const viewMeta = {
   today: ['ONE CLEAR MOVE', 'Today'], transactions: ['MONEY IN AND OUT', 'Payments'], pay: ['WHERE GROSS PAY GOES', 'Pay'],
@@ -79,7 +80,7 @@ function activateNormalMode(loaded) {
   }
   populateMonthOptions();
   populateAccountOptions();
-  populateBudgetCategoryOptions();
+  populatePaymentCategoryOptions();
   render();
   checkModel();
 }
@@ -345,7 +346,7 @@ function selectView(name) {
 
 function render() {
   populateMonthOptions();
-  populateBudgetCategoryOptions();
+  populatePaymentCategoryOptions();
   const month = state.settings.selectedMonth;
   const summary = calculatePeriodSummary(state, month);
   pendingAction = buildNextAction(state);
@@ -430,7 +431,10 @@ function renderTransactions() {
     .filter((item) => state.settings.selectedMonth === ALL_TIME_PERIOD || String(item.budgetMonth || item.date).startsWith(state.settings.selectedMonth))
     .filter((item) => account === 'all' || item.accountId === account)
     .filter((item) => type === 'all' || (type === 'incoming' && item.incoming > 0) || (type === 'outgoing' && item.outgoing > 0) || (type === 'transfer' && item.transferStatus !== 'no'))
-    .filter((item) => category === 'all' || (category === 'uncategorised' ? uncategorised.has(item.id) : budgetByTransaction.get(item.id)?.id === category))
+    .filter((item) => category === 'all'
+      || (category === 'uncategorised' ? uncategorised.has(item.id)
+        : category === INCOME_PAYMENT_CATEGORY_VALUE ? isIncomePayment(item)
+          : budgetByTransaction.get(item.id)?.id === category))
     .filter((item) => !search || [item.description, item.userDescription, budgetByTransaction.get(item.id)?.category, item.category, item.notes].join(' ').toLowerCase().includes(search))
     .sort((left, right) => left.date.localeCompare(right.date) || Number(left.sourceRow || 0) - Number(right.sourceRow || 0));
   const body = byId('transactionRows');
@@ -445,7 +449,8 @@ function renderTransactions() {
     if (item.userDescription) description.append(element('span', '', item.description));
     const badges = document.createElement('span');
     badges.className = 'note-preview';
-    badges.textContent = budgetByTransaction.get(item.id)?.category || (uncategorised.has(item.id) ? 'Uncategorised' : item.category || 'Not included in budget');
+    badges.textContent = isIncomePayment(item) ? INCOME_PAYMENT_CATEGORY
+      : budgetByTransaction.get(item.id)?.category || (uncategorised.has(item.id) ? 'Uncategorised' : item.category || 'Not included in budget');
     if (item.transferStatus !== 'no') badges.textContent += ` · ${item.transferStatus} transfer`;
     if (item.duplicateStatus === 'possible') {
       const duplicateLabel = item.reviewStatus === 'accepted' ? 'accepted possible duplicate'
@@ -582,7 +587,7 @@ function renderBudget() {
   byId('uncategorisedBudgetValue').textContent = formatCurrency(analysis.uncategorisedActual);
   byId('uncategorisedBudgetNotice').hidden = analysis.uncategorisedActual <= 0;
   const list = byId('budgetRows'); clear(list);
-  if (!state.budgets.length) {
+  if (!analysis.rows.length) {
     const empty = element('div', 'empty-inline', 'No budget items yet. Add essentials first, then minimum debt payments.');
     list.append(empty);
   }
@@ -1007,8 +1012,8 @@ function openEditor(type, id = '') {
   editorContext = { type, id };
   const collection = collectionFor(type);
   const item = id ? state[collection].find((entry) => entry.id === id) : null;
-  const editorItem = type === 'transaction' && item && !item.budgetCategoryId && item.categorySource !== 'manual'
-    ? { ...item, budgetCategoryId: legacyBudgetIdForTransaction(item) }
+  const editorItem = type === 'transaction' && item
+    ? transactionEditorItem(item)
     : item;
   byId('editEyebrow').textContent = item ? 'EDIT' : 'ADD';
   byId('editTitle').textContent = `${item ? 'Edit' : 'Add'} ${type === 'account' ? 'bank account' : type}`;
@@ -1032,7 +1037,10 @@ function editorDefinitions(type) {
     ['accountId', 'Account', 'select', state.accounts.map((account) => [account.id, account.name])], ['date', 'Date', 'date'],
     ['description', 'Statement / payment description', 'text', 'Required', 'wide-field'], ['userDescription', 'Your description', 'text', 'Optional clearer name', 'wide-field'],
     ['incoming', 'Incoming', 'number'], ['outgoing', 'Outgoing', 'number'], ['runningBalance', 'Running balance', 'number'],
-    ['budgetCategoryId', 'Budget category', 'select', [['','Uncategorised'], ...state.budgets.map((budget) => [budget.id, budget.category])]],
+    ['budgetCategoryId', 'Payment category', 'select', [
+      ['','Uncategorised'], [INCOME_PAYMENT_CATEGORY_VALUE, INCOME_PAYMENT_CATEGORY],
+      ...state.budgets.filter((budget) => !isIncomePayment({ category: budget.category })).map((budget) => [budget.id, budget.category])
+    ]],
     ['category', 'Statement category label', 'text'],
     ['budgetTreatment', 'Budget treatment', 'select', [['auto','Automatic'],['spending','Spending'],['refund','Refund'],['reversal','Reversal'],['transfer','Internal transfer'],['savings_transfer','Savings transfer'],['debt_payment','Debt payment'],['ignored','Do not include']]],
     ['transferStatus', 'Internal transfer match', 'select', [['no','No'],['possible','Possible'],['confirmed','Confirmed']]], ['recurring', 'Recurring payment', 'checkbox'], ['notes', 'Notes', 'textarea', '', 'wide-field']
@@ -1073,6 +1081,7 @@ async function saveEditor(event) {
   const { type, id } = editorContext;
   const collection = collectionFor(type);
   let item = id ? state[collection].find((entry) => entry.id === id) : null;
+  const wasIncomePayment = type === 'transaction' && isIncomePayment(item);
   const previousBudgetCategory = type === 'budget' ? item?.category : '';
   if (!item) { item = { id: createId(type) }; state[collection].push(item); }
   for (const definition of editorDefinitions(type)) {
@@ -1086,8 +1095,14 @@ async function saveEditor(event) {
     item.budgetMonth = item.date?.slice(0, 7) || state.settings.selectedMonth;
     item.source ||= 'manual'; item.cleared ??= true; item.incoming = Number(item.incoming || 0); item.outgoing = Number(item.outgoing || 0);
     item.categorySource = 'manual';
-    const budget = state.budgets.find((entry) => entry.id === item.budgetCategoryId);
-    if (budget) item.category = budget.category;
+    if (item.budgetCategoryId === INCOME_PAYMENT_CATEGORY_VALUE) {
+      item.budgetCategoryId = '';
+      item.category = INCOME_PAYMENT_CATEGORY;
+    } else {
+      const budget = state.budgets.find((entry) => entry.id === item.budgetCategoryId);
+      if (budget) item.category = budget.category;
+      else if (wasIncomePayment && isIncomePayment(item)) item.category = '';
+    }
   }
   if (type === 'budget' && previousBudgetCategory && previousBudgetCategory !== item.category) {
     for (const transaction of state.transactions) {
@@ -1098,7 +1113,7 @@ async function saveEditor(event) {
   if (type === 'account') { item.name ||= 'Unnamed account'; item.active ??= true; }
   await saveState();
   if (type === 'account') populateAccountOptions();
-  if (type === 'budget') populateBudgetCategoryOptions();
+  if (type === 'budget') populatePaymentCategoryOptions();
   if (type === 'transaction' || type === 'payslip') populateMonthOptions();
   byId('editDialog').close(); editorContext = null; render(); showToast('Saved.');
 }
@@ -1116,7 +1131,7 @@ async function deleteEditedItem(type, id) {
   const collection = collectionFor(type); state[collection] = state[collection].filter((item) => item.id !== id);
   await saveState();
   if (type === 'account') populateAccountOptions();
-  if (type === 'budget') populateBudgetCategoryOptions();
+  if (type === 'budget') populatePaymentCategoryOptions();
   byId('editDialog').close(); editorContext = null; render(); showToast('Deleted.');
 }
 
@@ -1132,7 +1147,7 @@ async function removeBudgetItem(id, closeEditor = false) {
     : '';
   if (!window.confirm(`Remove ${budget.category} from your budget?${linkedMessage}`)) return;
   await saveState(removeBudgetCategory(state, id));
-  populateBudgetCategoryOptions();
+  populatePaymentCategoryOptions();
   if (closeEditor && byId('editDialog').open) byId('editDialog').close();
   editorContext = closeEditor ? null : editorContext;
   render();
@@ -1495,15 +1510,26 @@ function populateAccountOptions() {
   }
 }
 
-function populateBudgetCategoryOptions() {
+function populatePaymentCategoryOptions() {
   const select = byId('transactionCategoryFilter');
   if (!select) return;
   const selected = select.value || 'all';
   clear(select);
-  for (const [value, label] of [['all', 'All categories'], ['uncategorised', 'Uncategorised'], ...state.budgets.map((budget) => [budget.id, budget.category])]) {
+  for (const [value, label] of [
+    ['all', 'All categories'], ['uncategorised', 'Uncategorised'], [INCOME_PAYMENT_CATEGORY_VALUE, INCOME_PAYMENT_CATEGORY],
+    ...state.budgets.filter((budget) => !isIncomePayment({ category: budget.category })).map((budget) => [budget.id, budget.category])
+  ]) {
     const option = document.createElement('option'); option.value = value; option.textContent = label; select.append(option);
   }
   select.value = [...select.options].some((option) => option.value === selected) ? selected : 'all';
+}
+
+function transactionEditorItem(transaction) {
+  if (isIncomePayment(transaction)) return { ...transaction, budgetCategoryId: INCOME_PAYMENT_CATEGORY_VALUE };
+  if (!transaction.budgetCategoryId && transaction.categorySource !== 'manual') {
+    return { ...transaction, budgetCategoryId: legacyBudgetIdForTransaction(transaction) };
+  }
+  return transaction;
 }
 
 function legacyBudgetIdForTransaction(transaction) {

--- a/tests/budget-payment-sync.test.js
+++ b/tests/budget-payment-sync.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import {
   calculateBudgetAnalysis, calculateBudgetRows, calculatePeriodSummary, findSavingsOpportunities,
-  isTransactionFinanciallyActive, removeBudgetCategory, resolvePossibleDuplicate
+  INCOME_PAYMENT_CATEGORY, isIncomePayment, isTransactionFinanciallyActive, removeBudgetCategory, resolvePossibleDuplicate
 } from '../finance-core.js';
 import { financialSnapshot } from '../local-llm-service.js';
 
@@ -88,6 +88,92 @@ test('confirmed internal transfers and explicit savings transfers do not count a
   const analysis = calculateBudgetAnalysis(input);
   assert.equal(analysis.actual, 0);
   assert.equal(analysis.uncategorisedActual, 0);
+});
+
+test('Income is a recognised payment category that remains in cashflow but never becomes budget expenditure', () => {
+  const income = {
+    id: 'salary', date: '2026-08-01', budgetMonth: '2026-08', incoming: 2100, outgoing: 0,
+    transferStatus: 'no', description: 'Fictional salary', category: INCOME_PAYMENT_CATEGORY,
+    budgetCategoryId: 'groceries', categorySource: 'manual'
+  };
+  const input = state({
+    budgets: [
+      { id: 'groceries', category: 'Groceries', planned: 300 },
+      { id: 'income-budget', category: 'Income', planned: 2100 }
+    ],
+    transactions: [income, outgoing('food', 200, { category: 'Groceries' })]
+  });
+
+  const analysis = calculateBudgetAnalysis(input);
+  const summary = calculatePeriodSummary(input);
+
+  assert.equal(isIncomePayment(income), true);
+  assert.deepEqual(analysis.rows.map((row) => row.id), ['groceries']);
+  assert.equal(analysis.rows[0].actual, 200);
+  assert.equal(analysis.rows[0].remaining, 100);
+  assert.equal(analysis.rows[0].progressPercent, 67);
+  assert.equal(analysis.actual, 200);
+  assert.equal(analysis.uncategorisedActual, 0);
+  assert.deepEqual(analysis.uncategorisedTransactionIds, []);
+  assert.equal(summary.income, 2100);
+  assert.equal(summary.spending, 200);
+  assert.equal(summary.netCashFlow, 1900);
+});
+
+test('Income exclusion is category-based even when an Income payment has an outgoing value', () => {
+  const analysis = calculateBudgetAnalysis(state({ transactions: [
+    outgoing('income-correction', 75, {
+      category: ' income ', budgetCategoryId: 'groceries', categorySource: 'manual'
+    })
+  ] }));
+
+  assert.equal(analysis.rows[0].actual, 0);
+  assert.equal(analysis.actual, 0);
+  assert.equal(analysis.uncategorisedActual, 0);
+  assert.equal(analysis.coveragePercent, 100);
+  assert.deepEqual(analysis.uncategorisedTransactionIds, []);
+});
+
+test('Income stays excluded from six-month plan-versus-actual calculations', () => {
+  const transactions = [];
+  for (let month = 3; month <= 8; month += 1) {
+    const period = `2026-${String(month).padStart(2, '0')}`;
+    transactions.push({
+      id: `salary-${period}`, date: `${period}-01`, budgetMonth: period, incoming: 2100, outgoing: 0,
+      transferStatus: 'no', description: 'Fictional salary', category: INCOME_PAYMENT_CATEGORY
+    });
+    transactions.push(outgoing(`food-${period}`, 270, {
+      date: `${period}-08`, budgetMonth: period, category: 'Groceries'
+    }));
+  }
+  const input = state({ settings: { selectedMonth: 'all' }, budgets: [{ id: 'groceries', category: 'Groceries', planned: 300 }], transactions });
+
+  const analysis = calculateBudgetAnalysis(input);
+  const summary = calculatePeriodSummary(input);
+
+  assert.equal(analysis.monthCount, 6);
+  assert.equal(analysis.rows[0].planned, 1800);
+  assert.equal(analysis.rows[0].actual, 1620);
+  assert.equal(analysis.rows[0].remaining, 180);
+  assert.equal(analysis.rows[0].progressPercent, 90);
+  assert.equal(analysis.actual, 1620);
+  assert.equal(summary.income, 12600);
+  assert.equal(summary.spending, 1620);
+  assert.equal(summary.netCashFlow, 10980);
+});
+
+test('positive payments are not automatically rewritten as Income', () => {
+  const payment = {
+    id: 'refund-or-reimbursement', date: '2026-08-12', budgetMonth: '2026-08', incoming: 50, outgoing: 0,
+    transferStatus: 'no', description: 'Fictional positive payment', category: ''
+  };
+  const input = state({ transactions: [payment] });
+
+  calculateBudgetAnalysis(input);
+  calculatePeriodSummary(input);
+
+  assert.equal(payment.category, '');
+  assert.equal(isIncomePayment(payment), false);
 });
 
 test('debt repayments are excluded unless assigned to an explicit commitment budget', () => {
@@ -255,6 +341,17 @@ test('budget rows expose clear accessible edit and remove controls', () => {
   assert.match(renderer, /Remove \$\{item\.category\} from budget/);
   assert.match(styles, /\.budget-item-actions\s*\{[^}]*display: flex/);
   assert.match(styles, /\.budget-remove-button\s*\{/);
+});
+
+test('payment editing and filtering expose Income as a standard category', () => {
+  const html = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  const renderer = fs.readFileSync(new URL('../renderer-app.js', import.meta.url), 'utf8');
+
+  assert.match(html, /<label>Payment category<select id="transactionCategoryFilter">/);
+  assert.match(renderer, /\['','Uncategorised'\], \[INCOME_PAYMENT_CATEGORY_VALUE, INCOME_PAYMENT_CATEGORY\]/);
+  assert.match(renderer, /item\.category = INCOME_PAYMENT_CATEGORY/);
+  assert.match(renderer, /category === INCOME_PAYMENT_CATEGORY_VALUE \? isIncomePayment\(item\)/);
+  assert.match(renderer, /isIncomePayment\(item\) \? INCOME_PAYMENT_CATEGORY/);
 });
 
 test('edited amount, date and planned amount are derived without cached actuals', () => {


### PR DESCRIPTION
### Purpose

Add a standard `Income` payment category so incoming payments can be categorised without appearing as Uncategorised, while keeping expenditure-based budget calculations accurate.

The central rule is: income remains part of Payments and cashflow reporting, but a transaction assigned to the Income category is not budget expenditure.

### Work completed

#### Payment categorisation

- Added `Income` to the standard payment categories.
- Made Income available in the existing payment editor.
- Added Income to payment-category filtering.
- Treated Income as a recognised category, so assigned transactions no longer appear as Uncategorised.
- Preserved Income transactions in Payments, search/filter workflows, incoming-money totals, and net cashflow.
- Kept categorisation explicit: positive payments are not automatically rewritten as Income.

#### Budget calculations and reporting

- Added an authoritative Income-category exclusion in `calculateBudgetAnalysis`.
- Excluded Income before budget matching, uncategorised spending, category actuals, percentage-used calculations, remaining amounts, and overspend status are calculated.
- Applied the same exclusion to monthly and all-time/multi-month budget analysis.
- Prevented Income from producing expenditure budget rows or affecting percentage-based row ranking.
- Preserved existing expenditure and refund behaviour for all other categories.

#### UI

- Added Income to the payment category selector.
- Added Income-aware payment display and category filtering.
- Renamed the category filter label from “Budget category” to “Payment category” because it now includes a non-budget payment category.

### Files changed

- `finance-core.js` — defines the Income category and centrally excludes assigned Income transactions from expenditure-budget analysis while leaving cashflow calculations unchanged.
- `renderer-app.js` — adds Income to payment editing, display, filtering, and recognised-category handling.
- `index.html` — renames the transaction category filter label to reflect payment categories.
- `tests/budget-payment-sync.test.js` — adds monthly, six-month, cashflow, UI, uncategorised, direction-independent, and regression coverage.

No files were added, renamed, or deleted.

### User-facing changes

- Users can manually change an existing payment from Uncategorised to Income without re-importing a document.
- Income transactions remain visible and usable in Payments.
- Income contributes to money-in and net-cashflow totals.
- Income no longer changes budget spending, remaining allowance, percentage used, overspend warnings, plan-versus-actual results, or all-time budget calculations.
- Other positive transactions remain unchanged unless the user explicitly assigns Income.

### Technical changes

- Uses the existing string-based transaction category field; no new data model or hidden transaction direction rule was introduced.
- The exclusion is enforced in shared financial logic rather than only in the UI.
- No dependency or configuration changes.
- No database, schema, storage-format, import, export, encryption, privacy, or security changes.
- No telemetry, analytics, cloud storage, or network service was added.
- No payslip or document-intelligence code was changed.

### Testing and verification

- **Passed:** `npm test` — 214/214 tests.
- **Passed:** targeted payment/budget suite — 27/27 tests.
- **Passed:** `npm run check`.
- **Passed:** repository privacy check.
- **Passed:** JavaScript syntax checks.
- **Passed:** Windows unpacked application packaging to `win-unpacked`.
- **Passed:** remote comparison — branch is one commit ahead of `main`, zero commits behind, and modifies only the four intended files.
- **Passed:** byte-for-byte verification — all four remote Git blob hashes match the approved local commit `3389e07`.
- **Unavailable:** interactive Electron startup/capture. Electron reached its runtime, but the restricted Linux container denied DBus, udev, and network-socket access and terminated the Electron process.
- **Unavailable:** final NSIS Windows installer generation because Wine is not installed in the Linux environment.
- **Not configured:** dedicated lint and type-check scripts are not present in the repository.

### Data and migration impact

- No migration is required.
- Existing transaction categories and stored financial data remain valid.
- Existing transactions are not rewritten, deleted, duplicated, re-dated, or re-valued.
- Payslip records and imported documents are unchanged.
- Historical budget amounts are unchanged.

### Known limitations

- Native interactive Electron desktop verification could not be completed in the restricted Linux environment.
- The final NSIS installer step could not run without Wine; the unpacked Windows application build completed successfully.
- Dedicated lint and type-check commands are unavailable because the repository does not define them.
- No other known issues.

### Excluded work

- Payslip parsing, importing, deductions, field detection, previews, storage, duplicate handling, and automatic payment creation.
- MyNavy payslip compatibility.
- Automatic salary detection or automatic recategorisation of positive payments.
- Income budgets, targets, forecasting, or a separate Income dashboard.
- Document-import and document-intelligence changes.

### Branch details

- Branch: `feature/income-payment-categorisation`
- Commit SHA: `a27189d79e38756b2c756c92ee27c6377982e816`
- Pull request: This draft pull request.
- Target branch: `main`

### Confirmations

- No changes were committed or pushed directly to `main`.
- The pull request has not been merged.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs were committed.
- Only files relevant to the requested payment-categorisation and budget-logic work were changed.
