### PR TITLE
[v2.1.19][Feature] MyNavy payslips and manual pay deductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ New installations start completely blank. This repository contains no personal a
 - Preserves newer balances and known defaults, arrears or arrangements when a report is older, incomplete or ambiguous, while keeping current-account borrowing as overdrafts.
 - Separates debts from overdrafts while applying one shared safety assessment to payoff forecasts, generated actions and local guidance.
 - Protects required payments and confirmed arrangements before considering an optional debt payment.
-- Tracks gross pay, PAYE, National Insurance, other deductions and net pay from supported payslips.
+- Tracks gross pay, PAYE, National Insurance, other deductions and net pay from supported payslips or manually entered pay records.
 - Stores imported originals in an encrypted local document vault.
 - Adds notes and clearer descriptions to accounts, payments, debts and overdrafts.
 - Detects exact and possible duplicate transactions conservatively.
@@ -41,6 +41,8 @@ Bank statements:
 Payslips:
 
 - JPA E017 PDF payslips
+- MyNavy Statement of Salary and Deductions PDFs, including itemised payments, deductions, current-period balances and year-to-date totals
+- Manual pay entry and full pay-record editing, with deduction totals calculated from itemised lines and reconciliation required before saving
 
 Credit reports:
 

--- a/document-import.js
+++ b/document-import.js
@@ -11,7 +11,7 @@ export function parseImportedDocument(fileName, payload, requestedKind = 'auto',
   const kind = requestedKind === 'auto' ? inferDocumentKind(fileName, payload?.text || String(payload || '')) : requestedKind;
 
   if (kind === 'payslip') {
-    return parsePayslipText(payload.text || String(payload || ''), fileName);
+    return parsePayslipDocument(payload, fileName);
   }
 
   if (kind === 'credit-report') {
@@ -31,7 +31,80 @@ export function parseImportedDocument(fileName, payload, requestedKind = 'auto',
   return rejectedImport('Unsupported file type. Use PDF, CSV, TSV, QIF, OFX, QFX or JSON.');
 }
 
+export function parsePayslipDocument(payload, fileName = 'Payslip.pdf') {
+  const document = payload && typeof payload === 'object' ? payload : { text: String(payload || '') };
+  const text = document.text || '';
+  return isMyNavyPayslip(text)
+    ? parseMyNavyPayslip(document, fileName)
+    : parsePayslipText(text, fileName);
+}
+
+export function parseMyNavyPayslip(document, fileName = 'MyNavy-payslip.pdf') {
+  const sourceText = String(document?.text || document || '');
+  const normal = normaliseWhitespace(sourceText);
+  const summaryValues = myNavySummaryValues(normal);
+  const currentBalances = labelledPayBalances(normal, 'PTD');
+  const ytdBalances = labelledPayBalances(normal, 'YTD');
+  const payDateText = myNavyPayDate(document, normal);
+  const payDate = parseDate(payDateText.replace(/-/g, ' '));
+  const period = payDate ? payDate.slice(0, 7) : '';
+  const annualSalary = findMoney(normal, /Annual Salary\s+([\d,]+\.\d{2})/i);
+  const taxDetails = myNavyTaxDetails(document, sourceText);
+  const table = myNavyLineItems(document, sourceText, summaryValues);
+  const gross = summaryValues.gross ?? currentBalances.grossPay;
+  const totalDeductions = summaryValues.deductions ?? roundMoney(table.deductions.reduce((sum, item) => sum + item.amount, 0));
+  const net = summaryValues.net;
+  const warnings = [];
+  const rejected = [];
+  const earningsTotal = roundMoney(table.earnings.reduce((sum, item) => sum + item.amount, 0));
+  const deductionsTotal = roundMoney(table.deductions.reduce((sum, item) => sum + item.amount, 0));
+
+  if (!period || gross === null || net === null) rejected.push({ row: 1, reason: 'Could not find the pay date, total gross pay or total amount paid.' });
+  if (!table.earnings.length) warnings.push('No itemised payment lines were detected.');
+  if (!table.deductions.length && totalDeductions) warnings.push('No itemised deduction lines were detected.');
+  if (gross !== null && table.earnings.length && Math.abs(earningsTotal - gross) > 0.02) warnings.push(`Payment lines total £${earningsTotal.toFixed(2)}, not gross pay £${gross.toFixed(2)}.`);
+  if (totalDeductions !== null && table.deductions.length && Math.abs(deductionsTotal - totalDeductions) > 0.02) warnings.push(`Deduction lines total £${deductionsTotal.toFixed(2)}, not £${totalDeductions.toFixed(2)}.`);
+  if (gross !== null && net !== null && totalDeductions !== null && Math.abs(roundMoney(gross - totalDeductions) - net) > 0.02) warnings.push('Gross pay less deductions does not reconcile to net pay.');
+
+  const payslip = {
+    id: stableId('payslip', fileName, period, gross, net),
+    provider: 'mynavy',
+    period,
+    payDate,
+    annualSalary,
+    grossPay: gross,
+    taxablePay: currentBalances.taxablePay,
+    niablePay: currentBalances.niablePay,
+    totalDeductions,
+    netPay: net,
+    taxCode: taxDetails.taxCode,
+    taxBasis: taxDetails.taxBasis,
+    niCategory: taxDetails.niCategory,
+    employerPayeReference: taxDetails.employerPayeReference,
+    grossPayYtd: ytdBalances.grossPay,
+    taxablePayYtd: ytdBalances.taxablePay,
+    niablePayYtd: ytdBalances.niablePay,
+    payeYtd: ytdBalances.paye,
+    niEmployeeYtd: ytdBalances.niEmployee,
+    niEmployerYtd: ytdBalances.niEmployer,
+    earnings: table.earnings,
+    deductions: table.deductions,
+    notes: '',
+    source: fileName
+  };
+
+  return {
+    kind: 'payslip',
+    records: rejected.length ? [] : [payslip],
+    rejected,
+    warnings,
+    summary: { provider: 'mynavy', period, gross, deductions: totalDeductions, net, earningsTotal },
+    reconciled: !rejected.length && !warnings.length
+  };
+}
+
 export function parsePayslipText(text, fileName = 'Payslip.pdf') {
+  if (isMyNavyPayslip(text)) return parseMyNavyPayslip({ text }, fileName);
   const normal = normaliseWhitespace(text);
   const gross = findMoney(normal, /Gross Pay PTD\s+([\d,]+\.\d{2})/i);
   const taxable = findMoney(normal, /Taxable Pay PTD\s+([\d,]+\.\d{2})/i);
@@ -61,6 +134,7 @@ export function parsePayslipText(text, fileName = 'Payslip.pdf') {
 
   const payslip = {
     id: stableId('payslip', fileName, period, gross, net),
+    provider: 'jpa',
     period,
     payDate,
     annualSalary,
@@ -83,6 +157,139 @@ export function parsePayslipText(text, fileName = 'Payslip.pdf') {
     summary: { period, gross, deductions: totalDeductions || deductionsTotal, net, earningsTotal },
     reconciled: !rejected.length && !warnings.length
   };
+}
+
+function isMyNavyPayslip(text) {
+  const value = String(text || '');
+  return /Statement of Salary and Deductions/i.test(value)
+    && /Summary of Payments/i.test(value)
+    && /Total Amount Paid/i.test(value);
+}
+
+function myNavySummaryValues(text) {
+  const match = String(text || '').match(/Total Gross Pay\s+Total Deductions\s+Total Amount Paid\s+(-?[\d,]+\.\d{2})\s+(-?[\d,]+\.\d{2})\s+(-?[\d,]+\.\d{2})/i);
+  return {
+    gross: match ? parseMoney(match[1]) : findMoney(text, /Total Gross Pay\s+(-?[\d,]+\.\d{2})/i),
+    deductions: match ? parseMoney(match[2]) : findMoney(text, /Total Deductions\s+(-?[\d,]+\.\d{2})/i),
+    net: match ? parseMoney(match[3]) : findMoney(text, /Total Amount Paid\s+(-?[\d,]+\.\d{2})/i)
+  };
+}
+
+function myNavyPayDate(document, text) {
+  for (const page of document?.pages || []) {
+    const heading = page.lines?.find((line) => line.items?.some((item) => /^Pay Date$/i.test(item.text)));
+    const headingItem = heading?.items?.find((item) => /^Pay Date$/i.test(item.text));
+    if (!heading || !headingItem) continue;
+    const valueLine = page.lines.find((line) => line.y < heading.y && heading.y - line.y < 18);
+    const value = valueLine?.items?.find((item) => item.x >= headingItem.x - 8)?.text || '';
+    if (/^\d{1,2}[- ](?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[- ]20\d{2}$/i.test(value)) return value;
+  }
+  return String(text || '').match(/Pay Date[\s\S]{0,80}?(\d{1,2}[- ](?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[- ]20\d{2})/i)?.[1] || '';
+}
+
+function labelledPayBalances(text, period) {
+  const value = String(text || '');
+  return {
+    grossPay: findMoney(value, new RegExp(`Gross Pay ${period}\\s+(-?[\\d,]+\\.\\d{2})`, 'i')),
+    taxablePay: findMoney(value, new RegExp(`Taxable Pay ${period}\\s+(-?[\\d,]+\\.\\d{2})`, 'i')),
+    niablePay: findMoney(value, new RegExp(`NIable Pay ${period}\\s+(-?[\\d,]+\\.\\d{2})`, 'i')),
+    paye: findMoney(value, new RegExp(`PAYE ${period}\\s+(-?[\\d,]+\\.\\d{2})`, 'i')),
+    niEmployee: findMoney(value, new RegExp(`NI Employee ${period}\\s+(-?[\\d,]+\\.\\d{2})`, 'i')),
+    niEmployer: findMoney(value, new RegExp(`NI Employer ${period}\\s+(-?[\\d,]+\\.\\d{2})`, 'i'))
+  };
+}
+
+function myNavyTaxDetails(document, text) {
+  for (const page of document?.pages || []) {
+    const headings = page.lines?.find((line) => line.items?.some((item) => /^Tax Code$/i.test(item.text)) && line.items.some((item) => /PAYE Reference/i.test(item.text)));
+    if (!headings) continue;
+    const values = page.lines.find((line) => line.y < headings.y && headings.y - line.y < 18 && line.items?.length >= 3);
+    if (!values) continue;
+    return {
+      taxCode: valueAtX(values.items, 0, 200),
+      taxBasis: valueAtX(values.items, 200, 360),
+      niCategory: valueAtX(values.items, 360, 470),
+      employerPayeReference: valueAtX(values.items, 470, Infinity)
+    };
+  }
+
+  const normal = normaliseWhitespace(text);
+  const match = normal.match(/Tax Code\s+Tax Basis\s+NI Category\s+Employers PAYE Reference Number\s+(\S+)\s+(.+?)\s+([A-Z])\s+(\S+)/i);
+  return {
+    taxCode: match?.[1] || '',
+    taxBasis: match?.[2]?.trim() || '',
+    niCategory: match?.[3] || '',
+    employerPayeReference: match?.[4] || ''
+  };
+}
+
+function valueAtX(items, minimum, maximum) {
+  return (items || []).filter((item) => item.x >= minimum && item.x < maximum).map((item) => item.text).join(' ').trim();
+}
+
+function myNavyLineItems(document, text, expected) {
+  for (const page of document?.pages || []) {
+    const header = page.lines?.find((line) => line.items?.some((item) => /^Payments$/i.test(item.text)) && line.items.some((item) => /^Deductions$/i.test(item.text)));
+    const footer = page.lines?.find((line) => line.items?.some((item) => /^Net Pay \/ Distribution$/i.test(item.text)));
+    if (!header || !footer || header.y <= footer.y) continue;
+    const splitX = header.items.find((item) => /^Deductions$/i.test(item.text))?.x;
+    if (!Number.isFinite(splitX)) continue;
+    const earnings = [];
+    const deductions = [];
+    const rows = page.lines.filter((line) => line.y < header.y && line.y > footer.y);
+    for (const line of rows) {
+      const left = parsePayTableSide(line.items.filter((item) => item.x < splitX), 'earning');
+      const right = parsePayTableSide(line.items.filter((item) => item.x >= splitX), 'deduction');
+      if (left) earnings.push(left);
+      if (right) deductions.push(right);
+    }
+    if (earnings.length || deductions.length) return { earnings, deductions };
+  }
+  return myNavyTextLineItems(text, expected);
+}
+
+function parsePayTableSide(items, type) {
+  const values = (items || []).filter((item) => !/^(?:Description|Amount)$/i.test(item.text));
+  const amountIndex = values.findLastIndex((item) => MONEY_PATTERN.test(item.text));
+  if (amountIndex <= 0) return null;
+  const name = values.slice(0, amountIndex).map((item) => item.text).join(' ').trim();
+  const amount = parseMoney(values[amountIndex].text);
+  if (!name || amount === null) return null;
+  return { id: stableId(type, name), name, amount, type, notes: '' };
+}
+
+function myNavyTextLineItems(text, expected = {}) {
+  const lines = String(text || '').split(/\r?\n/);
+  const start = lines.findIndex((line) => /^\s*Payments\s{2,}Deductions\s*$/i.test(line));
+  const end = lines.findIndex((line, index) => index > start && /Net Pay\s*\/\s*Distribution/i.test(line));
+  if (start < 0 || end < 0) return { earnings: [], deductions: [] };
+  const earnings = [];
+  const deductions = [];
+  for (const line of lines.slice(start + 1, end)) {
+    if (/^\s*(?:Description\s+Amount){1,2}\s*$/i.test(line)) continue;
+    const parts = line.trim().split(/\s{3,}/).map((part) => part.trim()).filter(Boolean);
+    if (parts.length >= 4 && MONEY_PATTERN.test(parts[1]) && MONEY_PATTERN.test(parts.at(-1))) {
+      const left = textPayItem(parts[0], parts[1], 'earning');
+      const right = textPayItem(parts.slice(2, -1).join(' '), parts.at(-1), 'deduction');
+      if (left) earnings.push(left);
+      if (right) deductions.push(right);
+      continue;
+    }
+    const match = line.trim().match(/^(.*?)\s+(-?[\d,]+\.\d{2})\s*$/);
+    if (!match) continue;
+    const earningsTotal = roundMoney(earnings.reduce((sum, item) => sum + item.amount, 0));
+    const type = expected.gross !== null && Math.abs(earningsTotal - Number(expected.gross || 0)) <= 0.02 ? 'deduction' : 'earning';
+    const item = textPayItem(match[1], match[2], type);
+    if (item) (type === 'deduction' ? deductions : earnings).push(item);
+  }
+  return { earnings, deductions };
+}
+
+function textPayItem(name, value, type) {
+  const amount = parseMoney(value);
+  const label = String(name || '').trim();
+  if (!label || amount === null) return null;
+  return { id: stableId(type, label), name: label, amount, type, notes: '' };
 }
 
 export function parseCreditReportText(text, fileName = 'credit-report.pdf') {

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
         </section>
 
         <section id="view-pay" class="view" hidden>
-          <div class="section-actions"><div><h2>Pay and deductions</h2><p>Gross pay, allowances, tax, National Insurance and net pay are tracked without double-counting your bank income.</p></div><button id="importPayslipButton" class="primary-button">Import payslip</button></div>
+          <div class="section-actions"><div><h2>Pay and deductions</h2><p>Gross pay, allowances, tax, National Insurance and net pay are tracked without double-counting your bank income.</p></div><div class="button-row"><button id="importPayslipButton" class="primary-button">Import payslip</button><button class="secondary-button" data-add="payslip">Add pay manually</button></div></div>
           <div class="metric-grid three"><article class="metric-card"><span>Gross pay</span><strong id="grossPayValue">£0.00</strong><small id="grossPayHint">Selected month</small></article><article class="metric-card"><span>Payroll deductions</span><strong id="deductionsValue">£0.00</strong><small id="deductionsHint">Tax, NI and other deductions</small></article><article class="metric-card"><span>Net pay</span><strong id="netPayValue">£0.00</strong><small id="netPayHint">Amount paid by payroll</small></article></div>
           <div id="payslipList" class="card-list"></div>
         </section>

--- a/main-process.js
+++ b/main-process.js
@@ -485,7 +485,7 @@ function canonicalDocumentName(document, preview, accountId, state) {
       : preview.summary?.statementEndDate || [...(preview.records || [])].map((item) => item.date).filter(Boolean).sort().at(-1) || new Date().toISOString().slice(0, 10);
   const type = preview.kind === 'payslip' ? 'payslip' : preview.kind === 'credit-report' ? 'credit-report' : 'bank-statement';
   const provider = preview.kind === 'payslip'
-    ? 'jpa'
+    ? slugName(record?.provider || 'jpa')
     : preview.kind === 'credit-report'
       ? slugName(record?.provider || 'unknown-provider')
       : slugName(state.accounts.find((account) => account.id === accountId)?.institution || 'unassigned');

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
       "local-llm-service.js",
       "main-process.js",
       "pdf-service.js",
+      "payslip-record.js",
       "preload-bridge.cjs",
       "renderer-app.js",
       "credit-report-intelligence.js",

--- a/payslip-record.js
+++ b/payslip-record.js
@@ -1,0 +1,116 @@
+const MONEY_TOLERANCE = 0.02;
+const PERIOD_PATTERN = /^20\d{2}-(?:0[1-9]|1[0-2])$/;
+const DATE_PATTERN = /^20\d{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])$/;
+
+export function payslipEditorItem(record = {}) {
+  return {
+    ...record,
+    earningsText: formatPayslipLineItems(record.earnings),
+    deductionsText: formatPayslipLineItems(record.deductions)
+  };
+}
+
+export function buildPayslipRecord(input, existing = {}) {
+  const errors = [];
+  const period = String(input.period || '').trim();
+  const payDate = String(input.payDate || '').trim();
+  const grossPay = moneyValue(input.grossPay);
+  const netPay = moneyValue(input.netPay);
+  const earningsResult = parsePayslipLineItems(input.earningsText, 'earning');
+  const deductionsResult = parsePayslipLineItems(input.deductionsText, 'deduction');
+  errors.push(...earningsResult.errors, ...deductionsResult.errors);
+
+  if (!PERIOD_PATTERN.test(period)) errors.push('Pay month must use YYYY-MM.');
+  if (!DATE_PATTERN.test(payDate) || !validDate(payDate)) errors.push('Pay date must be a real date using YYYY-MM-DD.');
+  if (payDate && period && payDate.slice(0, 7) !== period) errors.push('Pay date must fall within the selected pay month.');
+  if (grossPay === null || grossPay < 0) errors.push('Gross pay must be zero or more.');
+  if (netPay === null || netPay < 0) errors.push('Net pay must be zero or more.');
+
+  const earningsTotal = roundMoney(earningsResult.items.reduce((sum, item) => sum + item.amount, 0));
+  const totalDeductions = roundMoney(deductionsResult.items.reduce((sum, item) => sum + item.amount, 0));
+  if (grossPay !== null && earningsResult.items.length && Math.abs(earningsTotal - grossPay) > MONEY_TOLERANCE) {
+    errors.push(`Payment lines total £${earningsTotal.toFixed(2)}, not gross pay £${grossPay.toFixed(2)}.`);
+  }
+  if (grossPay !== null && netPay !== null && Math.abs(roundMoney(grossPay - totalDeductions) - netPay) > MONEY_TOLERANCE) {
+    errors.push(`Gross pay less itemised deductions must equal net pay (expected £${roundMoney(grossPay - totalDeductions).toFixed(2)}).`);
+  }
+
+  const record = {
+    ...existing,
+    id: existing.id || String(input.id || ''),
+    provider: existing.provider || String(input.provider || 'manual').trim() || 'manual',
+    period,
+    payDate,
+    annualSalary: moneyValue(input.annualSalary),
+    grossPay,
+    taxablePay: moneyValue(input.taxablePay),
+    niablePay: moneyValue(input.niablePay),
+    totalDeductions,
+    netPay,
+    taxCode: String(input.taxCode || '').trim(),
+    taxBasis: String(input.taxBasis || '').trim(),
+    niCategory: String(input.niCategory || '').trim(),
+    employerPayeReference: String(input.employerPayeReference || '').trim(),
+    grossPayYtd: moneyValue(input.grossPayYtd),
+    taxablePayYtd: moneyValue(input.taxablePayYtd),
+    niablePayYtd: moneyValue(input.niablePayYtd),
+    payeYtd: moneyValue(input.payeYtd),
+    niEmployeeYtd: moneyValue(input.niEmployeeYtd),
+    niEmployerYtd: moneyValue(input.niEmployerYtd),
+    earnings: earningsResult.items,
+    deductions: deductionsResult.items,
+    notes: String(input.notes || '').trim(),
+    source: existing.source || 'Manual entry'
+  };
+
+  return { valid: errors.length === 0, errors, record, earningsTotal, totalDeductions };
+}
+
+export function parsePayslipLineItems(value, type) {
+  const items = [];
+  const errors = [];
+  const lines = String(value || '').split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    if (!line) continue;
+    const match = line.match(/^(.*?)(?:\s*[|:]\s*|\s{2,}|\t)([-+]?\s*(?:£|GBP)?\s*[\d,]+\.\d{1,2})$/i)
+      || line.match(/^(.*?)\s+([-+]?\s*(?:£|GBP)?\s*[\d,]+\.\d{1,2})$/i);
+    if (!match || !match[1].trim()) {
+      errors.push(`${type === 'earning' ? 'Payment' : 'Deduction'} line ${index + 1} must use “Description | 0.00”.`);
+      continue;
+    }
+    const amount = moneyValue(match[2]);
+    if (amount === null || amount < 0) {
+      errors.push(`${type === 'earning' ? 'Payment' : 'Deduction'} line ${index + 1} must have an amount of zero or more.`);
+      continue;
+    }
+    const name = match[1].trim();
+    items.push({ id: stableLineId(type, name, index), name, amount, type, notes: '' });
+  }
+  return { items, errors };
+}
+
+export function formatPayslipLineItems(items = []) {
+  return (items || []).map((item) => `${item.name} | ${Number(item.amount || 0).toFixed(2)}`).join('\n');
+}
+
+function moneyValue(value) {
+  if (value === '' || value === null || value === undefined) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? roundMoney(value) : null;
+  const number = Number(String(value).replace(/£|GBP|,/gi, '').trim());
+  return Number.isFinite(number) ? roundMoney(number) : null;
+}
+
+function stableLineId(type, name, index) {
+  const compact = `${type}-${name}-${index}`.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return compact || `${type}-${index + 1}`;
+}
+
+function validDate(value) {
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+function roundMoney(value) {
+  return Math.round((Number(value || 0) + Number.EPSILON) * 100) / 100;
+}

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -6,6 +6,7 @@ import {
 } from './finance-core.js';
 import { applyCreditReportImportPlan, buildCreditReportImportPlan } from './credit-report-intelligence.js';
 import { applyStatementImportPlan, buildStatementImportPlan } from './statement-intelligence.js';
+import { buildPayslipRecord, payslipEditorItem } from './payslip-record.js';
 import {
   applyUpdateStatus, createUpdateUiState, dismissUpdateNotification as dismissUpdateUiNotification,
   setInstalledVersion, updateUiView
@@ -488,7 +489,7 @@ function renderPay() {
     const summary = element('div', 'payslip-summary');
     const title = element('div', 'entity-title');
     append(title, element('h3', '', monthLabel(payslip.period)), element('p', '', `${payslip.source} · Paid ${formatDate(payslip.payDate)}`));
-    append(summary, title, stat('Gross', formatCurrency(payslip.grossPay)), stat('Deductions', formatCurrency(payslip.totalDeductions)), stat('Net', formatCurrency(payslip.netPay)), actionButton('payslip', payslip.id, 'Notes'));
+    append(summary, title, stat('Gross', formatCurrency(payslip.grossPay)), stat('Deductions', formatCurrency(payslip.totalDeductions)), stat('Net', formatCurrency(payslip.netPay)), actionButton('payslip', payslip.id, 'Edit'));
     const details = element('details');
     const detailsSummary = element('summary', '', 'Show earnings and deductions');
     const detailGrid = element('div', 'payslip-details');
@@ -1014,7 +1015,9 @@ function openEditor(type, id = '') {
   const item = id ? state[collection].find((entry) => entry.id === id) : null;
   const editorItem = type === 'transaction' && item
     ? transactionEditorItem(item)
-    : item;
+    : type === 'payslip'
+      ? payslipEditorItem(item || { period: state.settings.selectedMonth === ALL_TIME_PERIOD ? new Date().toISOString().slice(0, 7) : state.settings.selectedMonth })
+      : item;
   byId('editEyebrow').textContent = item ? 'EDIT' : 'ADD';
   byId('editTitle').textContent = `${item ? 'Edit' : 'Add'} ${type === 'account' ? 'bank account' : type}`;
   const fields = byId('editFields'); clear(fields);
@@ -1045,7 +1048,20 @@ function editorDefinitions(type) {
     ['budgetTreatment', 'Budget treatment', 'select', [['auto','Automatic'],['spending','Spending'],['refund','Refund'],['reversal','Reversal'],['transfer','Internal transfer'],['savings_transfer','Savings transfer'],['debt_payment','Debt payment'],['ignored','Do not include']]],
     ['transferStatus', 'Internal transfer match', 'select', [['no','No'],['possible','Possible'],['confirmed','Confirmed']]], ['recurring', 'Recurring payment', 'checkbox'], ['notes', 'Notes', 'textarea', '', 'wide-field']
   ];
-  if (type === 'payslip') return [['notes', 'Notes', 'textarea', '', 'wide-field']];
+  if (type === 'payslip') return [
+    ['period', 'Pay month', 'month'], ['payDate', 'Pay date', 'date'],
+    ['grossPay', 'Gross pay', 'number'], ['netPay', 'Net pay', 'number'],
+    ['taxablePay', 'Taxable pay', 'number'], ['niablePay', 'NI-able pay', 'number'],
+    ['annualSalary', 'Annual salary', 'number'], ['taxCode', 'Tax code', 'text'],
+    ['taxBasis', 'Tax basis', 'text'], ['niCategory', 'NI category', 'text'],
+    ['employerPayeReference', 'Employer PAYE reference', 'text'],
+    ['earningsText', 'Payments and allowances - one per line as Description | 0.00', 'textarea', 'Basic pay | 2500.00', 'wide-field'],
+    ['deductionsText', 'Deductions - one per line as Description | 0.00 (total calculated automatically)', 'textarea', 'PAYE | 350.00', 'wide-field'],
+    ['grossPayYtd', 'Gross pay YTD', 'number'], ['taxablePayYtd', 'Taxable pay YTD', 'number'],
+    ['niablePayYtd', 'NI-able pay YTD', 'number'], ['payeYtd', 'PAYE YTD', 'number'],
+    ['niEmployeeYtd', 'Employee NI YTD', 'number'], ['niEmployerYtd', 'Employer NI YTD', 'number'],
+    ['notes', 'Notes', 'textarea', '', 'wide-field']
+  ];
   if (type === 'budget') return [['section','Section','select',[['Essentials','Essentials'],['Debt minimums','Debt minimums'],['Flexible','Flexible'],['Goals','Goals']]], ['category','Category','text'], ['planned','Planned monthly amount','number'], ['notes','Notes','textarea','','wide-field']];
   const base = [['name','Name','text'], ['type','Type','text'], ['accountReference','Account reference / last four digits','text'], ['openedDate','Opened date','date'], ['defaultDate','Default date','date'], ['lastReportedAt','Last reported date','date'], ['currentBalance','Current balance','number'], ['aprPercent','APR (%) - leave blank if unknown','number'], ['contractualPayment','Contractual / minimum payment','number'], ['arrearsAmount','Known arrears amount','number'], ['status','Status','select',[['unknown','Unknown'],['current','Current'],['arrears','Arrears'],['defaulted','Defaulted'],['over_limit','Over limit']]], ['arrangementStatus','Payment arrangement','select',[['unknown','Unknown'],['none','Confirmed none'],['confirmed','Confirmed arrangement']]], ['arrangementPayment','Agreed arrangement payment','number'], ['includeInPlan','Include in payoff plan','checkbox'], ['statusConflict','Status information conflicts / needs checking','checkbox'], ['interestFrozen','Interest or charges frozen','checkbox'], ['description','Description','textarea','','wide-field'], ['notes','Notes','textarea','','wide-field']];
   if (type === 'overdraft') {
@@ -1081,6 +1097,25 @@ async function saveEditor(event) {
   const { type, id } = editorContext;
   const collection = collectionFor(type);
   let item = id ? state[collection].find((entry) => entry.id === id) : null;
+  if (type === 'payslip') {
+    const values = {};
+    for (const definition of editorDefinitions(type)) {
+      const [name, , fieldType] = definition;
+      const input = byId('editFields').querySelector(`[name="${name}"]`);
+      values[name] = fieldType === 'number' && input.value.trim() !== '' ? Number(input.value) : input.value.trim();
+    }
+    const result = buildPayslipRecord(values, item || { id: createId('payslip'), provider: 'manual', source: 'Manual entry' });
+    if (!result.valid) {
+      window.alert(`This pay record cannot be saved yet:\n\n${result.errors.join('\n')}`);
+      return;
+    }
+    if (item) Object.assign(item, result.record);
+    else state.payslips.push(result.record);
+    await saveState();
+    populateMonthOptions();
+    byId('editDialog').close(); editorContext = null; render(); showToast('Pay record saved.');
+    return;
+  }
   const wasIncomePayment = type === 'transaction' && isIncomePayment(item);
   const previousBudgetCategory = type === 'budget' ? item?.category : '';
   if (!item) { item = { id: createId(type) }; state[collection].push(item); }

--- a/tests/document-import.test.js
+++ b/tests/document-import.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { parseCreditReportText, parseCsvStatement, parseImportedDocument, parseOfxStatement, parsePayslipText, parsePdfStatement, parseQifStatement } from '../document-import.js';
+import { parseCreditReportText, parseCsvStatement, parseImportedDocument, parseOfxStatement, parsePayslipDocument, parsePayslipText, parsePdfStatement, parseQifStatement } from '../document-import.js';
 
 test('CSV with separate debit and credit columns keeps a positive BACS credit as income', () => {
   const result = parseCsvStatement('Date,Description,Debit,Credit,Balance\n31/01/2025,BACS PAYROLL,,2500.00,100.00', 'pay.csv', 'acct-1');
@@ -250,3 +250,103 @@ test('JPA payslip parser reconciles gross, detailed deductions and net pay', () 
   assert.equal(result.records[0].earnings.length, 1);
   assert.equal(result.records[0].deductions.length, 2);
 });
+
+test('MyNavy layout parser separates side-by-side payments and deductions and extracts balances', () => {
+  const text = `Statement of Salary and Deductions
+Pay Processing Information
+Period Type Tax Period Number Pay Date
+Calendar Month 8 31-Aug-2026
+Tax Details
+Tax Code Tax Basis NI Category Employers PAYE Reference Number
+1100L Cumulative A 123/AB456
+Summary of Payments
+Total Gross Pay Total Deductions Total Amount Paid
+3200.00 600.00 2600.00
+Payments                        Deductions
+Description          Amount    Description                 Amount
+Basic Pay           3000.00    Example deduction A          20.00
+Allowance            200.00    Example deduction B         100.00
+                                Example deduction C          10.00
+                                Example deduction D         400.00
+                                Example deduction E          20.00
+                                Example deduction F          50.00
+Net Pay / Distribution
+Balances Current Period Balances Current Tax Year
+Gross Pay PTD 3200.00 Gross Pay YTD 25600.00
+NIable Pay PTD 3200.00 NIable Pay YTD 25600.00
+Taxable Pay PTD 3150.00 PAYE YTD 3200.00
+NI Employee YTD 1500.00
+NI Employer YTD 4200.00
+Taxable Pay YTD 25200.00
+Messages to Employee
+Basic Pay: Annual Salary 38,400.00`;
+  const document = {
+    text,
+    pages: [{ lines: [
+      layoutLine(620, [['Period Type', 44], ['Tax Period Number', 216], ['Pay Date', 388]]),
+      layoutLine(610, [['Calendar Month', 44], ['8', 216], ['31-Aug-2026', 388]]),
+      layoutLine(578, [['Tax Code', 44], ['Tax Basis', 261], ['NI Category', 382], ['Employers PAYE Reference Number', 431]]),
+      layoutLine(568, [['1100L', 44], ['Cumulative', 258], ['A', 417], ['123/AB456', 506]]),
+      layoutLine(503, [['Payments', 44], ['Deductions', 306]]),
+      layoutLine(492, [['Description', 44], ['Amount', 261], ['Description', 306], ['Amount', 523]]),
+      layoutLine(481, [['Basic Pay', 44], ['3000.00', 262], ['Example deduction A', 306], ['20.00', 532]]),
+      layoutLine(470, [['Allowance', 44], ['200.00', 262], ['Example deduction B', 306], ['100.00', 528]]),
+      layoutLine(459, [['Example deduction C', 306], ['10.00', 532]]),
+      layoutLine(448, [['Example deduction D', 306], ['400.00', 528]]),
+      layoutLine(437, [['Example deduction E', 306], ['20.00', 532]]),
+      layoutLine(426, [['Example deduction F', 306], ['50.00', 532]]),
+      layoutLine(406, [['Net Pay / Distribution', 44]])
+    ] }]
+  };
+
+  const result = parsePayslipDocument(document, 'fictional-mynavy.pdf');
+  const record = result.records[0];
+  assert.equal(result.reconciled, true);
+  assert.deepEqual(result.warnings, []);
+  assert.equal(record.provider, 'mynavy');
+  assert.equal(record.payDate, '2026-08-31');
+  assert.equal(record.grossPay, 3200);
+  assert.equal(record.totalDeductions, 600);
+  assert.equal(record.netPay, 2600);
+  assert.equal(record.earnings.length, 2);
+  assert.equal(record.deductions.length, 6);
+  assert.equal(record.taxablePay, 3150);
+  assert.equal(record.niablePay, 3200);
+  assert.equal(record.grossPayYtd, 25600);
+  assert.equal(record.taxablePayYtd, 25200);
+  assert.equal(record.niablePayYtd, 25600);
+  assert.equal(record.payeYtd, 3200);
+  assert.equal(record.niEmployeeYtd, 1500);
+  assert.equal(record.niEmployerYtd, 4200);
+  assert.equal(record.annualSalary, 38400);
+  assert.equal(record.taxCode, '1100L');
+  assert.equal(record.taxBasis, 'Cumulative');
+  assert.equal(record.niCategory, 'A');
+});
+
+test('MyNavy text-only fallback still reconciles when layout coordinates are unavailable', () => {
+  const text = `Statement of Salary and Deductions
+Period Type  Tax Period Number  Pay Date
+Calendar Month  8  31-Aug-2026
+Summary of Payments
+Total Gross Pay  Total Deductions  Total Amount Paid
+3200.00  600.00  2600.00
+Payments                        Deductions
+Description          Amount    Description                 Amount
+Basic Pay          3000.00     Example deduction A          100.00
+Allowance           200.00     Example deduction B          200.00
+                               Example deduction C          300.00
+Net Pay / Distribution
+Balances Current Period
+Gross Pay PTD 3200.00
+NIable Pay PTD 3200.00
+Taxable Pay PTD 3150.00`;
+  const result = parsePayslipText(text, 'fictional-text-only.pdf');
+  assert.equal(result.reconciled, true);
+  assert.equal(result.records[0].earnings.length, 2);
+  assert.equal(result.records[0].deductions.length, 3);
+});
+
+function layoutLine(y, values) {
+  return { y, items: values.map(([text, x]) => ({ text, x, width: Math.max(10, text.length * 4), height: 8 })), text: values.map(([text]) => text).join(' ') };
+}

--- a/tests/payslip-record.test.js
+++ b/tests/payslip-record.test.js
@@ -1,0 +1,50 @@
+import fs from 'node:fs/promises';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildPayslipRecord, formatPayslipLineItems, parsePayslipLineItems, payslipEditorItem } from '../payslip-record.js';
+
+test('manual pay records calculate deductions and reconcile before saving', () => {
+  const result = buildPayslipRecord({
+    period: '2026-08', payDate: '2026-08-31', grossPay: 3000, netPay: 2400,
+    taxablePay: 2950, niablePay: 3000, annualSalary: 36000,
+    earningsText: 'Basic pay | 2800.00\nAllowance | 200.00',
+    deductionsText: 'PAYE | 450.00\nNational Insurance | 150.00',
+    taxCode: '1100L', taxBasis: 'Cumulative', niCategory: 'A', notes: 'Fictional record'
+  }, { id: 'pay-1', provider: 'manual', source: 'Manual entry' });
+
+  assert.equal(result.valid, true);
+  assert.equal(result.totalDeductions, 600);
+  assert.equal(result.record.totalDeductions, 600);
+  assert.equal(result.record.earnings.length, 2);
+  assert.equal(result.record.deductions.length, 2);
+  assert.equal(result.record.source, 'Manual entry');
+});
+
+test('manual pay records cannot save when itemised figures do not balance', () => {
+  const result = buildPayslipRecord({
+    period: '2026-08', payDate: '2026-08-31', grossPay: 3000, netPay: 2500,
+    earningsText: 'Basic pay | 3000.00', deductionsText: 'PAYE | 400.00'
+  }, { id: 'pay-2' });
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join(' '), /gross pay less itemised deductions/i);
+});
+
+test('line-item editing round trips imported payments and deductions', () => {
+  const source = [{ id: 'old', name: 'Example deduction', amount: 12.34, type: 'deduction', notes: '' }];
+  const text = formatPayslipLineItems(source);
+  const parsed = parsePayslipLineItems(text, 'deduction');
+  assert.equal(text, 'Example deduction | 12.34');
+  assert.deepEqual(parsed.items.map((item) => [item.name, item.amount]), [['Example deduction', 12.34]]);
+  assert.equal(payslipEditorItem({ deductions: source }).deductionsText, text);
+});
+
+test('manual pay UI and packaged application include the pay-record workflow', async () => {
+  const [html, renderer, packageJson] = await Promise.all([
+    fs.readFile(new URL('../index.html', import.meta.url), 'utf8'),
+    fs.readFile(new URL('../renderer-app.js', import.meta.url), 'utf8'),
+    fs.readFile(new URL('../package.json', import.meta.url), 'utf8')
+  ]);
+  assert.match(html, /data-add="payslip"[^>]*>Add pay manually</);
+  assert.match(renderer, /buildPayslipRecord/);
+  assert.ok(JSON.parse(packageJson).build.files.includes('payslip-record.js'));
+});


### PR DESCRIPTION
### Purpose

Add compatibility with MyNavy Statement of Salary and Deductions PDFs and allow users to manually add or fully edit pay records and itemised deductions without weakening financial reconciliation.

### Work completed

#### MyNavy payslip import

- Added layout-aware recognition and parsing for MyNavy Statement of Salary and Deductions PDFs.
- Extracts the pay date and month, annual salary, gross pay, net pay, taxable pay, NI-able pay, tax code, tax basis, NI category, employer PAYE reference, current-period balances and year-to-date balances.
- Separates side-by-side payment and deduction columns into itemised rows.
- Added a text-only fallback when PDF layout coordinates are unavailable.
- Validates itemised payments and deductions against summary totals and checks that gross pay less deductions equals net pay.
- Preserved the existing JPA payslip parser and assigns explicit `mynavy` and `jpa` provider identifiers.

#### Manual pay and deduction entry

- Added an **Add pay manually** action to the Pay and deductions screen.
- Replaced the payslip notes-only action with a complete pay-record editor.
- Allows users to enter or correct pay dates, salary and pay totals, tax details, payment lines, deduction lines, YTD balances and notes.
- Calculates total deductions from itemised deduction lines.
- Refuses to save records whose gross pay, deductions and net pay do not reconcile.
- Supports editing both imported and manually created pay records.

#### Secure document naming and packaging

- MyNavy vault documents now use the canonical `mynavy` provider name while JPA documents retain `jpa`.
- Added the new pay-record helper module to the packaged Electron application.

### Files changed

- `README.md` — documents MyNavy import support and manual pay entry.
- `document-import.js` — adds MyNavy detection, layout-aware parsing, text fallback, balance extraction, provider identification and reconciliation.
- `index.html` — adds the manual-pay action to the Pay and deductions screen.
- `main-process.js` — uses the parsed payslip provider when naming encrypted vault documents.
- `package.json` — includes `payslip-record.js` in packaged application files; no dependency or version changes.
- `payslip-record.js` — new manual pay-record parsing, formatting and reconciliation module.
- `renderer-app.js` — adds the full pay editor, imported-record editing and validated save flow.
- `tests/document-import.test.js` — adds fictional, anonymised MyNavy layout and text-fallback coverage while retaining JPA tests.
- `tests/payslip-record.test.js` — adds manual-entry, reconciliation, line-item round-trip and packaged-UI tests.

No files were renamed or deleted.

### User-facing changes

Users can import the supplied MyNavy payslip format and see itemised payments, deductions and pay metadata. They can also add a pay record manually or edit an imported record. Deduction totals are calculated automatically, and the application explains and blocks unbalanced records rather than accepting inconsistent figures.

### Technical changes

- MyNavy parsing uses extracted PDF line coordinates when available to keep the side-by-side payment and deduction columns distinct.
- A text-only parser provides a conservative fallback for documents without layout metadata.
- Imported records now carry a provider identifier used by secure-document naming.
- Manual and imported records use one reconciliation helper for itemised rows and monetary totals.
- No dependencies were added, removed or updated.
- No telemetry, analytics, cloud storage or new network service was introduced.
- The supplied real payslip was used only for local verification and was not committed; repository fixtures are fictional and anonymised.

### Testing and verification

- **Passed:** complete automated test suite — 220 passed, 0 failed.
- **Passed:** focused payslip tests — 28 passed, 0 failed.
- **Passed:** supplied MyNavy PDF import — one reconciled record with two payment lines and six deduction lines.
- **Passed:** project validation.
- **Passed:** repository privacy scan.
- **Passed:** `git diff --check`.
- **Passed:** unpacked Windows application packaging and expected bundle-content verification.
- **Passed:** remote publication verification — the GitHub tree exactly matches the tree of approved local commit `a484e19`; branch is one commit ahead of and zero behind `main`.
- **Unavailable:** Electron GUI startup because the Linux host forbids creation of the required D-Bus socket; the app did not reach startup, so this is recorded as an environment limitation rather than a passed manual launch.
- **Unavailable:** final NSIS installer compilation because Wine is not installed on the Linux host.

### Data and migration impact

No database or stored-data migration is required. New pay fields are optional, existing payslip records remain compatible, and no stored documents or user data are rewritten or deleted.

### Known limitations

- Substantially different historical MyNavy layouts may require additional anonymised examples.
- Electron desktop rendering and the final NSIS installer could not be exercised in this Linux environment for the reasons listed above.

### Excluded work

- No application version bump.
- No release creation or installer publication.
- No changes outside payslip import, pay-record editing, secure document naming and directly relevant documentation/tests.
- No changes to statement, credit-report or other document intelligence behaviour.

### Branch details

- Branch: `feature/mynavy-payslip-manual-deductions`
- Commit SHA: `36f23138c7f9168100636e38ce499f77344d862a`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/23
- Target branch: `main`

The published commit has a new SHA because it was created through the connected GitHub integration after HTTPS Git authentication was unavailable. Its complete Git tree is byte-for-byte identical to approved local commit `a484e19`.

### Confirmations

- No changes were committed or pushed directly to `main`.
- The pull request has not been merged.
- No personal financial data, imported documents, credentials, secrets or sensitive logs were committed.
- Only files relevant to the requested work were changed.
