### PR TITLE
[v2.1.22][Feature] Action lifecycle and Review Inbox

### DIFF
--- a/credit-report-intelligence.js
+++ b/credit-report-intelligence.js
@@ -1,4 +1,5 @@
 import { createId } from './finance-core.js';
+import { synchroniseReviewItems } from './review-lifecycle.js';
 
 const SUPPORTED_TYPES = new Set([
   'credit-card', 'personal-loan', 'car-finance', 'hire-purchase', 'store-card',
@@ -112,7 +113,7 @@ export function applyCreditReportImportPlan(state, preview, reviewedPlan, docume
     conflictCount: currentPlan.counts.conflict,
     ignoredCount: currentPlan.counts.ignore
   });
-  return { state: next, result };
+  return { state: synchroniseReviewItems(next, new Date(importedAt)), result };
 }
 
 export function normaliseCreditAccountType(value) {

--- a/data-store.js
+++ b/data-store.js
@@ -3,6 +3,7 @@ import { constants as fsConstants } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { localFinancialMonthKey } from './date-utils.js';
+import { knownPaydayDay, synchroniseReviewItems } from './review-lifecycle.js';
 
 const STATE_FILE = 'finance-state.json';
 const KEY_FILE = 'vault-key.json';
@@ -11,7 +12,7 @@ const BACKUP_MAGIC = Buffer.from('LFB1');
 const LEGACY_BACKUP_MAGIC = Buffer.from('HFB1');
 const PORTABLE_BACKUP_FORMAT_VERSION = 2;
 const LOCAL_BACKUP_FORMAT_VERSION = 1;
-const CURRENT_SCHEMA_VERSION = 7;
+const CURRENT_SCHEMA_VERSION = 8;
 const FRESH_START_CONFIRMATION_MS = 5 * 60 * 1000;
 const MAX_BACKUP_BYTES = 512 * 1024 * 1024;
 const MAX_BACKUP_FILE_BYTES = 128 * 1024 * 1024;
@@ -19,7 +20,7 @@ const MAX_BACKUP_ENTRIES = 5000;
 const JOURNAL_FILE = 'active-restore.json';
 const STATE_COLLECTIONS = Object.freeze([
   'accounts', 'transactions', 'payslips', 'taxDocuments', 'creditReports', 'debts', 'overdrafts',
-  'budgets', 'scheduledPayments', 'documents', 'tasks', 'checkIns', 'importBatches'
+  'budgets', 'scheduledPayments', 'documents', 'tasks', 'checkIns', 'importBatches', 'reviewItems'
 ]);
 
 export const RECOVERY_MODES = Object.freeze({
@@ -1846,14 +1847,14 @@ function isCanonicalBase64AllowEmpty(value) {
 
 function migrateState(input) {
   const state = input && typeof input === 'object' ? input : {};
-  return {
+  const migrated = {
     schemaVersion: CURRENT_SCHEMA_VERSION,
     meta: {
       createdAt: state.meta?.createdAt || new Date().toISOString(),
       updatedAt: state.meta?.updatedAt || new Date().toISOString(),
       revision: nonNegativeInteger(state.meta?.revision, 0)
     },
-    profile: state.profile || { name: '', locale: 'en-GB', currency: 'GBP', dependableIncome: 0, paydayDay: 30 },
+    profile: migrateProfile(state.profile, state.schemaVersion),
     accounts: Array.isArray(state.accounts) ? state.accounts : [],
     transactions: Array.isArray(state.transactions) ? state.transactions.map(migrateTransactionReviewState) : [],
     payslips: Array.isArray(state.payslips) ? state.payslips : [],
@@ -1867,7 +1868,22 @@ function migrateState(input) {
     tasks: Array.isArray(state.tasks) ? state.tasks : [],
     checkIns: Array.isArray(state.checkIns) ? state.checkIns : [],
     importBatches: Array.isArray(state.importBatches) ? state.importBatches : [],
+    reviewItems: Array.isArray(state.reviewItems) ? state.reviewItems : [],
     settings: migrateSettings(state.settings)
+  };
+  return synchroniseReviewItems(migrated);
+}
+
+function migrateProfile(value, sourceSchemaVersion) {
+  const profile = isPlainObject(value) ? value : {};
+  return {
+    ...profile,
+    name: String(profile.name || ''),
+    locale: String(profile.locale || 'en-GB'),
+    currency: String(profile.currency || 'GBP'),
+    dependableIncome: finiteNumber(profile.dependableIncome, 0),
+    // Older builds supplied day 30 as an invisible default, so it was not confirmed by the user.
+    paydayDay: Number(sourceSchemaVersion) >= 8 ? knownPaydayDay(profile.paydayDay) : null
   };
 }
 
@@ -1913,16 +1929,19 @@ function migrateSnoozedActions(value) {
 function migrateTransactionReviewState(item) {
   if (!isPlainObject(item)) throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
   const duplicateStatus = ['none', 'possible', 'exact'].includes(item.duplicateStatus) ? item.duplicateStatus : 'none';
+  const importReviewStatus = ['trusted', 'pending', 'accepted', 'rejected'].includes(item.importReviewStatus) ? item.importReviewStatus : 'trusted';
+  const importActive = !['pending', 'rejected'].includes(importReviewStatus);
   if (duplicateStatus === 'possible') {
     const reviewStatus = ['pending', 'accepted', 'rejected'].includes(item.reviewStatus) ? item.reviewStatus : 'pending';
-    return { ...item, duplicateStatus, reviewStatus, financiallyActive: reviewStatus === 'accepted' };
+    return { ...item, duplicateStatus, reviewStatus, importReviewStatus, financiallyActive: reviewStatus === 'accepted' && importActive };
   }
-  if (duplicateStatus === 'exact') return { ...item, duplicateStatus, reviewStatus: 'rejected', financiallyActive: false };
+  if (duplicateStatus === 'exact') return { ...item, duplicateStatus, reviewStatus: 'rejected', importReviewStatus, financiallyActive: false };
   return {
     ...item,
     duplicateStatus,
+    importReviewStatus,
     reviewStatus: item.reviewStatus === 'rejected' ? 'rejected' : 'not_required',
-    financiallyActive: item.reviewStatus === 'rejected' ? false : item.financiallyActive !== false
+    financiallyActive: item.reviewStatus === 'rejected' || !importActive ? false : item.financiallyActive !== false
   };
 }
 
@@ -2051,6 +2070,9 @@ function validateMigratedState(state) {
   if (!Number.isInteger(state.meta.revision) || state.meta.revision < 0 || !isPlainObject(state.settings.snoozedActions)) {
     throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
   }
+  if (state.profile.paydayDay !== null && knownPaydayDay(state.profile.paydayDay) === null) {
+    throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+  }
   for (const value of [
     state.profile.dependableIncome,
     state.settings.extraDebtPayment,
@@ -2074,9 +2096,27 @@ function validateMigratedState(state) {
     if (!isPlainObject(transaction)
       || !['none', 'possible', 'exact'].includes(transaction.duplicateStatus)
       || !['not_required', 'pending', 'accepted', 'rejected'].includes(transaction.reviewStatus)
+      || !['trusted', 'pending', 'accepted', 'rejected'].includes(transaction.importReviewStatus)
       || typeof transaction.financiallyActive !== 'boolean'
-      || (transaction.duplicateStatus === 'possible' && transaction.financiallyActive !== (transaction.reviewStatus === 'accepted'))
+      || (transaction.duplicateStatus === 'possible' && transaction.financiallyActive !== (transaction.reviewStatus === 'accepted' && !['pending', 'rejected'].includes(transaction.importReviewStatus)))
       || (transaction.duplicateStatus === 'exact' && transaction.financiallyActive !== false)) {
+      throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
+    }
+  }
+  for (const item of state.reviewItems) {
+    if (!isPlainObject(item)
+      || typeof item.id !== 'string'
+      || !['needs_attention', 'in_progress', 'snoozed', 'resolved'].includes(item.status)
+      || !['high', 'normal', 'low'].includes(item.priority)
+      || typeof item.type !== 'string'
+      || typeof item.sourceType !== 'string'
+      || typeof item.sourceId !== 'string'
+      || !validIsoDate(item.createdAt)
+      || !validIsoDate(item.updatedAt)
+      || (item.snoozedUntil !== null && !validIsoDate(item.snoozedUntil))
+      || (item.status === 'snoozed') !== (item.snoozedUntil !== null)
+      || (item.status === 'resolved') !== Boolean(item.resolution)
+      || (item.resolution && (!isPlainObject(item.resolution) || typeof item.resolution.decision !== 'string' || !validIsoDate(item.resolution.resolvedAt)))) {
       throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
     }
   }

--- a/finance-core.js
+++ b/finance-core.js
@@ -1,6 +1,7 @@
 import { localFinancialMonthKey } from './date-utils.js';
+import { activeReviewItems, reviewItemPresentation, synchroniseReviewItems } from './review-lifecycle.js';
 
-export const SCHEMA_VERSION = 7;
+export const SCHEMA_VERSION = 8;
 export const ALL_TIME_PERIOD = 'all';
 export const INCOME_PAYMENT_CATEGORY = 'Income';
 
@@ -236,10 +237,20 @@ function budgetUsageRatio(row) {
 export function buildNextAction(state, now = new Date()) {
   const today = localDateKey(now);
   const isSnoozed = (id) => String(state.settings?.snoozedActions?.[id] || '') > today;
-  const task = (state.tasks || [])
-    .filter((entry) => !entry.completedAt && (!entry.snoozedUntil || entry.snoozedUntil <= today))
-    .sort((left, right) => Number(left.order || 999) - Number(right.order || 999))[0];
-  if (task) return task;
+  synchroniseReviewItems(state, now);
+  const reviewItem = activeReviewItems(state, now)[0];
+  if (reviewItem) {
+    const presentation = reviewItemPresentation(reviewItem, state);
+    return {
+      id: `generated-review-${reviewItem.id}`,
+      reviewId: reviewItem.id,
+      completeDirect: reviewItem.type === 'generated_action',
+      title: presentation.title,
+      detail: presentation.detail,
+      timeframe: reviewItem.type === 'uncategorised_payment' ? '2 min' : '10 min',
+      stage: reviewItem.priority === 'high' ? 'today' : 'this week'
+    };
+  }
 
   const checkIn = { id: 'generated-checkin', title: 'Complete a five-minute check-in', detail: 'Update one balance, then stop. Consistency matters more than perfection.', timeframe: '5 min', stage: 'today' };
   if (!(state.accounts || []).length) {
@@ -343,6 +354,7 @@ export function findSavingsOpportunities(state) {
 
 export function isTransactionFinanciallyActive(transaction = {}) {
   if (transaction.deletedAt || transaction.ignored === true || transaction.valid === false) return false;
+  if (['pending', 'rejected'].includes(transaction.importReviewStatus)) return false;
   if (transaction.duplicateStatus === 'exact') return false;
   if (transaction.reviewStatus === 'rejected') return false;
   if (transaction.duplicateStatus === 'possible' && transaction.reviewStatus !== 'accepted') return false;
@@ -355,9 +367,10 @@ export function resolvePossibleDuplicate(state, transactionId, decision) {
   const transaction = (next.transactions || []).find((item) => item.id === transactionId);
   if (!transaction || transaction.duplicateStatus !== 'possible') throw new Error('This possible duplicate is no longer available for review.');
   transaction.reviewStatus = decision;
-  transaction.financiallyActive = decision === 'accepted';
+  transaction.financiallyActive = decision === 'accepted' && !['pending', 'rejected'].includes(transaction.importReviewStatus);
   transaction.reviewedAt = new Date().toISOString();
-  return next;
+  transaction.duplicateDecision = decision === 'accepted' ? 'both_genuine' : 'duplicate';
+  return synchroniseReviewItems(next);
 }
 
 export function debtPlan(state, strategy = 'hybrid', extraPayment = state.settings?.extraDebtPayment ?? 0, startMonth = currentMonth()) {
@@ -696,7 +709,8 @@ function priorityOrder(items, balances, strategy) {
 function assessDebtAccount(item) {
   const balance = Math.max(0, Number(item.currentBalance || 0));
   const storedStatus = normaliseDebtStatus(item.status);
-  const reportedStatus = creditReportDebtStatus(item.reportedStatus);
+  const reportedStatusReviewed = Boolean(item.statusReviewedAt) && String(item.reviewedReportedStatus || '') === String(item.reportedStatus || '');
+  const reportedStatus = reportedStatusReviewed ? 'unknown' : creditReportDebtStatus(item.reportedStatus);
   const statusSignals = new Set([storedStatus]);
   if (reportedStatus !== 'unknown') statusSignals.add(reportedStatus);
   if (item.defaultDate) statusSignals.add('defaulted');
@@ -711,7 +725,7 @@ function assessDebtAccount(item) {
   const requiredPayment = arrangementStatus === 'confirmed' ? arrangementPayment : contractualPayment;
   const reportedConflict = storedStatus !== 'unknown' && reportedStatus !== 'unknown' && storedStatus !== reportedStatus;
   const defaultDateConflict = Boolean(item.defaultDate) && !['defaulted', 'unknown'].includes(storedStatus);
-  const conflictingStatus = Boolean(item.statusConflict) || creditReportStatusConflict(item.reportedStatus) || reportedConflict || defaultDateConflict;
+  const conflictingStatus = Boolean(item.statusConflict) || (!reportedStatusReviewed && creditReportStatusConflict(item.reportedStatus)) || reportedConflict || defaultDateConflict;
   const blocking = [];
   const reasonCodes = [];
   const addBlock = (code, message) => { reasonCodes.push(code); blocking.push(message); };

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
         </div>
         <nav aria-label="Main navigation">
           <button class="nav-button active" type="button" data-view="today"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 11.5 12 4l9 7.5"/><path d="M5.5 10.5V20h13v-9.5"/><path d="M9.5 20v-6h5v6"/></svg><span class="nav-label">Today</span></button>
+          <button class="nav-button" type="button" data-view="review"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4h12v16H6z"/><path d="M9 8h6M9 12h6M9 16h4"/></svg><span class="nav-label">Review <span id="reviewNavCount" class="nav-count" aria-label="0 active review items" hidden>0</span></span></button>
           <button class="nav-button" type="button" data-view="transactions"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 4v16M3.5 7.5 7 4l3.5 3.5M17 20V4m-3.5 12.5L17 20l3.5-3.5"/></svg><span class="nav-label">Payments</span></button>
           <button class="nav-button" type="button" data-view="pay"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6.5 8.5a5.5 5.5 0 1 1 0 7"/><path d="M4 12h9M4 16h9"/></svg><span class="nav-label">Pay</span></button>
           <button class="nav-button" type="button" data-view="debts"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="6" width="18" height="13" rx="2"/><path d="M3 10h18M7 15h3"/></svg><span class="nav-label">Debts</span></button>
@@ -77,6 +78,7 @@
         </header>
 
         <section id="view-today" class="view active" aria-labelledby="viewTitle">
+          <article id="welcomeBackPanel" class="welcome-back" hidden><div><p class="eyebrow">WELCOME BACK</p><h2>Welcome back</h2><p id="welcomeBackText">A few things are worth checking.</p></div><button id="welcomeBackReviewButton" class="secondary-button" type="button">Open Review Inbox</button></article>
           <article class="focus-panel">
             <div class="focus-copy"><div class="step-emblem" aria-hidden="true"><span>1</span></div><div><p class="eyebrow">IMMEDIATE ACTION</p><h2 id="nextActionTitle">Loading your next action…</h2><p id="nextActionDetail"></p></div></div>
             <div class="focus-actions"><span id="nextActionTime" class="time-chip">10 min</span><button id="completeActionButton" class="primary-button" type="button">Complete &amp; finish</button><button id="snoozeActionButton" class="secondary-button" type="button">Snooze 1 day</button></div>
@@ -96,8 +98,19 @@
 
           <div class="two-column">
             <article class="panel"><div class="panel-heading"><div><p class="eyebrow">QUICK READ</p><h2>What needs attention</h2></div></div><div id="checksList" class="checks-list"></div></article>
-            <article class="panel encouragement-panel"><p class="eyebrow">MOMENTUM</p><h2 id="momentumTitle">Showing up counts</h2><div class="progress-track"><span id="bufferProgress"></span></div><p id="momentumText"></p><button id="quickCheckInButton" class="secondary-button" type="button">Complete five-minute check-in</button><p id="checkInStatus" class="check-in-status">Use this when you reviewed your money but did not finish the action above.</p></article>
+            <article class="panel encouragement-panel"><p class="eyebrow">FIVE-MINUTE CHECK-IN</p><h2 id="momentumTitle">Showing up counts</h2><div class="progress-track"><span id="bufferProgress"></span></div><p id="momentumText"></p><div id="checkInReviewList" class="check-in-review-list"></div><button id="quickCheckInButton" class="secondary-button" type="button">Complete five-minute check-in</button><p id="checkInStatus" class="check-in-status">Use this when you reviewed your money but did not finish the action above.</p></article>
           </div>
+        </section>
+
+        <section id="view-review" class="view" hidden aria-labelledby="viewTitle">
+          <div class="review-hero">
+            <div><p class="eyebrow">ONE PLACE FOR UNFINISHED WORK</p><h2 id="reviewSummaryTitle">Nothing needs reviewing right now</h2><p id="reviewSummaryText">OneStep will put work here only when a decision or correction is genuinely needed.</p></div>
+            <div class="review-summary-counts" aria-label="Review Inbox summary"><span><strong id="reviewImportantCount">0</strong> important</span><span><strong id="reviewNormalCount">0</strong> normal</span><span><strong id="reviewSnoozedCount">0</strong> snoozed</span></div>
+          </div>
+          <p id="reviewInboxStatus" class="sr-only" role="status" aria-live="polite"></p>
+          <div id="reviewDoneState" class="review-done" hidden><span aria-hidden="true">✓</span><div><strong>Nothing needs reviewing right now</strong><p>OneStep has no unresolved work that needs your judgement.</p></div></div>
+          <div id="reviewActiveSection"><div class="section-heading"><div><h2>Needs attention</h2><p>Important work first, with related payments grouped together.</p></div></div><div id="reviewActiveList" class="review-list"></div></div>
+          <div id="reviewSnoozedSection" class="review-snoozed-section" hidden><div class="section-heading"><div><h2>Snoozed</h2><p>Still unresolved and due to return automatically.</p></div></div><div id="reviewSnoozedList" class="review-list compact"></div></div>
         </section>
 
         <section id="view-transactions" class="view" hidden>
@@ -157,7 +170,7 @@
         <section id="view-settings" class="view" hidden>
           <div class="settings-grid">
             <article class="panel"><div class="panel-heading"><div><h2>Accounts</h2><p class="muted">Add an account before importing its statements.</p></div><button class="secondary-button" type="button" data-add="account">Add account</button></div><div id="accountCards" class="compact-card-list"></div></article>
-            <article class="panel"><h2>Planning</h2><label>Dependable monthly income<input id="dependableIncomeInput" type="number" min="0" step="0.01" /></label><label>Extra debt-payment target<input id="extraPaymentInput" type="number" min="0" step="10" /></label><label>Emergency-buffer target<input id="bufferTargetInput" type="number" min="0" step="50" /></label><label>Current emergency buffer<input id="bufferBalanceInput" type="number" min="0" step="1" /></label><button id="saveSettingsButton" class="primary-button" type="button">Save settings</button></article>
+            <article class="panel"><h2>Planning</h2><label>Dependable monthly income<input id="dependableIncomeInput" type="number" min="0" step="0.01" /></label><label>Payday day · optional<input id="paydayDayInput" type="number" min="1" max="31" step="1" placeholder="Leave blank if not known" /></label><p class="muted">Used only for “Snooze until payday”. Full payday automation remains a later feature.</p><label>Extra debt-payment target<input id="extraPaymentInput" type="number" min="0" step="10" /></label><label>Emergency-buffer target<input id="bufferTargetInput" type="number" min="0" step="50" /></label><label>Current emergency buffer<input id="bufferBalanceInput" type="number" min="0" step="1" /></label><button id="saveSettingsButton" class="primary-button" type="button">Save settings</button></article>
             <article class="panel"><h2>Local model</h2><label>Ollama model<input id="llmModelInput" type="text" value="qwen2.5:1.5b" /></label><p class="muted">Recommended small model: qwen2.5:1.5b. The app connects only to Ollama on 127.0.0.1.</p><button id="checkModelButton" class="secondary-button" type="button">Check model</button></article>
             <article class="panel"><h2>Encrypted backup</h2><p class="muted">A portable backup includes one verified snapshot of your financial data and encrypted document vault. Use a password you will remember.</p><label>Backup password<input id="backupPassphrase" type="password" minlength="8" autocomplete="new-password" /></label><div class="button-row"><button id="createBackupButton" class="primary-button" type="button">Create backup</button><button id="restoreBackupButton" class="secondary-button" type="button">Restore backup</button></div><p id="backupStatus" class="muted" aria-live="polite"></p></article>
             <article class="panel"><h2>Updates</h2><p id="updateStatus" class="muted" aria-live="polite">Updates are checked automatically. Downloads and installation only start when you choose.</p><progress id="settingsUpdateProgress" class="update-progress" max="100" value="0" aria-label="Update download 0% complete" hidden></progress><div class="update-action-grid"><button id="checkUpdateButton" class="secondary-button" type="button">Check for updates</button><button class="secondary-button" type="button" data-view-update hidden>View on GitHub</button><button class="primary-button update-primary-action" type="button" data-download-update hidden>Download update</button><button class="primary-button update-primary-action" type="button" data-restart-update hidden>Restart and install</button></div></article>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onestep-money",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.21",
+      "version": "2.1.22",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",
@@ -57,6 +57,7 @@
       "payslip-record.js",
       "preload-bridge.cjs",
       "renderer-app.js",
+      "review-lifecycle.js",
       "credit-report-intelligence.js",
       "statement-intelligence.js",
       "transaction-ledger.js",

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -15,6 +15,10 @@ import {
   buildTransactionLedgerIndex, filterTransactionLedger, INCOME_PAYMENT_CATEGORY_VALUE,
   paginateTransactionLedger
 } from './transaction-ledger.js';
+import {
+  knownPaydayDay, resolveReviewItem, reviewInboxSummary, reviewItemPresentation, reviewRoute,
+  selectCheckInReviewItems, snoozeReviewGroup, snoozeReviewItem, startReviewItem, synchroniseReviewItems
+} from './review-lifecycle.js';
 
 let state;
 let encryption;
@@ -34,9 +38,11 @@ let recoveryEventsBound = false;
 let restoreEventsBound = false;
 let transactionPage = 1;
 let financialViewCache = null;
+let reviewGroupsById = new Map();
+let welcomeBack = false;
 
 const viewMeta = {
-  today: ['ONE CLEAR MOVE', 'Today'], transactions: ['MONEY IN AND OUT', 'Payments'], pay: ['WHERE GROSS PAY GOES', 'Pay'],
+  today: ['ONE CLEAR MOVE', 'Today'], review: ['UNFINISHED FINANCIAL WORK', 'Review Inbox'], transactions: ['MONEY IN AND OUT', 'Payments'], pay: ['WHERE GROSS PAY GOES', 'Pay'],
   debts: ['LOANS, CARDS AND FINANCE', 'Debts'], overdrafts: ['BANK BORROWING', 'Overdrafts'], budget: ['DEPENDABLE INCOME FIRST', 'Budget'],
   guide: ['PRIVATE AND LOCAL', 'Guide'], documents: ['ENCRYPTED ON THIS DEVICE', 'Documents'], settings: ['CONTROL AND PRIVACY', 'Settings']
 };
@@ -75,6 +81,8 @@ function renderAppVersion(value) {
 
 function activateNormalMode(loaded) {
   state = loaded.state;
+  synchroniseReviewItems(state);
+  welcomeBack = Boolean(state.meta?.updatedAt && Date.now() - Date.parse(state.meta.updatedAt) >= 3 * 86_400_000);
   encryption = loaded.encryption;
   recoveryResult = null;
   freshStartToken = null;
@@ -322,6 +330,10 @@ function bindEvents() {
     selectView('transactions');
     renderTransactions();
   });
+  byId('welcomeBackReviewButton').addEventListener('click', () => selectView('review'));
+  byId('reviewActiveList').addEventListener('click', handleReviewAction);
+  byId('reviewSnoozedList').addEventListener('click', handleReviewAction);
+  byId('checkInReviewList').addEventListener('click', handleReviewAction);
   byId('payslipList').addEventListener('click', handleEditClick);
   byId('documentCards').addEventListener('click', handleDocumentClick);
   byId('accountCards').addEventListener('click', handleEditClick);
@@ -369,6 +381,7 @@ function selectView(name) {
 }
 
 function render() {
+  synchroniseReviewItems(state);
   populateMonthOptions();
   populatePaymentCategoryOptions();
   const month = state.settings.selectedMonth;
@@ -377,6 +390,7 @@ function render() {
   byId('nextActionTitle').textContent = pendingAction.title;
   byId('nextActionDetail').textContent = pendingAction.detail || '';
   byId('nextActionTime').textContent = pendingAction.timeframe || '10 min';
+  byId('completeActionButton').textContent = pendingAction.reviewId && !pendingAction.completeDirect ? 'Review now' : 'Complete & finish';
   byId('completeActionButton').hidden = Boolean(pendingAction.passive);
   byId('snoozeActionButton').hidden = Boolean(pendingAction.passive);
   renderDailyCompletion();
@@ -397,6 +411,7 @@ function render() {
   byId('streakValue').textContent = calculateStreak(state.checkIns);
   renderChecks();
   renderMomentum();
+  renderReviewInbox();
   renderTransactions();
   renderPay();
   renderDebts();
@@ -429,9 +444,22 @@ function renderMomentum() {
   byId('momentumText').textContent = current ? `${formatCurrency(current)} saved toward ${formatCurrency(target)}. Keep the target small while payments are being stabilised.` : 'Your first win is a completed check-in. The buffer can grow after essential payments are secure.';
   byId('quickCheckInButton').disabled = completedToday;
   byId('quickCheckInButton').textContent = completedToday ? 'Check-in complete today' : 'Complete five-minute check-in';
+  const reviewSelection = selectCheckInReviewItems(state);
+  const reviewList = byId('checkInReviewList'); clear(reviewList);
+  for (const item of reviewSelection) {
+    const presentation = reviewItemPresentation(item, state);
+    const row = element('div', 'check-in-review-item');
+    const label = element('strong', '', presentation.title);
+    const button = element('button', 'secondary-button', 'Open');
+    button.type = 'button'; button.dataset.reviewRoute = item.id;
+    button.setAttribute('aria-label', `Open ${presentation.title}`);
+    append(row, label, button); reviewList.append(row);
+  }
+  reviewList.hidden = reviewSelection.length === 0;
   byId('checkInStatus').textContent = completedToday
-    ? 'Recorded for today. There is nothing else you need to tick off.'
-    : 'Use this when you reviewed your money but did not finish the action above.';
+    ? 'Recorded for today. Unresolved review work remains available in the Review Inbox.'
+    : reviewSelection.length ? `A manageable ${reviewSelection.length} ${reviewSelection.length === 1 ? 'item is' : 'items are'} ready if you want to use the check-in.`
+      : 'Nothing needs reviewing. A quick check-in is enough.';
 }
 
 function renderDailyCompletion() {
@@ -439,6 +467,195 @@ function renderDailyCompletion() {
   document.querySelector('.focus-panel').hidden = completedToday;
   document.querySelector('.permission-slip').hidden = completedToday;
   byId('dailyCompleteState').hidden = !completedToday;
+}
+
+function renderReviewInbox() {
+  const summary = reviewInboxSummary(state);
+  reviewGroupsById = new Map(summary.groups.map((group) => [group.id, group]));
+  const count = byId('reviewNavCount');
+  count.textContent = String(summary.total);
+  count.hidden = summary.total === 0;
+  count.setAttribute('aria-label', `${summary.total} active review ${summary.total === 1 ? 'item' : 'items'}`);
+  byId('reviewSummaryTitle').textContent = summary.total
+    ? `${summary.total} ${summary.total === 1 ? 'thing needs' : 'things need'} attention`
+    : 'Nothing needs reviewing right now';
+  byId('reviewSummaryText').textContent = summary.total
+    ? 'Start with important work. Open details only when you need them.'
+    : 'OneStep will put work here only when a decision or correction is genuinely needed.';
+  byId('reviewImportantCount').textContent = summary.important;
+  byId('reviewNormalCount').textContent = summary.normal + summary.low;
+  byId('reviewSnoozedCount').textContent = summary.snoozed.length;
+  byId('reviewDoneState').hidden = summary.total !== 0;
+  byId('reviewActiveSection').hidden = summary.total === 0;
+  byId('reviewInboxStatus').textContent = summary.total ? `${summary.total} review items are active.` : 'Nothing needs reviewing right now.';
+
+  const activeList = byId('reviewActiveList'); clear(activeList);
+  for (const group of summary.groups) activeList.append(reviewGroupCard(group));
+
+  const snoozedSection = byId('reviewSnoozedSection');
+  const snoozedList = byId('reviewSnoozedList'); clear(snoozedList);
+  snoozedSection.hidden = summary.snoozed.length === 0;
+  for (const item of summary.snoozed) snoozedList.append(snoozedReviewCard(item));
+
+  const welcomePanel = byId('welcomeBackPanel');
+  welcomePanel.hidden = !(welcomeBack && summary.total > 0);
+  if (!welcomePanel.hidden) byId('welcomeBackText').textContent = `${Math.min(3, summary.total)} ${summary.total === 1 ? 'thing is' : 'things are'} worth checking. You do not need to catch up on everything.`;
+}
+
+function reviewGroupCard(group) {
+  const presentation = group.presentation;
+  const card = element('article', `review-card priority-${group.priority}`);
+  card.dataset.reviewGroup = group.id;
+  const copy = element('div', 'review-card-copy');
+  const heading = element('div', 'review-card-heading');
+  append(heading, element('h3', '', presentation.title), element('span', 'review-priority', group.priority === 'high' ? 'Important' : 'Normal'));
+  append(copy, heading, element('p', 'review-card-detail', presentation.detail));
+  const explanation = element('details', 'review-explanation');
+  explanation.append(element('summary', '', 'Why does this need review?'));
+  explanation.append(element('p', '', `${presentation.why} ${presentation.consequence}`));
+  copy.append(explanation);
+  if (group.type === 'uncategorised_payment' && group.items.length > 1) copy.append(reviewGroupDetails(group));
+
+  const actions = element('div', 'review-card-actions');
+  const open = element('button', 'primary-button', presentation.action);
+  open.type = 'button'; open.dataset.reviewRoute = group.items[0].id;
+  actions.append(open);
+  if (group.type === 'possible_duplicate') actions.append(reviewDecisionRow(group.items[0]));
+  if (group.type === 'import_conflict') {
+    const item = group.items[0];
+    const batch = item.sourceType === 'importBatch' ? state.importBatches.find((entry) => String(entry.id) === item.sourceId) : null;
+    if (batch?.kind === 'statement') {
+      const decisions = element('div', 'review-decision-row');
+      const apply = element('button', 'secondary-button', 'Apply payments');
+      apply.type = 'button'; apply.dataset.reviewDecision = 'apply_import'; apply.dataset.reviewItem = item.id;
+      const keep = element('button', 'secondary-button', 'Reject changes');
+      keep.type = 'button'; keep.dataset.reviewDecision = 'keep_current'; keep.dataset.reviewItem = item.id;
+      append(decisions, apply, keep); actions.append(decisions);
+    } else {
+      const keep = element('button', 'secondary-button', item.sourceType === 'document' ? 'Keep document only' : 'Keep current data');
+      keep.type = 'button'; keep.dataset.reviewDecision = item.sourceType === 'document' ? 'ignore_import' : 'keep_current'; keep.dataset.reviewItem = item.id;
+      actions.append(keep);
+    }
+  }
+  actions.append(reviewSnoozeControls(group));
+  append(card, copy, actions);
+  return card;
+}
+
+function reviewGroupDetails(group) {
+  const details = element('details', 'review-group-items');
+  details.append(element('summary', '', `Show ${group.items.length} payments`));
+  for (const item of group.items.slice(0, 100)) {
+    const presentation = reviewItemPresentation(item, state);
+    const row = element('div', 'review-group-row');
+    const button = element('button', 'secondary-button', 'Categorise');
+    button.type = 'button'; button.dataset.reviewRoute = item.id;
+    append(row, element('span', '', presentation.detail), button); details.append(row);
+  }
+  if (group.items.length > 100) details.append(element('p', 'muted', `Showing the first 100 of ${group.items.length}. Use Payments to work through the complete group.`));
+  return details;
+}
+
+function reviewDecisionRow(item) {
+  const row = element('div', 'review-decision-row');
+  const genuine = element('button', 'secondary-button', 'Both genuine');
+  genuine.type = 'button'; genuine.dataset.reviewDecision = 'both_genuine'; genuine.dataset.reviewItem = item.id;
+  const duplicate = element('button', 'secondary-button', 'Duplicate');
+  duplicate.type = 'button'; duplicate.dataset.reviewDecision = 'duplicate'; duplicate.dataset.reviewItem = item.id;
+  append(row, genuine, duplicate); return row;
+}
+
+function reviewSnoozeControls(group) {
+  const controls = element('div', 'review-snooze-controls');
+  const select = document.createElement('select');
+  select.className = 'review-snooze-choice'; select.setAttribute('aria-label', `Snooze ${group.presentation.title}`);
+  for (const [value, label] of [['tomorrow', 'Tomorrow'], ['weekend', 'This weekend'], ['next_week', 'Next week']]) {
+    const option = document.createElement('option'); option.value = value; option.textContent = label; select.append(option);
+  }
+  const payday = document.createElement('option'); payday.value = 'payday'; payday.textContent = knownPaydayDay(state.profile?.paydayDay) ? 'Payday' : 'Payday · not known'; payday.disabled = !knownPaydayDay(state.profile?.paydayDay); select.append(payday);
+  const button = element('button', 'secondary-button', 'Snooze');
+  button.type = 'button'; button.dataset.reviewSnooze = group.id;
+  append(controls, select, button); return controls;
+}
+
+function snoozedReviewCard(item) {
+  const presentation = reviewItemPresentation(item, state);
+  const card = element('article', 'review-card');
+  const copy = element('div', 'review-card-copy');
+  append(copy, element('h3', '', presentation.title), element('p', 'review-card-detail', presentation.detail), element('span', 'review-due', `Returns ${formatReviewDate(item.snoozedUntil)}`));
+  const actions = element('div', 'review-card-actions');
+  const button = element('button', 'secondary-button', 'Review now'); button.type = 'button'; button.dataset.reviewRoute = item.id;
+  actions.append(button); append(card, copy, actions); return card;
+}
+
+async function handleReviewAction(event) {
+  const decision = event.target.closest('[data-review-decision]');
+  if (decision) {
+    const confirmations = {
+      duplicate: 'Confirm these records are the same transaction. The reviewed payment will remain excluded from trusted totals.',
+      both_genuine: 'Confirm both payments are legitimate. The reviewed payment will be included in trusted totals.',
+      apply_import: 'Apply these reviewed statement payments to trusted totals? The protected account balance will not be guessed.',
+      keep_current: 'Keep the current trusted data and reject the uncertain imported change?',
+      ignore_import: 'Keep the encrypted document without importing its uncertain financial information?'
+    };
+    if (!window.confirm(confirmations[decision.dataset.reviewDecision] || 'Confirm this review decision?')) return;
+    const labels = { duplicate: 'Payment confirmed as a duplicate.', both_genuine: 'Both payments confirmed as genuine.', apply_import: 'Reviewed payments added to trusted totals.', keep_current: 'Current trusted financial data kept.', ignore_import: 'Document kept without importing uncertain information.' };
+    resolveReviewItem(state, decision.dataset.reviewItem, decision.dataset.reviewDecision);
+    await saveState(); render(); showToast(labels[decision.dataset.reviewDecision] || 'Review item resolved.');
+    return;
+  }
+  const snooze = event.target.closest('[data-review-snooze]');
+  if (snooze) {
+    const group = reviewGroupsById.get(snooze.dataset.reviewSnooze);
+    const choice = snooze.closest('.review-card').querySelector('.review-snooze-choice').value;
+    snoozeReviewGroup(state, group.items.map((item) => item.id), choice);
+    await saveState(); render(); showToast('Review work snoozed. It will return automatically.');
+    return;
+  }
+  const routeButton = event.target.closest('[data-review-route]');
+  if (routeButton) await openReviewWorkflow(routeButton.dataset.reviewRoute);
+}
+
+async function openReviewWorkflow(itemId) {
+  const item = state.reviewItems.find((entry) => entry.id === itemId);
+  if (!item || item.status === 'resolved') { render(); showToast('That review work is already complete.'); return; }
+  startReviewItem(state, itemId);
+  await saveState();
+  const route = reviewRoute(item, state);
+  if (route.type === 'transaction') {
+    const transaction = state.transactions.find((entry) => String(entry.id) === route.id);
+    if (item.type === 'uncategorised_payment') {
+      selectView('transactions'); openEditor('transaction', route.id, { reviewItemId: item.id });
+      return;
+    }
+    state.settings.selectedMonth = ALL_TIME_PERIOD;
+    byId('transactionSearch').value = transaction?.userDescription || transaction?.description || '';
+    transactionPage = 1; populateMonthOptions(); selectView('transactions'); renderTransactions(); focusTransactionTable();
+    return;
+  }
+  if (route.type === 'debt' || route.type === 'overdraft') {
+    selectView(route.view); openEditor(route.type, route.id, { reviewItemId: item.id });
+    return;
+  }
+  if (route.type === 'import') {
+    selectView(route.view);
+    byId(route.controlId)?.focus();
+    showToast('Choose the correct account where needed, then select the original document again.');
+    return;
+  }
+  if (route.type === 'importBatch' && route.view === 'transactions') {
+    state.settings.selectedMonth = ALL_TIME_PERIOD;
+    byId('transactionSearch').value = '';
+    byId('transactionCategoryFilter').value = 'all';
+    transactionPage = 1; populateMonthOptions(); selectView('transactions'); renderTransactions(); focusTransactionTable();
+    return;
+  }
+  selectView(route.view);
+}
+
+function formatReviewDate(value) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'later' : new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
 }
 
 function renderTransactions() {
@@ -473,6 +690,8 @@ function renderTransactions() {
           : 'possible duplicate · excluded pending review';
       badges.textContent += ` · ${duplicateLabel}`;
     }
+    if (item.importReviewStatus === 'pending') badges.textContent += ' · import review pending · excluded from trusted totals';
+    if (item.importReviewStatus === 'rejected') badges.textContent += ' · rejected import · excluded from trusted totals';
     description.append(badges);
     row.append(description);
     row.append(amountCell(item.incoming, 'incoming'));
@@ -687,6 +906,7 @@ function renderAccounts() {
 
 function renderSettings() {
   byId('dependableIncomeInput').value = state.profile.dependableIncome;
+  byId('paydayDayInput').value = knownPaydayDay(state.profile.paydayDay) || '';
   byId('extraPaymentInput').value = state.settings.extraDebtPayment;
   byId('bufferTargetInput').value = state.settings.emergencyBufferTarget;
   byId('bufferBalanceInput').value = state.settings.emergencyBufferBalance;
@@ -787,7 +1007,8 @@ function syncConfirmImportButton() {
   button.disabled = preview.kind === 'statement'
     ? !currentImport.statementPlan.canApply
     : preview.kind === 'credit-report' ? !currentImport.creditPlan.canApply : !preview.records.length;
-  button.textContent = preview.kind === 'credit-report' ? 'Apply reviewed credit report' : 'Import reviewed records';
+  button.textContent = preview.kind === 'credit-report' ? 'Apply reviewed credit report'
+    : preview.kind === 'statement' && !preview.reconciled ? 'Store for Review Inbox' : 'Import reviewed records';
 }
 
 function renderImportPreview(preview) {
@@ -899,6 +1120,7 @@ function statementRecordActionLabel(plan) {
 }
 
 function statementCompletionMessage(result) {
+  if (result.awaitingImportReview) return `Statement stored. ${result.added} payment${result.added === 1 ? '' : 's'} remain outside trusted totals until you apply or reject them in Review Inbox.`;
   const balance = result.balanceAction === 'overdraft-created'
     ? ' Account balance updated and its overdraft added.'
     : result.balanceAction === 'overdraft-updated' ? ' Account and overdraft balances updated.'
@@ -956,6 +1178,19 @@ function renderCreditReportChanges(plan) {
 
 async function completeNextAction() {
   if (hasCompletedCheckIn(state.checkIns)) return;
+  if (pendingAction.reviewId) {
+    if (pendingAction.completeDirect) {
+      const item = state.reviewItems.find((entry) => entry.id === pendingAction.reviewId);
+      const task = state.tasks.find((entry) => String(entry.id) === item?.sourceId);
+      if (task) task.completedAt = new Date().toISOString();
+      synchroniseReviewItems(state);
+      state.checkIns.push({ id: createId('checkin'), date: new Date().toISOString(), completed: true, kind: 'action', actionId: item?.sourceId, note: pendingAction.title });
+      await saveState(); render(); showToast('Today is complete. You can close the app now.');
+      return;
+    }
+    await openReviewWorkflow(pendingAction.reviewId);
+    return;
+  }
   const blocker = actionCompletionBlocker(pendingAction);
   if (blocker) {
     byId('nextActionDetail').textContent = blocker;
@@ -983,6 +1218,14 @@ function actionCompletionBlocker(action) {
 }
 
 async function snoozeNextAction() {
+  if (pendingAction.reviewId) {
+    snoozeReviewItem(state, pendingAction.reviewId, 'tomorrow');
+    await saveState();
+    await animateFocusPanel('is-switching', 180);
+    render();
+    showToast('Snoozed until tomorrow. Here is your next available step.');
+    return;
+  }
   const task = state.tasks.find((item) => item.id === pendingAction.id);
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
@@ -1032,7 +1275,10 @@ async function handleEditClick(event) {
     const decision = review.dataset.duplicateReview;
     const label = decision === 'accepted' ? 'include this payment in trusted financial totals' : 'keep this payment excluded as a duplicate';
     if (!window.confirm(`Confirm that OneStep should ${label}?`)) return;
-    const next = resolvePossibleDuplicate(state, review.dataset.id, decision);
+    const item = state.reviewItems.find((entry) => entry.type === 'possible_duplicate' && entry.sourceId === review.dataset.id && entry.status !== 'resolved');
+    const next = item
+      ? resolveReviewItem(state, item.id, decision === 'accepted' ? 'both_genuine' : 'duplicate')
+      : resolvePossibleDuplicate(state, review.dataset.id, decision);
     await saveState(next);
     render();
     showToast(decision === 'accepted' ? 'Payment accepted and included in financial totals.' : 'Duplicate confirmed and kept out of financial totals.');
@@ -1042,8 +1288,8 @@ async function handleEditClick(event) {
   if (button) openEditor(button.dataset.edit, button.dataset.id);
 }
 
-function openEditor(type, id = '') {
-  editorContext = { type, id };
+function openEditor(type, id = '', context = {}) {
+  editorContext = { type, id, ...context };
   const collection = collectionFor(type);
   const item = id ? state[collection].find((entry) => entry.id === id) : null;
   const editorItem = type === 'transaction' && item
@@ -1177,7 +1423,13 @@ async function saveEditor(event) {
       if (!transaction.budgetCategoryId && transaction.categorySource !== 'manual' && normalisedText(transaction.category) === normalisedText(previousBudgetCategory)) transaction.budgetCategoryId = item.id;
     }
   }
-  if (type === 'debt' || type === 'overdraft') { item.updatedAt = new Date().toISOString(); item.planPriority ??= 999; item.arrangementConfirmed = item.arrangementStatus === 'confirmed'; }
+  if (type === 'debt' || type === 'overdraft') {
+    item.updatedAt = new Date().toISOString(); item.planPriority ??= 999; item.arrangementConfirmed = item.arrangementStatus === 'confirmed';
+    if (editorContext.reviewItemId && item.statusConflict === false) {
+      item.reviewedReportedStatus = item.reportedStatus || '';
+      item.statusReviewedAt = item.updatedAt;
+    }
+  }
   if (type === 'account') { item.name ||= 'Unnamed account'; item.active ??= true; }
   await saveState();
   if (type === 'account') populateAccountOptions();
@@ -1259,6 +1511,7 @@ async function checkModel() {
 
 async function saveSettings() {
   state.profile.dependableIncome = Number(byId('dependableIncomeInput').value || 0);
+  state.profile.paydayDay = knownPaydayDay(byId('paydayDayInput').value);
   state.settings.extraDebtPayment = Number(byId('extraPaymentInput').value || 0);
   state.settings.emergencyBufferTarget = Number(byId('bufferTargetInput').value || 0);
   state.settings.emergencyBufferBalance = Number(byId('bufferBalanceInput').value || 0);
@@ -1554,6 +1807,7 @@ function focusTransactionTable() {
 async function saveAndRender() { await saveState(); render(); }
 async function saveState(nextState = state) {
   synchroniseSelectedMonth(nextState);
+  synchroniseReviewItems(nextState);
   const saved = await window.financeAPI.saveState(nextState);
   if (saved?.status === 'blocked') throw new Error(saved.message || 'Saving is paused while recovery is required.');
   if (saved?.status === 'conflict') {

--- a/review-lifecycle.js
+++ b/review-lifecycle.js
@@ -1,0 +1,535 @@
+const REVIEW_STATUSES = new Set(['needs_attention', 'in_progress', 'snoozed', 'resolved']);
+const REVIEW_PRIORITIES = new Set(['high', 'normal', 'low']);
+
+export const REVIEW_STATUS = Object.freeze({
+  NEEDS_ATTENTION: 'needs_attention',
+  IN_PROGRESS: 'in_progress',
+  SNOOZED: 'snoozed',
+  RESOLVED: 'resolved'
+});
+
+export const REVIEW_DIAGNOSTIC_CODES = Object.freeze({
+  STATE_INVALID: 'REVIEW_ITEM_STATE_INVALID',
+  RESOLUTION_FAILED: 'REVIEW_RESOLUTION_FAILED',
+  SNOOZE_INVALID: 'SNOOZE_STATE_INVALID'
+});
+
+export function synchroniseReviewItems(state, now = new Date()) {
+  const target = state && typeof state === 'object' ? state : {};
+  const timestamp = validDate(now).toISOString();
+  const existing = new Map((Array.isArray(target.reviewItems) ? target.reviewItems : [])
+    .map((item) => migrateReviewItem(item, timestamp))
+    .filter(Boolean)
+    .map((item) => [item.id, item]));
+  const sources = reviewSources(target, now);
+  const activeSourceIds = new Set();
+
+  for (const source of sources) {
+    const id = reviewItemId(source.type, source.sourceType, source.sourceId);
+    activeSourceIds.add(id);
+    const previous = existing.get(id);
+    if (!previous) {
+      existing.set(id, createReviewItem(source, id, timestamp));
+      continue;
+    }
+    let changed = previous.type !== source.type
+      || previous.priority !== source.priority
+      || previous.sourceType !== source.sourceType
+      || previous.sourceId !== String(source.sourceId)
+      || previous.groupKey !== (source.groupKey || '')
+      || previous.conditionKey !== (source.conditionKey || '');
+    previous.type = source.type;
+    previous.priority = source.priority;
+    previous.sourceType = source.sourceType;
+    previous.sourceId = String(source.sourceId);
+    previous.groupKey = source.groupKey || '';
+    previous.conditionKey = source.conditionKey || '';
+    if (previous.status === REVIEW_STATUS.SNOOZED && due(previous.snoozedUntil, now)) {
+      previous.status = REVIEW_STATUS.NEEDS_ATTENTION;
+      previous.snoozedUntil = null;
+      changed = true;
+    }
+    if (previous.status === REVIEW_STATUS.RESOLVED && previous.resolution?.decision === 'source_resolved') {
+      previous.status = REVIEW_STATUS.NEEDS_ATTENTION;
+      previous.resolution = null;
+      previous.snoozedUntil = null;
+      changed = true;
+    }
+    if (changed) previous.updatedAt = timestamp;
+  }
+
+  for (const item of existing.values()) {
+    if (activeSourceIds.has(item.id) || item.status === REVIEW_STATUS.RESOLVED) continue;
+    item.status = REVIEW_STATUS.RESOLVED;
+    item.snoozedUntil = null;
+    item.updatedAt = timestamp;
+    item.resolution = { decision: 'source_resolved', resolvedAt: timestamp };
+  }
+
+  const sorted = [...existing.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id));
+  const active = sorted.filter((item) => item.status !== REVIEW_STATUS.RESOLVED);
+  const resolved = sorted.filter((item) => item.status === REVIEW_STATUS.RESOLVED).slice(-5000);
+  target.reviewItems = [...resolved, ...active]
+    .sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id));
+  return target;
+}
+
+export function activeReviewItems(state, now = new Date()) {
+  synchroniseReviewItems(state, now);
+  return (state.reviewItems || [])
+    .filter((item) => item.status !== REVIEW_STATUS.RESOLVED && !(item.status === REVIEW_STATUS.SNOOZED && !due(item.snoozedUntil, now)))
+    .sort(compareReviewPriority);
+}
+
+export function snoozedReviewItems(state, now = new Date()) {
+  synchroniseReviewItems(state, now);
+  return (state.reviewItems || [])
+    .filter((item) => item.status === REVIEW_STATUS.SNOOZED && !due(item.snoozedUntil, now))
+    .sort((left, right) => String(left.snoozedUntil).localeCompare(String(right.snoozedUntil)));
+}
+
+export function reviewInboxSummary(state, now = new Date()) {
+  const active = activeReviewItems(state, now);
+  const snoozed = snoozedReviewItems(state, now);
+  const groups = groupReviewItems(active, state);
+  return {
+    active,
+    snoozed,
+    groups,
+    total: groups.length,
+    important: groups.filter((item) => item.priority === 'high').length,
+    normal: groups.filter((item) => item.priority === 'normal').length,
+    low: groups.filter((item) => item.priority === 'low').length
+  };
+}
+
+export function groupReviewItems(items, state) {
+  const groups = new Map();
+  for (const item of items) {
+    const key = item.type === 'uncategorised_payment' && item.groupKey
+      ? `uncategorised_payment:${item.groupKey}`
+      : item.id;
+    const group = groups.get(key) || { id: key, type: item.type, priority: item.priority, items: [] };
+    group.items.push(item);
+    if (priorityRank(item.priority) < priorityRank(group.priority)) group.priority = item.priority;
+    groups.set(key, group);
+  }
+  return [...groups.values()]
+    .map((group) => ({ ...group, presentation: reviewGroupPresentation(group, state) }))
+    .sort((left, right) => compareReviewPriority(left, right));
+}
+
+export function reviewItemPresentation(item, state) {
+  return reviewGroupPresentation({ type: item.type, items: [item], priority: item.priority }, state);
+}
+
+export function startReviewItem(state, itemId, now = new Date()) {
+  synchroniseReviewItems(state, now);
+  const item = requireOpenItem(state, itemId);
+  if (item.status !== REVIEW_STATUS.SNOOZED) item.status = REVIEW_STATUS.IN_PROGRESS;
+  item.updatedAt = validDate(now).toISOString();
+  return state;
+}
+
+export function snoozeReviewItem(state, itemId, choice, now = new Date()) {
+  synchroniseReviewItems(state, now);
+  const item = requireOpenItem(state, itemId);
+  const snoozedUntil = snoozeUntil(choice, now, state.profile?.paydayDay);
+  if (!snoozedUntil) {
+    const error = new Error(choice === 'payday' ? 'Payday is not known yet.' : 'Choose a supported snooze time.');
+    error.code = REVIEW_DIAGNOSTIC_CODES.SNOOZE_INVALID;
+    throw error;
+  }
+  item.status = REVIEW_STATUS.SNOOZED;
+  item.snoozedUntil = snoozedUntil;
+  item.updatedAt = validDate(now).toISOString();
+  return state;
+}
+
+export function snoozeReviewGroup(state, itemIds, choice, now = new Date()) {
+  for (const itemId of itemIds) snoozeReviewItem(state, itemId, choice, now);
+  return state;
+}
+
+export function resolveReviewItem(state, itemId, decision, now = new Date()) {
+  synchroniseReviewItems(state, now);
+  const item = requireOpenItem(state, itemId);
+  const timestamp = validDate(now).toISOString();
+
+  if (item.type === 'possible_duplicate') {
+    const transaction = (state.transactions || []).find((entry) => String(entry.id) === item.sourceId);
+    if (!transaction || transaction.duplicateStatus !== 'possible' || transaction.reviewStatus !== 'pending') {
+      return synchroniseReviewItems(state, now);
+    }
+    if (!['duplicate', 'both_genuine'].includes(decision)) throw resolutionError('Choose Duplicate or Both are genuine.');
+    transaction.reviewStatus = decision === 'duplicate' ? 'rejected' : 'accepted';
+    transaction.financiallyActive = decision === 'both_genuine' && !['pending', 'rejected'].includes(transaction.importReviewStatus);
+    transaction.reviewedAt = timestamp;
+    transaction.duplicateDecision = decision;
+  } else if (item.type === 'import_conflict') {
+    if (!['keep_current', 'ignore_import', 'apply_import'].includes(decision)) throw resolutionError('Choose how the uncertain import should be handled.');
+    resolveImportConflict(state, item, decision, timestamp);
+  } else if (!sourceResolved(state, item)) {
+    throw resolutionError('Complete the underlying financial work before resolving this review item.');
+  }
+
+  item.status = REVIEW_STATUS.RESOLVED;
+  item.snoozedUntil = null;
+  item.updatedAt = timestamp;
+  item.resolution = { decision, resolvedAt: timestamp };
+  return synchroniseReviewItems(state, now);
+}
+
+export function selectCheckInReviewItems(state, now = new Date(), limit = 4) {
+  const items = activeReviewItems(state, now);
+  const selected = [];
+  const important = items.find((item) => item.priority === 'high');
+  if (important) selected.push(important);
+  for (const item of items) {
+    if (selected.includes(item)) continue;
+    if (selected.length >= limit) break;
+    selected.push(item);
+  }
+  return selected;
+}
+
+export function reviewRoute(item, state = {}) {
+  if (!item) return { view: 'review' };
+  if (item.type === 'uncategorised_payment' || item.type === 'possible_duplicate') return { view: 'transactions', type: 'transaction', id: item.sourceId };
+  if (item.type === 'financial_action') return { view: item.sourceType === 'overdraft' ? 'overdrafts' : 'debts', type: item.sourceType, id: item.sourceId };
+  if (item.sourceType === 'document') {
+    const document = (state.documents || []).find((entry) => String(entry.id) === item.sourceId);
+    if (document?.kind === 'statement') return { view: 'transactions', type: 'import', id: item.sourceId, controlId: 'importStatementButton' };
+    if (document?.kind === 'credit-report') return { view: 'debts', type: 'import', id: item.sourceId, controlId: 'importCreditReportButton' };
+    if (document?.kind === 'payslip') return { view: 'pay', type: 'import', id: item.sourceId, controlId: 'importPayslipButton' };
+    return { view: 'documents', type: 'document', id: item.sourceId };
+  }
+  if (item.sourceType === 'importBatch') {
+    const batch = (state.importBatches || []).find((entry) => String(entry.id) === item.sourceId);
+    return { view: batch?.kind === 'statement' ? 'transactions' : 'debts', type: 'importBatch', id: item.sourceId };
+  }
+  if (item.sourceType === 'task') return { view: 'today', type: 'task', id: item.sourceId };
+  return { view: 'review' };
+}
+
+export function knownPaydayDay(value) {
+  const day = Number(value);
+  return Number.isInteger(day) && day >= 1 && day <= 31 ? day : null;
+}
+
+function reviewSources(state, now) {
+  return [
+    ...uncategorisedSources(state),
+    ...duplicateSources(state),
+    ...financialActionSources(state),
+    ...importConflictSources(state),
+    ...taskSources(state, now)
+  ];
+}
+
+function uncategorisedSources(state) {
+  const budgets = state.budgets || [];
+  return (state.transactions || [])
+    .filter((transaction) => transactionNeedsCategory(transaction, budgets))
+    .map((transaction) => ({
+      type: 'uncategorised_payment', priority: 'normal', sourceType: 'transaction', sourceId: transaction.id,
+      groupKey: merchantKey(transaction), conditionKey: categoryConditionKey(transaction)
+    }));
+}
+
+function duplicateSources(state) {
+  return (state.transactions || [])
+    .filter((transaction) => transaction.duplicateStatus === 'possible' && transaction.reviewStatus === 'pending')
+    .map((transaction) => ({
+      type: 'possible_duplicate', priority: 'high', sourceType: 'transaction', sourceId: transaction.id,
+      groupKey: '', conditionKey: [transaction.duplicateCandidateId || '', transaction.date || '', transaction.incoming || 0, transaction.outgoing || 0].join('|')
+    }));
+}
+
+function financialActionSources(state) {
+  const output = [];
+  for (const [sourceType, records] of [['debt', state.debts || []], ['overdraft', state.overdrafts || []]]) {
+    for (const account of records) {
+      const reasons = financialActionReasons(account, sourceType);
+      if (!reasons.length) continue;
+      output.push({
+        type: 'financial_action', priority: reasons.some((reason) => ['conflict', 'over_limit', 'default_arrangement', 'arrears_arrangement'].includes(reason)) ? 'high' : 'normal',
+        sourceType, sourceId: account.id, groupKey: '', conditionKey: reasons.sort().join('|')
+      });
+    }
+  }
+  return output;
+}
+
+function importConflictSources(state) {
+  const output = [];
+  for (const document of state.documents || []) {
+    if (document.parseStatus !== 'needs_review') continue;
+    output.push({ type: 'import_conflict', priority: 'high', sourceType: 'document', sourceId: document.id, groupKey: '', conditionKey: 'document-needs-review' });
+  }
+  for (const batch of state.importBatches || []) {
+    if (batch.reconciliationState !== 'review-required' || batch.reviewDecision) continue;
+    const requiresImportDecision = batch.kind === 'credit-report'
+      ? Number(batch.reviewCount || 0) + Number(batch.conflictCount || 0) > 0
+      : batch.kind === 'statement' && batch.reconciled === false;
+    if (!requiresImportDecision) continue;
+    output.push({
+      type: 'import_conflict', priority: 'high', sourceType: 'importBatch', sourceId: batch.id,
+      groupKey: '', conditionKey: [batch.documentId || '', batch.reviewCount || 0, batch.conflictCount || 0, batch.possibleDuplicateCount || 0].join('|')
+    });
+  }
+  return output;
+}
+
+function taskSources(state, now) {
+  const today = localDateKey(validDate(now));
+  return (state.tasks || [])
+    .filter((task) => !task.completedAt && (!task.snoozedUntil || String(task.snoozedUntil) <= today))
+    .map((task) => ({ type: 'generated_action', priority: task.priority === 'high' ? 'high' : 'normal', sourceType: 'task', sourceId: task.id, groupKey: '', conditionKey: String(task.updatedAt || task.createdAt || '') }));
+}
+
+function transactionNeedsCategory(transaction, budgets) {
+  if (!transaction || transaction.deletedAt || transaction.ignored === true || transaction.valid === false) return false;
+  if (transaction.duplicateStatus === 'exact' || transaction.reviewStatus === 'rejected' || transaction.financiallyActive === false) return false;
+  if (Number(transaction.outgoing || 0) <= 0 || normalise(transaction.category) === 'income') return false;
+  if (['transfer', 'savings_transfer', 'debt_payment', 'ignored'].includes(normalise(transaction.budgetTreatment))) return false;
+  if (transaction.transferStatus === 'confirmed') return false;
+  if (transaction.budgetCategoryId && budgets.some((budget) => String(budget.id) === String(transaction.budgetCategoryId))) return false;
+  if (transaction.categorySource === 'manual') return !normalise(transaction.category);
+  const category = normalise(transaction.category);
+  const description = normalise(transaction.description);
+  const matches = budgets.filter((budget) => {
+    const categories = (budget.categories?.length ? budget.categories : [budget.category]).map(normalise);
+    const terms = (budget.merchantTerms || []).map(normalise).filter(Boolean);
+    return (category && categories.includes(category)) || terms.some((term) => description.includes(term));
+  });
+  return matches.length !== 1;
+}
+
+function financialActionReasons(account, sourceType) {
+  if (!account || Number(account.currentBalance || 0) <= 0 || account.includeInPlan === false) return [];
+  const reasons = [];
+  const status = normalise(account.status).replace(/ /g, '_');
+  const arrangement = normalise(account.arrangementStatus);
+  const limit = finiteOrNull(sourceType === 'overdraft' ? account.limit : account.creditLimit);
+  if (account.statusConflict === true) reasons.push('conflict');
+  if (status === 'unknown' || !status) reasons.push('unknown_status');
+  if (Number.isFinite(limit) && Number(account.currentBalance) > limit) reasons.push('over_limit');
+  if (status === 'defaulted' && arrangement !== 'confirmed') reasons.push('default_arrangement');
+  else if (status === 'arrears' && arrangement !== 'confirmed') reasons.push('arrears_arrangement');
+  else if (!arrangement || arrangement === 'unknown') reasons.push('unknown_arrangement');
+  if (arrangement === 'confirmed' && !knownNonNegative(account.arrangementPayment)) reasons.push('arrangement_payment');
+  if (arrangement === 'none' && ['current', 'over_limit'].includes(status) && !knownNonNegative(account.contractualPayment)) reasons.push('required_payment');
+  if ((sourceType === 'overdraft' || revolvingCredit(account)) && !Number.isFinite(limit)) reasons.push('credit_limit');
+  return [...new Set(reasons)];
+}
+
+function sourceResolved(state, item) {
+  if (item.type === 'uncategorised_payment') {
+    const transaction = (state.transactions || []).find((entry) => String(entry.id) === item.sourceId);
+    return !transaction || !transactionNeedsCategory(transaction, state.budgets || []);
+  }
+  if (item.type === 'financial_action') {
+    const collection = item.sourceType === 'overdraft' ? state.overdrafts : state.debts;
+    const account = (collection || []).find((entry) => String(entry.id) === item.sourceId);
+    return !account || financialActionReasons(account, item.sourceType).length === 0;
+  }
+  if (item.type === 'generated_action') {
+    const task = (state.tasks || []).find((entry) => String(entry.id) === item.sourceId);
+    return !task || Boolean(task.completedAt);
+  }
+  return false;
+}
+
+function resolveImportConflict(state, item, decision, timestamp) {
+  if (item.sourceType === 'document') {
+    const document = (state.documents || []).find((entry) => String(entry.id) === item.sourceId);
+    if (!document || document.parseStatus !== 'needs_review') throw resolutionError('This document no longer has an unresolved import review.');
+    if (decision !== 'ignore_import') throw resolutionError('Choose Keep document only for this unresolved import.');
+    document.parseStatus = 'ignored';
+    document.reviewedAt = timestamp;
+    return;
+  }
+  const batch = (state.importBatches || []).find((entry) => String(entry.id) === item.sourceId);
+  if (!batch || batch.reconciliationState !== 'review-required') throw resolutionError('This import conflict is no longer available.');
+  const statementDecision = batch.kind === 'statement' && ['keep_current', 'apply_import'].includes(decision);
+  if (!statementDecision && decision !== 'keep_current') throw resolutionError('Choose how this imported conflict should be handled.');
+  batch.reviewDecision = decision;
+  batch.reviewedAt = timestamp;
+  if (batch.kind === 'statement') {
+    for (const transaction of state.transactions || []) {
+      if (transaction.sourceDocumentId !== batch.documentId && !(transaction.sourceDocumentIds || []).includes(batch.documentId)) continue;
+      transaction.importReviewStatus = decision === 'apply_import' ? 'accepted' : 'rejected';
+      transaction.financiallyActive = decision === 'apply_import'
+        && transaction.duplicateStatus !== 'exact'
+        && !(transaction.duplicateStatus === 'possible' && transaction.reviewStatus !== 'accepted');
+      transaction.importReviewedAt = timestamp;
+    }
+    return;
+  }
+  const report = (state.creditReports || []).find((entry) => entry.id === batch.sourceReportId);
+  for (const account of [...(state.debts || []), ...(state.overdrafts || [])]) {
+    if (!report || account.sourceCreditReportId !== report.id) continue;
+    account.statusConflict = false;
+    account.reviewedReportedStatus = account.reportedStatus || '';
+    account.statusReviewedAt = timestamp;
+  }
+}
+
+function reviewGroupPresentation(group, state) {
+  const item = group.items[0];
+  if (group.type === 'uncategorised_payment') {
+    const transactions = group.items.map((entry) => (state.transactions || []).find((transaction) => String(transaction.id) === entry.sourceId)).filter(Boolean);
+    const merchant = displayGroupMerchant(transactions[0]);
+    const count = transactions.length;
+    return {
+      title: count > 1 ? `${count} ${merchant} payments need categorising` : 'Payment needs a category',
+      detail: count > 1 ? 'Choose the right category for each payment. The group updates as you work.' : paymentDetail(transactions[0]),
+      why: 'OneStep could not match this spending to exactly one budget category.', action: 'Categorise', consequence: 'Categorised spending will be included in the correct budget totals.'
+    };
+  }
+  if (group.type === 'possible_duplicate') {
+    const transaction = (state.transactions || []).find((entry) => String(entry.id) === item.sourceId);
+    return {
+      title: 'Possible duplicate payment', detail: paymentDetail(transaction),
+      why: 'This payment looks similar to an existing one, so it is excluded from trusted totals until you decide.', action: 'Review duplicate',
+      consequence: 'Choosing Duplicate keeps it excluded; Both are genuine includes it in trusted totals.'
+    };
+  }
+  if (group.type === 'financial_action') {
+    const collection = item.sourceType === 'overdraft' ? state.overdrafts : state.debts;
+    const account = (collection || []).find((entry) => String(entry.id) === item.sourceId);
+    const reasons = financialActionReasons(account, item.sourceType);
+    const arrangementReview = reasons.some((reason) => ['default_arrangement', 'arrears_arrangement', 'unknown_arrangement', 'arrangement_payment'].includes(reason));
+    return {
+      title: arrangementReview ? 'Check your payment arrangement' : `Confirm the details for ${account?.name || 'this account'}`,
+      detail: financialReasonText(account, item.sourceType), why: 'OneStep is keeping financial safety cautious until the missing or conflicting details are confirmed.',
+      action: 'Review account', consequence: 'Saving confirmed details updates Financial Safety and automatically clears this item when it is safe.'
+    };
+  }
+  if (group.type === 'import_conflict') {
+    const document = item.sourceType === 'document' ? (state.documents || []).find((entry) => String(entry.id) === item.sourceId) : null;
+    const batch = item.sourceType === 'importBatch' ? (state.importBatches || []).find((entry) => String(entry.id) === item.sourceId) : null;
+    const statementBatch = batch?.kind === 'statement';
+    return {
+      title: item.sourceType === 'document' ? 'Import needs a decision' : 'Imported information needs review',
+      detail: document ? `${document.originalName || 'A saved document'} was kept without applying uncertain financial information.` : `${batch?.kind === 'credit-report' ? 'Credit-report' : 'Statement'} information was kept outside trusted decisions where it conflicted.`,
+      why: 'OneStep could not apply this information safely without a deliberate choice.', action: item.sourceType === 'document' ? 'Retry import' : statementBatch ? 'Review imported payments' : 'Review affected accounts',
+      consequence: item.sourceType === 'document' ? 'You can keep the encrypted document without importing it.' : statementBatch ? 'The stored payments stay outside trusted totals until you apply or reject them.' : 'You can deliberately keep the current trusted data.'
+    };
+  }
+  const task = (state.tasks || []).find((entry) => String(entry.id) === item.sourceId);
+  return { title: task?.title || 'Financial action', detail: task?.detail || task?.description || 'This action still needs completing.', why: 'This saved action remains open.', action: 'Continue', consequence: 'Completing the action removes it from active review.' };
+}
+
+function paymentDetail(transaction) {
+  if (!transaction) return 'The payment is no longer available.';
+  const direction = Number(transaction.incoming || 0) > 0 ? 'incoming' : 'outgoing';
+  return `${displayMerchant(transaction)} · ${formatMoney(transaction[direction])}`;
+}
+
+function financialReasonText(account, sourceType) {
+  const reasons = financialActionReasons(account, sourceType);
+  if (reasons.includes('conflict')) return 'The recorded status conflicts with imported information.';
+  if (reasons.includes('over_limit')) return 'This borrowing appears to be above its recorded limit.';
+  if (reasons.includes('default_arrangement') || reasons.includes('arrears_arrangement')) return 'The account status is serious and its payment arrangement is not confirmed.';
+  if (reasons.includes('unknown_status')) return 'The current account status is not known.';
+  if (reasons.includes('unknown_arrangement') || reasons.includes('arrangement_payment')) return 'The payment-arrangement details are incomplete.';
+  if (reasons.includes('required_payment')) return 'The required payment is not known.';
+  if (reasons.includes('credit_limit')) return 'The borrowing limit is not known.';
+  return 'Some safety-critical account details are missing.';
+}
+
+function migrateReviewItem(item, now) {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return null;
+  const type = safeToken(item.type, 60);
+  const sourceType = safeToken(item.sourceType, 40);
+  const sourceId = String(item.sourceId || '').slice(0, 160);
+  if (!type || !sourceType || !sourceId) return null;
+  const status = REVIEW_STATUSES.has(item.status) ? item.status : REVIEW_STATUS.NEEDS_ATTENTION;
+  const priority = REVIEW_PRIORITIES.has(item.priority) ? item.priority : 'normal';
+  const createdAt = validIso(item.createdAt) ? item.createdAt : now;
+  const updatedAt = validIso(item.updatedAt) ? item.updatedAt : createdAt;
+  const snoozedUntil = status === REVIEW_STATUS.SNOOZED && validIso(item.snoozedUntil) ? item.snoozedUntil : null;
+  const resolution = status === REVIEW_STATUS.RESOLVED && item.resolution && typeof item.resolution === 'object' && validIso(item.resolution.resolvedAt)
+    ? { decision: safeToken(item.resolution.decision, 60) || 'source_resolved', resolvedAt: item.resolution.resolvedAt }
+    : null;
+  const migratedStatus = (status === REVIEW_STATUS.SNOOZED && !snoozedUntil) || (status === REVIEW_STATUS.RESOLVED && !resolution)
+    ? REVIEW_STATUS.NEEDS_ATTENTION : status;
+  return {
+    id: reviewItemId(type, sourceType, sourceId), type, status: migratedStatus,
+    priority, createdAt, updatedAt, snoozedUntil, sourceType, sourceId,
+    groupKey: String(item.groupKey || '').slice(0, 160), conditionKey: String(item.conditionKey || '').slice(0, 500), resolution: migratedStatus === REVIEW_STATUS.RESOLVED ? resolution : null
+  };
+}
+
+function createReviewItem(source, id, timestamp) {
+  return {
+    id, type: source.type, status: REVIEW_STATUS.NEEDS_ATTENTION, priority: source.priority,
+    createdAt: timestamp, updatedAt: timestamp, snoozedUntil: null,
+    sourceType: source.sourceType, sourceId: String(source.sourceId), groupKey: source.groupKey || '', conditionKey: source.conditionKey || '', resolution: null
+  };
+}
+
+function requireOpenItem(state, itemId) {
+  const item = (state.reviewItems || []).find((entry) => entry.id === itemId);
+  if (!item || item.status === REVIEW_STATUS.RESOLVED) {
+    const error = new Error('This review item is no longer active.');
+    error.code = REVIEW_DIAGNOSTIC_CODES.STATE_INVALID;
+    throw error;
+  }
+  return item;
+}
+
+function resolutionError(message) {
+  const error = new Error(message);
+  error.code = REVIEW_DIAGNOSTIC_CODES.RESOLUTION_FAILED;
+  return error;
+}
+
+function snoozeUntil(choice, now, paydayDay) {
+  const date = validDate(now);
+  const target = new Date(date);
+  target.setHours(9, 0, 0, 0);
+  if (choice === 'tomorrow') target.setDate(target.getDate() + 1);
+  else if (choice === 'next_week') target.setDate(target.getDate() + 7);
+  else if (choice === 'weekend') {
+    const days = (6 - target.getDay() + 7) % 7;
+    target.setDate(target.getDate() + (days || 7));
+  } else if (choice === 'payday') {
+    const day = knownPaydayDay(paydayDay);
+    if (!day) return null;
+    const candidate = nextPayday(target, day);
+    target.setTime(candidate.getTime());
+  } else return null;
+  return target.toISOString();
+}
+
+function nextPayday(from, requestedDay) {
+  const candidateFor = (year, month) => {
+    const lastDay = new Date(year, month + 1, 0).getDate();
+    return new Date(year, month, Math.min(requestedDay, lastDay), 9, 0, 0, 0);
+  };
+  let candidate = candidateFor(from.getFullYear(), from.getMonth());
+  if (candidate <= from) candidate = candidateFor(from.getFullYear(), from.getMonth() + 1);
+  return candidate;
+}
+
+function due(value, now) { return !validIso(value) || Date.parse(value) <= validDate(now).getTime(); }
+function validDate(value) { const date = value instanceof Date ? new Date(value) : new Date(value); return Number.isNaN(date.getTime()) ? new Date() : date; }
+function validIso(value) { return typeof value === 'string' && Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value; }
+function safeToken(value, length) { const token = String(value || '').toLowerCase().replace(/[^a-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '').slice(0, length); return token; }
+function reviewItemId(type, sourceType, sourceId) { return `review:${safeToken(type, 60)}:${safeToken(sourceType, 40)}:${hashId(String(sourceId))}`; }
+function hashId(value) { let hash = 2166136261; for (const character of value) { hash ^= character.charCodeAt(0); hash = Math.imul(hash, 16777619); } return `${(hash >>> 0).toString(36)}-${value.length}`; }
+function compareReviewPriority(left, right) { return priorityRank(left.priority) - priorityRank(right.priority) || String(left.createdAt || '').localeCompare(String(right.createdAt || '')) || String(left.id).localeCompare(String(right.id)); }
+function priorityRank(value) { return ({ high: 0, normal: 1, low: 2 })[value] ?? 3; }
+function normalise(value) { return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim().replace(/\s+/g, ' '); }
+function merchantKey(transaction) { return normalise(transaction.userDescription || transaction.description).replace(/\b\d+\b/g, '').trim().slice(0, 80) || 'other'; }
+function displayMerchant(transaction) { return String(transaction?.userDescription || transaction?.description || 'Payment').trim().replace(/\s+/g, ' ').slice(0, 80); }
+function displayGroupMerchant(transaction) { return displayMerchant(transaction).replace(/\b\d+\b/g, '').replace(/\s+/g, ' ').trim() || 'Related'; }
+function categoryConditionKey(transaction) { return [transaction.budgetCategoryId || '', transaction.category || '', transaction.categorySource || '', transaction.budgetTreatment || ''].join('|'); }
+function knownNonNegative(value) { return value !== null && value !== undefined && value !== '' && Number.isFinite(Number(value)) && Number(value) >= 0; }
+function finiteOrNull(value) { return value === null || value === undefined || value === '' || !Number.isFinite(Number(value)) ? null : Number(value); }
+function revolvingCredit(item) { return /credit card|store card|revolving|catalogue/i.test(String(item?.type || '')); }
+function formatMoney(value) { return new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(Number(value || 0)); }
+function localDateKey(date) { return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`; }

--- a/scripts/check-project.mjs
+++ b/scripts/check-project.mjs
@@ -13,7 +13,7 @@ for (const file of javascript) {
 }
 
 const seed = JSON.parse(fs.readFileSync(path.join(root, 'seed-data.json'), 'utf8'));
-const emptyCollections = ['accounts', 'transactions', 'payslips', 'taxDocuments', 'creditReports', 'debts', 'overdrafts', 'budgets', 'scheduledPayments', 'documents', 'tasks', 'checkIns', 'importBatches'];
+const emptyCollections = ['accounts', 'transactions', 'payslips', 'taxDocuments', 'creditReports', 'debts', 'overdrafts', 'budgets', 'scheduledPayments', 'documents', 'tasks', 'checkIns', 'importBatches', 'reviewItems'];
 for (const collection of emptyCollections) {
   if (!Array.isArray(seed[collection]) || seed[collection].length) throw new Error(`Public seed ${collection} must be an empty array.`);
 }
@@ -27,6 +27,7 @@ if (packageJson.name !== 'onestep-money' || packageJson.build?.productName !== '
 if (!packageJson.dependencies?.['electron-updater']) throw new Error('The installed update channel is not configured.');
 if (!packageJson.build?.files?.includes('diagnostic-logger.js')) throw new Error('The diagnostic logger is missing from packaged builds.');
 if (!packageJson.build?.files?.includes('transaction-ledger.js')) throw new Error('The paginated transaction ledger is missing from packaged builds.');
+if (!packageJson.build?.files?.includes('review-lifecycle.js')) throw new Error('The persisted review lifecycle is missing from packaged builds.');
 if (packageJson.scripts?.lint !== 'eslint .') throw new Error('The correctness-focused static analysis command is not configured.');
 
 console.log(JSON.stringify({ javascriptFiles: javascript.length, seedCollections: emptyCollections.length, package: packageJson.name, version: packageJson.version }));

--- a/seed-data.json
+++ b/seed-data.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 7,
+  "schemaVersion": 8,
   "meta": {
     "createdAt": "",
     "updatedAt": "",
@@ -10,7 +10,7 @@
     "locale": "en-GB",
     "currency": "GBP",
     "dependableIncome": 0,
-    "paydayDay": 30
+    "paydayDay": null
   },
   "accounts": [],
   "transactions": [],
@@ -25,6 +25,7 @@
   "tasks": [],
   "checkIns": [],
   "importBatches": [],
+  "reviewItems": [],
   "settings": {
     "selectedMonth": "",
     "extraDebtPayment": 0,

--- a/statement-intelligence.js
+++ b/statement-intelligence.js
@@ -2,6 +2,7 @@ import {
   createId, detectRecurringTransactions, findDuplicateCandidates, matchInternalTransfers,
   isTransactionFinanciallyActive, matchStatementAccount, syncStatementAccount
 } from './finance-core.js';
+import { synchroniseReviewItems } from './review-lifecycle.js';
 
 export function buildStatementImportPlan(state, preview, documentId = '') {
   if (preview?.kind !== 'statement') throw new Error('Statement Intelligence only accepts bank-statement previews.');
@@ -12,7 +13,7 @@ export function buildStatementImportPlan(state, preview, documentId = '') {
   const possibleIds = new Set(duplicates.possible.map((item) => item.incoming.id));
   const newRecords = (preview.records || []).filter((record) => !exactIds.has(record.id));
   const trustedHistory = (state.transactions || []).filter(isTransactionFinanciallyActive);
-  const trustedNewRecords = newRecords.filter((record) => !possibleIds.has(record.id));
+  const trustedNewRecords = preview.reconciled ? newRecords.filter((record) => !possibleIds.has(record.id)) : [];
   const recurring = detectRecurringTransactions(trustedHistory, trustedNewRecords);
   const transferMatches = matchInternalTransfers([...trustedHistory, ...trustedNewRecords], accounts)
     .filter((match) => trustedNewRecords.some((record) => record.id === match.debitId || record.id === match.creditId));
@@ -71,6 +72,7 @@ export function applyStatementImportPlan(state, preview, reviewedPlan, documentI
   next.overdrafts ||= [];
   const recurringById = new Map(currentPlan.recurring.map((item) => [item.transactionId, item]));
   const possibleIds = new Set(currentPlan.duplicates.possible.map((item) => item.incoming.id));
+  const possibleMatches = new Map(currentPlan.duplicates.possible.map((item) => [item.incoming.id, item.existing.id]));
   const addedIds = new Set();
   for (const duplicate of currentPlan.duplicates.exact) {
     const existing = next.transactions.find((item) => item.id === duplicate.existing.id);
@@ -85,7 +87,9 @@ export function applyStatementImportPlan(state, preview, reviewedPlan, documentI
       sourceDocumentIds: [...new Set([...(record.sourceDocumentIds || []), documentId || record.sourceDocumentId].filter(Boolean))],
       duplicateStatus: possibleIds.has(record.id) ? 'possible' : 'none',
       reviewStatus: possibleIds.has(record.id) ? 'pending' : 'not_required',
-      financiallyActive: !possibleIds.has(record.id),
+      importReviewStatus: preview.reconciled ? 'trusted' : 'pending',
+      financiallyActive: Boolean(preview.reconciled) && !possibleIds.has(record.id),
+      duplicateCandidateId: possibleMatches.get(record.id) || '',
       recurring: record.recurring || observation?.confidence === 'confirmed',
       recurringObservation: observation || null
     });
@@ -113,14 +117,15 @@ export function applyStatementImportPlan(state, preview, reviewedPlan, documentI
     accountId: account.id
   });
   return {
-    state: next,
+    state: synchroniseReviewItems(next, new Date(importedAt)),
     result: {
       added: currentPlan.newRecords.length,
       alreadyKnown: currentPlan.counts.alreadyKnown,
       needsReview: currentPlan.counts.needsReview,
       balanceAction,
       recurring: currentPlan.counts.recurring,
-      transfers: currentPlan.counts.transfers
+      transfers: currentPlan.counts.transfers,
+      awaitingImportReview: !preview.reconciled
     }
   };
 }

--- a/styles.css
+++ b/styles.css
@@ -602,6 +602,48 @@ tr:last-child td { border-bottom: 0; }
 .duplicate-review-button.accept { color: var(--green); background: var(--green-soft); border-color: #bde8d6; }
 .duplicate-review-button.reject { color: #7b5709; background: var(--amber-soft); border-color: #ecd9a9; }
 
+.nav-count { min-width: 1.35rem; height: 1.35rem; display: inline-grid; place-items: center; margin-left: 0.28rem; padding: 0 0.36rem; color: #d8fff7; background: rgba(61, 205, 181, 0.16); border: 1px solid rgba(113, 230, 209, 0.32); border-radius: 999px; font-size: 0.65rem; font-variant-numeric: tabular-nums; }
+.welcome-back, .review-hero { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; padding: 1.05rem 1.15rem; background: linear-gradient(135deg, #f4fbfa, #f8fafc); border: 1px solid #cfe8e3; border-radius: 16px; box-shadow: var(--shadow-sm); }
+.welcome-back h2, .review-hero h2 { margin: 0.12rem 0 0.25rem; }
+.welcome-back p, .review-hero p { margin: 0; color: var(--muted); }
+.review-summary-counts { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 0.45rem; }
+.review-summary-counts span { display: grid; gap: 0.05rem; min-width: 82px; padding: 0.6rem 0.7rem; color: var(--muted); background: #fff; border: 1px solid var(--line); border-radius: 11px; font-size: 0.69rem; text-align: center; }
+.review-summary-counts strong { color: var(--navy); font-size: 1.02rem; font-variant-numeric: tabular-nums; }
+.review-list { display: grid; gap: 0.75rem; }
+.review-card { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 1rem; padding: 1rem; background: #fff; border: 1px solid var(--line); border-left: 4px solid var(--teal); border-radius: 14px; box-shadow: var(--shadow-sm); }
+.review-card.priority-high { border-left-color: #c76a3b; }
+.review-card-copy { min-width: 0; }
+.review-card-heading { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.28rem; }
+.review-card-heading h3 { margin: 0; }
+.review-priority { padding: 0.24rem 0.45rem; color: var(--teal-dark); background: var(--teal-soft); border-radius: 999px; font-size: 0.64rem; font-weight: 800; letter-spacing: 0.04em; text-transform: uppercase; }
+.priority-high .review-priority { color: #7b4b0a; background: var(--amber-soft); }
+.review-card-detail { margin: 0; color: var(--ink-soft); line-height: 1.45; }
+.review-explanation { margin-top: 0.65rem; }
+.review-explanation summary { color: var(--teal-dark); font-size: 0.75rem; font-weight: 770; cursor: pointer; }
+.review-explanation p { margin: 0.42rem 0 0; color: var(--muted); font-size: 0.76rem; line-height: 1.5; }
+.review-card-actions { min-width: 185px; display: grid; align-content: start; gap: 0.48rem; }
+.review-card-actions > button, .review-card-actions > select { width: 100%; }
+.review-decision-row { display: grid; grid-template-columns: 1fr 1fr; gap: 0.4rem; }
+.review-decision-row button { min-height: 38px; padding: 0.45rem; font-size: 0.72rem; }
+.review-snooze-controls { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 0.4rem; }
+.review-snooze-controls select { min-width: 0; }
+.review-snooze-controls button { min-height: 38px; padding: 0.45rem 0.58rem; }
+.review-group-items { margin-top: 0.7rem; border-top: 1px solid var(--line); }
+.review-group-items summary { padding-top: 0.65rem; color: var(--teal-dark); font-size: 0.76rem; font-weight: 760; cursor: pointer; }
+.review-group-row { display: flex; align-items: center; justify-content: space-between; gap: 0.7rem; padding: 0.5rem 0; border-bottom: 1px solid #edf1f4; color: var(--ink-soft); font-size: 0.78rem; }
+.review-group-row:last-child { border-bottom: 0; }
+.review-group-row button { min-height: 34px; padding: 0.4rem 0.58rem; font-size: 0.7rem; }
+.review-done { display: flex; align-items: center; gap: 0.85rem; padding: 1.1rem; color: var(--green); background: var(--green-soft); border: 1px solid #bde8d6; border-radius: 14px; }
+.review-done > span { width: 2rem; height: 2rem; display: grid; place-items: center; flex: 0 0 auto; color: #fff; background: var(--green); border-radius: 50%; font-weight: 900; }
+.review-done p { margin: 0.2rem 0 0; color: var(--muted); }
+.review-snoozed-section { margin-top: 1.2rem; }
+.review-list.compact .review-card { opacity: 0.86; border-left-color: #8b9aad; }
+.review-due { color: var(--muted); font-size: 0.72rem; }
+.check-in-review-list { display: grid; gap: 0.38rem; margin: 0.6rem 0; }
+.check-in-review-item { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; padding: 0.48rem 0.58rem; background: #f7fafb; border: 1px solid var(--line); border-radius: 9px; font-size: 0.75rem; }
+.check-in-review-item strong { color: var(--navy); }
+.check-in-review-item button { min-height: 32px; padding: 0.36rem 0.52rem; font-size: 0.68rem; }
+
 .prompt-chips { display: flex; flex-wrap: wrap; gap: 0.55rem; margin: 1rem 0; }
 .prompt-chips button { padding: 0.55rem 0.74rem; color: var(--teal-dark); background: var(--teal-soft); border: 1px solid #c0e8e0; }
 .prompt-chips button:hover { color: var(--navy); background: #d9f5ef; transform: translateY(-1px); }
@@ -803,7 +845,7 @@ tr:last-child td { border-bottom: 0; }
   .notification-layer { padding-bottom: 76px; }
   .sidebar { position: fixed; inset: auto 0 0 0; z-index: 6; width: 100%; height: auto; padding: 0.45rem; }
   .sidebar::before, .sidebar::after, .brand, .sidebar-footer { display: none; }
-  .sidebar nav { grid-template-columns: repeat(9, minmax(58px, 1fr)); overflow-x: auto; }
+  .sidebar nav { grid-template-columns: repeat(10, minmax(58px, 1fr)); overflow-x: auto; }
   .nav-button { min-width: 56px; min-height: 48px; }
   .main-content { padding-bottom: 5rem; }
   .topbar, .section-actions, .focus-panel { align-items: flex-start; flex-direction: column; }
@@ -826,6 +868,9 @@ tr:last-child td { border-bottom: 0; }
   .chat-form { grid-template-columns: 1fr; }
   .transaction-ledger-footer { align-items: stretch; flex-direction: column; }
   .transaction-pagination { justify-content: space-between; }
+  .review-hero, .welcome-back, .review-card { align-items: stretch; grid-template-columns: 1fr; flex-direction: column; }
+  .review-summary-counts { justify-content: flex-start; }
+  .review-card-actions { min-width: 0; }
 }
 
 @media (max-width: 560px) {

--- a/tests/data-store-recovery.test.js
+++ b/tests/data-store-recovery.test.js
@@ -15,7 +15,7 @@ test('a genuine first launch creates one valid initial state and starts normally
   const first = await harness.store.loadState();
   assert.equal(first.status, 'normal');
   assert.equal(first.source, 'first_install');
-  assert.equal(first.state.schemaVersion, 7);
+  assert.equal(first.state.schemaVersion, 8);
 
   const firstBytes = await fs.readFile(harness.store.statePath);
   const second = await harness.store.loadState();
@@ -51,7 +51,7 @@ test('legacy debt safety fields migrate conservatively and persist across restar
 
   const loaded = await harness.store.loadState();
 
-  assert.equal(loaded.state.schemaVersion, 7);
+  assert.equal(loaded.state.schemaVersion, 8);
   assert.equal(loaded.state.debts[0].arrangementStatus, 'unknown');
   assert.equal(loaded.state.debts[0].arrangementPayment, null);
   assert.equal(loaded.state.debts[0].statusConflict, false);
@@ -184,7 +184,7 @@ test('restoring a validated backup exits recovery only after the restored state 
   assert.equal(restored.status, 'normal');
   assert.equal(restored.source, 'restored_backup');
   assert.equal(restored.state.profile.name, 'Restored User');
-  assert.equal(restored.state.schemaVersion, 7);
+  assert.equal(restored.state.schemaVersion, 8);
   assert.deepEqual(await fs.readFile(backupPath), backup);
   const recoveryCopies = await fs.readdir(harness.store.recoveryPath);
   assert.ok(recoveryCopies.length >= 2);
@@ -263,7 +263,7 @@ test('fresh start requires a live confirmation and cancellation changes nothing'
   const confirmed = await harness.store.confirmFreshStart(confirmedRequest.token);
   assert.equal(confirmed.status, 'normal');
   assert.equal(confirmed.source, 'fresh_start');
-  assert.equal(confirmed.state.schemaVersion, 7);
+  assert.equal(confirmed.state.schemaVersion, 8);
   assert.equal(confirmed.state.accounts.length, 0);
   assert.notDeepEqual(await fs.readFile(harness.store.statePath), original);
   const recoveryCopies = await fs.readdir(harness.store.recoveryPath);

--- a/tests/interaction-ui.test.js
+++ b/tests/interaction-ui.test.js
@@ -62,3 +62,23 @@ test('all transient and update notifications share a promoted browser top layer'
   assert.match(css, /\.notification-layer \{[^}]*position: fixed;[^}]*inset: 0;[^}]*z-index: 2147483647/);
   assert.match(css, /\.notification-layer::backdrop \{ background: transparent; pointer-events: none; \}/);
 });
+
+test('Review Inbox uses accessible controls, restrained counts and progressive disclosure', async () => {
+  const [html, renderer, css] = await Promise.all([
+    fs.readFile(new URL('../index.html', import.meta.url), 'utf8'),
+    fs.readFile(new URL('../renderer-app.js', import.meta.url), 'utf8'),
+    fs.readFile(new URL('../styles.css', import.meta.url), 'utf8')
+  ]);
+
+  assert.match(html, /data-view="review"[\s\S]*id="reviewNavCount"/);
+  assert.match(html, /id="view-review"[\s\S]*id="reviewInboxStatus"[^>]*role="status"[^>]*aria-live="polite"/);
+  assert.match(html, /id="reviewDoneState"[\s\S]*Nothing needs reviewing right now/);
+  assert.match(html, /id="reviewActiveList"/);
+  assert.match(html, /id="reviewSnoozedList"/);
+  assert.match(renderer, /resolveReviewItem\(state/);
+  assert.match(renderer, /snoozeReviewGroup\(state/);
+  assert.match(renderer, /openEditor\('transaction', route\.id, \{ reviewItemId: item\.id \}\)/);
+  assert.match(renderer, /knownPaydayDay\(state\.profile\?\.paydayDay\)/);
+  assert.match(css, /\.review-priority/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+});

--- a/tests/review-lifecycle.test.js
+++ b/tests/review-lifecycle.test.js
@@ -1,0 +1,248 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { applyCreditReportImportPlan, buildCreditReportImportPlan } from '../credit-report-intelligence.js';
+import { FinanceDataStore, RECOVERY_MODES, RecoveryModeError } from '../data-store.js';
+import { debtSafetyAssessment } from '../finance-core.js';
+import {
+  activeReviewItems, groupReviewItems, resolveReviewItem, reviewInboxSummary,
+  snoozeReviewItem, startReviewItem, synchroniseReviewItems
+} from '../review-lifecycle.js';
+
+const seedPath = new URL('../seed-data.json', import.meta.url);
+
+test('uncategorised payment creates review work and categorising it resolves without regeneration', () => {
+  const state = baseState();
+  state.budgets.push({ id: 'food', category: 'Food', planned: 100 });
+  state.transactions.push(transaction({ id: 'payment-1', description: 'Fictional Grocer' }));
+
+  synchroniseReviewItems(state, new Date('2026-08-09T09:00:00.000Z'));
+  const item = activeReviewItems(state)[0];
+  assert.equal(item.type, 'uncategorised_payment');
+
+  state.transactions[0].budgetCategoryId = 'food';
+  state.transactions[0].category = 'Food';
+  state.transactions[0].categorySource = 'manual';
+  synchroniseReviewItems(state, new Date('2026-08-09T09:05:00.000Z'));
+  assert.equal(activeReviewItems(state).length, 0);
+  assert.equal(state.reviewItems[0].status, 'resolved');
+
+  synchroniseReviewItems(state, new Date('2026-08-09T09:06:00.000Z'));
+  assert.equal(state.reviewItems.length, 1);
+  assert.equal(state.reviewItems[0].status, 'resolved');
+});
+
+test('possible duplicate decisions persist for Duplicate and Both are genuine', () => {
+  const duplicateState = baseState();
+  duplicateState.transactions.push(transaction({ id: 'possible-1', duplicateStatus: 'possible', reviewStatus: 'pending', financiallyActive: false, duplicateCandidateId: 'existing-1' }));
+  synchroniseReviewItems(duplicateState);
+  resolveReviewItem(duplicateState, duplicateState.reviewItems[0].id, 'duplicate', new Date('2026-08-09T10:00:00.000Z'));
+  assert.equal(duplicateState.transactions[0].reviewStatus, 'rejected');
+  assert.equal(duplicateState.transactions[0].financiallyActive, false);
+  assert.equal(duplicateState.reviewItems[0].resolution.decision, 'duplicate');
+  synchroniseReviewItems(duplicateState);
+  assert.equal(duplicateState.reviewItems.length, 1);
+
+  const genuineState = baseState();
+  genuineState.transactions.push(transaction({ id: 'possible-2', duplicateStatus: 'possible', reviewStatus: 'pending', financiallyActive: false, duplicateCandidateId: 'existing-2' }));
+  synchroniseReviewItems(genuineState);
+  resolveReviewItem(genuineState, genuineState.reviewItems[0].id, 'both_genuine', new Date('2026-08-09T10:00:00.000Z'));
+  assert.equal(genuineState.transactions[0].reviewStatus, 'accepted');
+  assert.equal(genuineState.transactions[0].financiallyActive, true);
+  assert.equal(activeReviewItems(genuineState).some((item) => item.type === 'possible_duplicate'), false);
+});
+
+test('snoozed work disappears now and automatically returns when due', () => {
+  const state = baseState();
+  state.transactions.push(transaction());
+  const now = new Date('2026-08-09T09:00:00.000Z');
+  synchroniseReviewItems(state, now);
+  snoozeReviewItem(state, state.reviewItems[0].id, 'tomorrow', now);
+
+  assert.equal(activeReviewItems(state, new Date('2026-08-09T12:00:00.000Z')).length, 0);
+  assert.equal(state.reviewItems[0].status, 'snoozed');
+  assert.equal(activeReviewItems(state, new Date('2026-08-10T10:00:00.000Z')).length, 1);
+  assert.equal(state.reviewItems[0].status, 'needs_attention');
+});
+
+test('payday snooze is unavailable until a payday is genuinely known', () => {
+  const state = baseState();
+  state.transactions.push(transaction());
+  synchroniseReviewItems(state);
+  assert.throws(() => snoozeReviewItem(state, state.reviewItems[0].id, 'payday'), /not known/i);
+  state.profile.paydayDay = 28;
+  snoozeReviewItem(state, state.reviewItems[0].id, 'payday', new Date('2026-08-09T09:00:00.000Z'));
+  assert.match(state.reviewItems[0].snoozedUntil, /^2026-08-28T/);
+});
+
+test('related uncategorised payments group by merchant while retaining source-level resolution', () => {
+  const state = baseState();
+  state.transactions.push(
+    transaction({ id: 'one', description: 'Fictional Grocer 1234', outgoing: 20 }),
+    transaction({ id: 'two', description: 'Fictional Grocer 5678', outgoing: 30 }),
+    transaction({ id: 'three', description: 'Different Merchant', outgoing: 10 })
+  );
+  synchroniseReviewItems(state);
+  const groups = groupReviewItems(activeReviewItems(state), state);
+  assert.equal(groups.length, 2);
+  assert.equal(groups.find((group) => group.items.length === 2).presentation.title, '2 Fictional Grocer payments need categorising');
+});
+
+test('credit-report conflicts create review work without overwriting trusted balances', () => {
+  const state = baseState();
+  state.documents.push({ id: 'document-1', parseStatus: 'ready' });
+  state.debts.push({
+    id: 'debt-1', name: 'Fictional Card', type: 'Credit card', accountReference: '1234', currentBalance: 700,
+    balanceEffectiveDate: '2026-08-07', balanceSourceProvider: 'transunion', contractualPayment: 30, creditLimit: 1000,
+    status: 'current', reportedStatus: 'Current', arrangementStatus: 'none', arrangementConfirmed: false,
+    arrangementPayment: null, arrearsAmount: null, statusConflict: false, includeInPlan: true
+  });
+  const preview = creditPreview();
+  const plan = buildCreditReportImportPlan(state, preview, 'document-1');
+  assert.equal(plan.accountPlans[0].category, 'conflict');
+  const applied = applyCreditReportImportPlan(state, preview, plan, 'document-1', '2026-08-09T12:00:00.000Z');
+
+  assert.equal(applied.state.debts[0].currentBalance, 700);
+  const review = activeReviewItems(applied.state).find((item) => item.type === 'import_conflict');
+  assert.ok(review);
+  assert.equal(debtSafetyAssessment(applied.state).accounts[0].reasonCodes.includes('conflicting_status'), true);
+
+  resolveReviewItem(applied.state, review.id, 'keep_current', new Date('2026-08-09T12:05:00.000Z'));
+  assert.equal(applied.state.debts[0].currentBalance, 700);
+  assert.equal(activeReviewItems(applied.state).some((item) => item.type === 'import_conflict'), false);
+  assert.equal(debtSafetyAssessment(applied.state).accounts[0].reasonCodes.includes('conflicting_status'), false);
+});
+
+test('an unresolved saved document can be deliberately kept without applying its import', () => {
+  const state = baseState();
+  state.documents.push({ id: 'document-1', originalName: 'fictional.pdf', parseStatus: 'needs_review' });
+  synchroniseReviewItems(state);
+  const review = activeReviewItems(state)[0];
+  assert.equal(review.type, 'import_conflict');
+  resolveReviewItem(state, review.id, 'ignore_import');
+  assert.equal(state.documents[0].parseStatus, 'ignored');
+  assert.equal(activeReviewItems(state).length, 0);
+});
+
+test('active, in-progress, snoozed and resolved review state survives restart and encrypted backup restore', async (t) => {
+  const harness = await createHarness(t);
+  let state = (await harness.store.loadState()).state;
+  state.transactions.push(
+    transaction({ id: 'active', description: 'Active Fictional Payment' }),
+    transaction({ id: 'progress', description: 'Progress Fictional Payment' }),
+    transaction({ id: 'snoozed', description: 'Snoozed Fictional Payment' }),
+    transaction({ id: 'resolved', description: 'Resolved Fictional Payment', duplicateStatus: 'possible', reviewStatus: 'pending', financiallyActive: false })
+  );
+  synchroniseReviewItems(state);
+  const snoozed = state.reviewItems.find((item) => item.sourceId === 'snoozed');
+  const progress = state.reviewItems.find((item) => item.sourceId === 'progress');
+  const resolved = state.reviewItems.find((item) => item.sourceId === 'resolved');
+  startReviewItem(state, progress.id);
+  snoozeReviewItem(state, snoozed.id, 'next_week');
+  resolveReviewItem(state, resolved.id, 'both_genuine');
+  state = await harness.store.saveState(state);
+
+  const restarted = new FinanceDataStore(harness.directory, seedPath, null, { secureStorage: secureStorage() });
+  await restarted.initialise();
+  state = (await restarted.loadState()).state;
+  assert.equal(state.reviewItems.find((item) => item.sourceId === 'active').status, 'needs_attention');
+  assert.equal(state.reviewItems.find((item) => item.sourceId === 'progress').status, 'in_progress');
+  assert.equal(state.reviewItems.find((item) => item.sourceId === 'snoozed').status, 'snoozed');
+  assert.equal(state.reviewItems.find((item) => item.sourceId === 'resolved').status, 'resolved');
+
+  const backupPath = path.join(harness.directory, 'review-state.osmb');
+  await restarted.createPortableBackup(backupPath, 'fictional-passphrase', state);
+  const changed = structuredClone(state);
+  changed.transactions = [];
+  await restarted.saveState(changed);
+  const restored = await restarted.restorePortableBackup(backupPath, 'fictional-passphrase');
+  assert.equal(restored.status, 'restored');
+  assert.equal(restored.state.reviewItems.find((item) => item.sourceId === 'snoozed').status, 'snoozed');
+  assert.equal(restored.state.reviewItems.find((item) => item.sourceId === 'resolved').resolution.decision, 'both_genuine');
+});
+
+test('recovery mode remains authoritative over duplicate decisions that mutate financial state', async (t) => {
+  const harness = await createHarness(t);
+  let state = (await harness.store.loadState()).state;
+  state.transactions.push(transaction({ duplicateStatus: 'possible', reviewStatus: 'pending', financiallyActive: false }));
+  state = await harness.store.saveState(state);
+  const attempted = structuredClone(state);
+  resolveReviewItem(attempted, attempted.reviewItems[0].id, 'both_genuine');
+  harness.store.mode = RECOVERY_MODES.REQUIRED;
+  await assert.rejects(harness.store.saveState(attempted), (error) => error instanceof RecoveryModeError);
+  harness.store.mode = RECOVERY_MODES.NORMAL;
+  const unchanged = (await harness.store.loadState()).state;
+  assert.equal(unchanged.transactions[0].reviewStatus, 'pending');
+  assert.equal(unchanged.reviewItems[0].status, 'needs_attention');
+});
+
+test('inbox summary uses restrained grouped counts and does not count snoozed work as active', () => {
+  const state = baseState();
+  state.transactions.push(transaction({ id: 'one', description: 'Fictional Shop 1' }), transaction({ id: 'two', description: 'Fictional Shop 2' }));
+  synchroniseReviewItems(state);
+  snoozeReviewItem(state, state.reviewItems[0].id, 'next_week');
+  const summary = reviewInboxSummary(state);
+  assert.equal(summary.total, 1);
+  assert.equal(summary.snoozed.length, 1);
+});
+
+test('large grouped review sources retain every active payment without flooding the visible inbox', () => {
+  const state = baseState();
+  state.transactions = Array.from({ length: 6000 }, (_, index) => transaction({ id: `bulk-${index}`, description: `Fictional Bulk Merchant ${index}` }));
+  synchroniseReviewItems(state);
+  const summary = reviewInboxSummary(state);
+  assert.equal(state.reviewItems.filter((item) => item.status !== 'resolved').length, 6000);
+  assert.equal(summary.total, 1);
+  assert.equal(summary.groups[0].items.length, 6000);
+});
+
+function baseState() {
+  return {
+    schemaVersion: 8, meta: { createdAt: '2026-08-09T08:00:00.000Z', updatedAt: '2026-08-09T08:00:00.000Z', revision: 0 },
+    profile: { name: '', locale: 'en-GB', currency: 'GBP', dependableIncome: 0, paydayDay: null },
+    accounts: [], transactions: [], payslips: [], taxDocuments: [], creditReports: [], debts: [], overdrafts: [], budgets: [],
+    scheduledPayments: [], documents: [], tasks: [], checkIns: [], importBatches: [], reviewItems: [],
+    settings: { selectedMonth: '2026-08', extraDebtPayment: 0, emergencyBufferTarget: 500, emergencyBufferBalance: 0, extraIncomeDebtPercent: 80, llmModel: 'qwen2.5:1.5b', reminders: { weekly: false, weeklyDay: 'monday', hour: 9 }, snoozedActions: {} }
+  };
+}
+
+function transaction(overrides = {}) {
+  return {
+    id: 'payment-1', accountId: 'account-1', date: '2026-08-09', budgetMonth: '2026-08', description: 'Fictional Payment',
+    incoming: 0, outgoing: 10, budgetCategoryId: '', category: '', categorySource: 'manual', budgetTreatment: 'auto',
+    transferStatus: 'no', duplicateStatus: 'none', reviewStatus: 'not_required', financiallyActive: true, ...overrides
+  };
+}
+
+function creditPreview() {
+  return {
+    kind: 'credit-report', warnings: [], rejected: [], reconciled: true,
+    summary: { provider: 'Experian', reportDate: '2026-08-07', score: 700, scoreMaximum: 999 },
+    records: [{
+      id: 'report-1', provider: 'Experian', reportDate: '2026-08-07', score: 700, scoreMaximum: 999,
+      accounts: [{
+        id: 'reported-1', lender: 'Fictional Card', accountType: 'Credit card', normalisedAccountType: 'credit-card', accountReference: '1234',
+        currentBalance: 800, creditLimit: 1000, contractualPayment: 30, apr: null, status: 'Default', normalisedStatus: 'defaulted',
+        arrangementStatus: 'none', updatedDate: '2026-08-07', defaultDate: '', arrearsAmount: null, arrangementPayment: null, interestFrozen: false
+      }]
+    }]
+  };
+}
+
+async function createHarness(t) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-review-'));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const store = new FinanceDataStore(directory, seedPath, null, { secureStorage: secureStorage(), appVersion: '2.1.22' });
+  await store.initialise();
+  return { directory, store };
+}
+
+function secureStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(value, 'utf8'),
+    decryptString: (value) => value.toString('utf8')
+  };
+}

--- a/tests/statement-intelligence.test.js
+++ b/tests/statement-intelligence.test.js
@@ -3,9 +3,10 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import {
   detectRecurringTransactions, findDuplicateCandidates, matchInternalTransfers,
-  matchStatementAccount, syncStatementAccount
+  isTransactionFinanciallyActive, matchStatementAccount, syncStatementAccount
 } from '../finance-core.js';
 import { applyStatementImportPlan, buildStatementImportPlan } from '../statement-intelligence.js';
+import { activeReviewItems, resolveReviewItem } from '../review-lifecycle.js';
 
 const transaction = (overrides = {}) => ({
   id: overrides.id || `transaction-${Math.random()}`,
@@ -84,6 +85,8 @@ test('possible duplicate imports are retained with pending inactive review state
   assert.equal(possible.sourceDocumentId, 'document-1');
   assert.equal(possible.recurring, false);
   assert.equal(possible.transferStatus, 'no');
+  assert.equal(possible.duplicateCandidateId, 'existing');
+  assert.equal(applied.state.reviewItems.filter((item) => item.type === 'possible_duplicate' && item.status === 'needs_attention').length, 1);
 });
 
 test('provider transaction identifiers provide exact duplicate evidence', () => {
@@ -228,6 +231,13 @@ test('unreconciled statements can add reviewed transactions without changing acc
   assert.equal(applied.state.transactions.length, 1);
   assert.equal(applied.state.accounts[0].currentBalance, 100);
   assert.equal(applied.result.balanceAction, '');
+  assert.equal(applied.state.transactions[0].importReviewStatus, 'pending');
+  assert.equal(isTransactionFinanciallyActive(applied.state.transactions[0]), false);
+  const review = activeReviewItems(applied.state).find((item) => item.type === 'import_conflict');
+  assert.ok(review);
+  resolveReviewItem(applied.state, review.id, 'apply_import');
+  assert.equal(applied.state.transactions[0].importReviewStatus, 'accepted');
+  assert.equal(isTransactionFinanciallyActive(applied.state.transactions[0]), true);
 });
 
 test('foreign-currency statement is review-only for a GBP profile', () => {


### PR DESCRIPTION
## Purpose

OneStep needed one persistent, local lifecycle for work that requires human judgement. This release consolidates reviewable financial work into a Review Inbox so uncertain conditions are not guessed, scattered across temporary warnings, or repeatedly recreated after the user makes a decision.

## Work completed

- Added a dedicated Review Inbox with progressive summary counts, restrained navigation count, important/normal sections, snoozed work, and a clear empty state.
- Added the shared lifecycle: Needs Attention, In Progress, Snoozed, and Resolved.
- Added source-linked, stable review identifiers and idempotent synchronization to prevent duplicate work on restart.
- Added genuine source-aware resolution rules. Source workflows automatically resolve related review work when the underlying condition is fixed.
- Added Tomorrow, This weekend, Next week, and conditional Payday snoozes. Payday is unavailable unless the user has provided a valid payday.
- Added sensible high/normal/low priority without introducing the v2.1.23 Next Move engine.
- Grouped repetitive uncategorized payments by normalized merchant, with individual quick categorization in the group details.
- Integrated uncategorized outgoing payments; categorized Income does not become review work.
- Integrated possible duplicates with persistent **Duplicate** and **Both are genuine** decisions.
- Integrated ambiguous/unresolved document and import work while preserving source relationships.
- Added a pending import gate for unreconciled statement transactions so uncertain data stays out of trusted totals until explicitly applied; rejected changes remain excluded.
- Integrated credit-report conflicts while protecting authoritative balances and allowing a deliberate keep-current decision.
- Converged generated financial actions and Today task completion onto the shared lifecycle where reliable.
- Updated Five-Minute Check-In to surface a bounded selection (one important item first, plus a few manageable items).
- Added a compact Welcome Back summary rather than dumping accumulated work.
- Kept temporary toasts/notifications separate from persistent Review Inbox work.
- Added keyboard-accessible buttons, focus behavior, screen-reader labels/live status, non-color priority labels, and reduced-motion compatibility.
- Added privacy-safe lifecycle diagnostics without financial content.
- Upgraded the application version from 2.1.21 to 2.1.22 and schema version from 7 to 8.
- Added lifecycle, snooze, duplicate, categorization, import, persistence, backup/restore, recovery, scale/grouping, and accessibility regression coverage.

## Files changed

- `review-lifecycle.js` — new shared lifecycle, source synchronization, priority, grouping, snooze, routing, and resolution rules.
- `data-store.js` — schema-v8 review-item persistence, validation, migration, backup/restore support, and import trust state.
- `finance-core.js` — trusted-total gates, duplicate/import resolution behavior, generated-action convergence, and safety handling.
- `statement-intelligence.js` — duplicate source relationships and pending/rejected statement-import review state.
- `credit-report-intelligence.js` — review synchronization and protected credit-conflict decisions.
- `renderer-app.js` — Review Inbox UI behavior, source workflow routing, quick resolution, snooze, check-in, Welcome Back, and counts.
- `index.html` — Review navigation/view structure, accessible live regions, import wording, and payday setting.
- `styles.css` — inbox/group/status styling, restrained priority treatment, focus/reduced-motion support, and mobile navigation update.
- `seed-data.json` — schema-v8 defaults with an empty review collection and no invented payday.
- `package.json` — version 2.1.22 and production inclusion of the lifecycle module.
- `package-lock.json` — lockfile version synchronization.
- `scripts/check-project.mjs` — schema-v8/review collection validation.
- `tests/review-lifecycle.test.js` — new end-to-end lifecycle regression suite.
- `tests/data-store-recovery.test.js` — persistence, encrypted backup/restore, migration, and recovery-mode coverage.
- `tests/statement-intelligence.test.js` — duplicate and unresolved import trust-gate coverage.
- `tests/interaction-ui.test.js` — Review Inbox accessibility and integration assertions.

## User-facing changes

Review Inbox is available from primary navigation as **Review**, with a restrained active count. It contains only persistent work that needs a decision or real task: uncategorized payments, possible duplicates, account/document/import conflicts, and relevant financial actions.

Each item explains what needs attention, why OneStep could not safely decide, the available action, and where that action leads. Items open the relevant transaction, debt, account/import, or reconciliation workflow. Fixing the source automatically removes the active review item when OneStep can reliably determine completion.

Snoozed items leave active attention and return when due. Payday snooze is disabled until a real payday is known. Repetitive uncategorized work is grouped by merchant; users can expand the group and categorize the individual payments.

## Technical changes

- Added persisted `reviewItems` with source references rather than duplicated financial records.
- Stable IDs derive from review type/source type/source ID; repeated synchronization updates the existing item instead of creating duplicates.
- Resolved decisions persist and reopen only if the authoritative source genuinely becomes unresolved again.
- Added `importReviewStatus` to transactions. Pending and rejected uncertain imports are financially inactive, so they cannot influence trusted totals.
- Source-aware resolution prevents generic completion while the underlying financial condition remains unresolved.
- Backup and restore include review lifecycle state through the encrypted application state.
- Schema migration is additive and non-destructive. Existing transactions, accounts, debts, budgets, documents, payslips, and credit reports are preserved.
- The former implicit schema-v7 payday value is migrated to unknown because it was not user-confirmed; schema v8 accepts only a valid explicitly stored day.
- Recovery mode remains authoritative and blocks review decisions that would mutate financial state.
- Review diagnostics use technical codes only and never include merchant, value, account, or review-body content.

## Testing and verification

| Check | Result | Notes |
| --- | --- | --- |
| Dependency installation | Passed | `npm ci` |
| Full test suite | Passed | 242/242 tests, 0 failures |
| Review lifecycle tests | Passed | Create, progress, resolve, reopen, source completion |
| Snooze tests | Passed | Tomorrow/due return and conditional payday |
| Duplicate-review tests | Passed | Duplicate and Both are genuine persist without regeneration |
| Transaction categorization tests | Passed | Source resolution and grouped categorization |
| Import review tests | Passed | Pending imports excluded until deliberate apply/reject |
| Persistence/restart tests | Passed | Active, snoozed, and resolved state survives reload |
| Backup/restore tests | Passed | Encrypted round-trip preserves lifecycle state |
| Recovery tests | Passed | Financial mutations remain blocked |
| Financial Safety tests | Passed | Existing safety authority retained |
| Privacy checks | Passed | 60 checked files; no telemetry or sensitive diagnostic content added |
| Project validation | Passed | Schema 8, 14 seed collections, version 2.1.22 |
| Lint | Passed | `npm run lint` |
| Type checks | Unavailable | No separate type-check script is configured |
| Quality benchmark | Passed | 10k-record workload passed |
| Git whitespace validation | Passed | `git diff --check` |
| Production Electron build | Passed | `electron-builder --dir`; packaged ASAR contains the new lifecycle module |
| Electron manual UI verification | Unavailable | Runner has no graphical display; GTK could not create a display context |
| Windows packaging | Unavailable | win32 unpacked application was produced and NSIS began, but installer finalization requires Wine, which is absent |
| Manual Windows scenarios 1–10 | Unavailable | No Windows host/display is available in this environment |

## Data and migration impact

Schema v8 adds the local `reviewItems` collection and transaction-level import review status. Migration initializes review state without inventing historical work; reliable current conditions are synchronized idempotently after load. Existing financial collections are not rewritten merely to create the inbox. Review state is included in normal encrypted persistence, backup, and restore. No data leaves the device.

## Known limitations

- Final NSIS installer completion and the ten manual Electron/Windows scenarios still need verification on a Windows-capable runner.
- Full Next Move ranking and automatic priority consolidation remain deferred to v2.1.23.
- Full payday scheduling remains deferred to v2.2.0; this release only uses an explicitly known payday as a snooze target.
- Unresolved document retries intentionally require the original local file to be selected again; source file paths are not retained.
- Ambiguous credit-report conflicts support keeping current authoritative data or editing the authoritative financial record; unsafe automatic application is not offered without a reliable mapping.

## Excluded work

- Next Move
- Full prioritisation engine
- Dashboard redesign
- Payment chart expansion or other charts
- Night Mode
- Browser Demo
- Payday automation
- AI Companion

## Branch details

- Branch: `feature/action-review-lifecycle`
- Commit SHA: `048a8126d56e7b6ec6f488c216d6627df0fa80bd`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/26
- Target branch: `main`

## Confirmations

- Nothing was committed or pushed directly to `main`.
- This pull request is a draft and has not been merged.
- No personal financial information, imported documents, credentials, secrets, or sensitive logs were committed.
- No telemetry, analytics, cloud review store, or remote notification system was introduced.
- Only work relevant to v2.1.22 was changed.
