### PR TITLE
[v2.1.24][UI/UX] Dashboard, charts, night mode and personalisation

### DIFF
--- a/data-store.js
+++ b/data-store.js
@@ -3,6 +3,7 @@ import { constants as fsConstants } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { localFinancialMonthKey } from './date-utils.js';
+import { normaliseAppearanceSettings, normaliseDashboardSettings } from './presentation-settings.js';
 import { knownPaydayDay, synchroniseReviewItems } from './review-lifecycle.js';
 
 const STATE_FILE = 'finance-state.json';
@@ -12,7 +13,7 @@ const BACKUP_MAGIC = Buffer.from('LFB1');
 const LEGACY_BACKUP_MAGIC = Buffer.from('HFB1');
 const PORTABLE_BACKUP_FORMAT_VERSION = 2;
 const LOCAL_BACKUP_FORMAT_VERSION = 1;
-const CURRENT_SCHEMA_VERSION = 8;
+const CURRENT_SCHEMA_VERSION = 9;
 const FRESH_START_CONFIRMATION_MS = 5 * 60 * 1000;
 const MAX_BACKUP_BYTES = 512 * 1024 * 1024;
 const MAX_BACKUP_FILE_BYTES = 128 * 1024 * 1024;
@@ -1899,7 +1900,9 @@ const SETTING_NORMALISERS = Object.freeze({
   extraIncomeDebtPercent: (value) => finiteNumber(value, 80),
   llmModel: (value) => String(value || 'qwen2.5:1.5b').replace(/[\r\n]/g, '').slice(0, 120) || 'qwen2.5:1.5b',
   reminders: migrateReminders,
-  snoozedActions: migrateSnoozedActions
+  snoozedActions: migrateSnoozedActions,
+  appearance: normaliseAppearanceSettings,
+  dashboard: normaliseDashboardSettings
 });
 
 function migrateSettings(value) {
@@ -2064,7 +2067,8 @@ function validateMigratedState(state) {
   for (const collection of STATE_COLLECTIONS) {
     if (!Array.isArray(state[collection])) throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
   }
-  if (!isPlainObject(state.meta) || !isPlainObject(state.profile) || !isPlainObject(state.settings) || !isPlainObject(state.settings.reminders)) {
+  if (!isPlainObject(state.meta) || !isPlainObject(state.profile) || !isPlainObject(state.settings)
+    || !isPlainObject(state.settings.reminders) || !isPlainObject(state.settings.appearance) || !isPlainObject(state.settings.dashboard)) {
     throw new StateLoadError(LOAD_REASON_CODES.SCHEMA_VALIDATION_FAILURE);
   }
   if (!Number.isInteger(state.meta.revision) || state.meta.revision < 0 || !isPlainObject(state.settings.snoozedActions)) {

--- a/finance-core.js
+++ b/finance-core.js
@@ -2,7 +2,7 @@ import { localFinancialMonthKey } from './date-utils.js';
 import { synchroniseReviewItems } from './review-lifecycle.js';
 import { prioritySnapshot } from './next-move-priority.js';
 
-export const SCHEMA_VERSION = 8;
+export const SCHEMA_VERSION = 9;
 export const ALL_TIME_PERIOD = 'all';
 export const INCOME_PAYMENT_CATEGORY = 'Income';
 
@@ -937,7 +937,7 @@ function csvCell(value) {
   return `"${text.replace(/"/g, '""')}"`;
 }
 
-function isExternalCashflowTransaction(transaction) {
+export function isExternalCashflowTransaction(transaction) {
   const treatment = normaliseBudgetTreatment(transaction.budgetTreatment);
   return transaction.transferStatus !== 'confirmed'
     && !['transfer', 'savings_transfer', 'ignored'].includes(treatment);

--- a/financial-reporting.js
+++ b/financial-reporting.js
@@ -1,0 +1,197 @@
+import {
+  ALL_TIME_PERIOD, availableReportingMonths, calculateBudgetAnalysis, calculatePeriodSummary,
+  formatCurrency, isExternalCashflowTransaction, periodTransactions
+} from './finance-core.js';
+
+export function buildFinancialReport(state, period = state.settings?.selectedMonth, now = new Date()) {
+  const summary = calculatePeriodSummary(state, period);
+  const budget = calculateBudgetAnalysis(state, period);
+  const months = availableReportingMonths(state).sort();
+  const timeline = months.map((month) => {
+    const monthSummary = calculatePeriodSummary(state, month);
+    return {
+      month,
+      income: monthSummary.income,
+      spending: monthSummary.budgetActualSpending,
+      cashOut: monthSummary.spending,
+      net: monthSummary.netCashFlow,
+      incomplete: isIncompleteMonth(month, now)
+    };
+  });
+  const selectedTimeline = period === ALL_TIME_PERIOD ? timeline : timeline.filter((row) => row.month === period);
+  const categories = [
+    ...budget.rows.map((row) => ({ id: row.id, label: row.category, amount: row.actual })),
+    ...(budget.uncategorisedActual > 0 ? [{ id: 'uncategorised', label: 'Uncategorised', amount: budget.uncategorisedActual, needsReview: true }] : [])
+  ].filter((row) => row.amount !== 0).sort((left, right) => right.amount - left.amount || left.label.localeCompare(right.label));
+  const recurring = recurringSplit(state, period, budget);
+  const comparison = period === ALL_TIME_PERIOD ? allTimeComparison(timeline) : monthlyComparison(timeline, period, now);
+  return {
+    period,
+    isAllTime: period === ALL_TIME_PERIOD,
+    summary,
+    budget,
+    timeline: selectedTimeline,
+    fullTimeline: timeline,
+    spendingTimeline: spendingTimeline(state, period, budget, timeline),
+    incomeTimeline: incomeTimeline(state, period, timeline),
+    categories,
+    largestCategory: categories[0] || null,
+    recurring,
+    comparison,
+    progress: buildProgress(state),
+    wins: buildFinancialWins(state, comparison),
+    accountBalance: sum((state.accounts || []).filter((account) => account.active !== false), 'currentBalance'),
+    upcomingCommitments: (state.scheduledPayments || []).filter((item) => !['paid', 'cancelled'].includes(item.status)).reduce((total, item) => total + Number(item.amount || 0), 0)
+  };
+}
+
+function spendingTimeline(state, period, budget, monthlyTimeline) {
+  if (period === ALL_TIME_PERIOD) return monthlyTimeline.map((row) => ({ label: row.month, amount: row.spending, incomplete: row.incomplete }));
+  const transactions = new Map((state.transactions || []).map((transaction) => [String(transaction.id), transaction]));
+  const amounts = new Map();
+  for (const row of budget.rows) {
+    for (const contribution of row.contributions) {
+      const date = String(transactions.get(String(contribution.id))?.date || '').slice(0, 10);
+      if (date) amounts.set(date, roundMoney((amounts.get(date) || 0) + Number(contribution.amount || 0)));
+    }
+  }
+  for (const id of budget.uncategorisedTransactionIds) {
+    const transaction = transactions.get(String(id));
+    const date = String(transaction?.date || '').slice(0, 10);
+    if (date) amounts.set(date, roundMoney((amounts.get(date) || 0) + Number(transaction.outgoing || 0)));
+  }
+  return [...amounts.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([label, amount]) => ({ label, amount, incomplete: false }));
+}
+
+function incomeTimeline(state, period, monthlyTimeline) {
+  if (period === ALL_TIME_PERIOD) return monthlyTimeline.map((row) => ({ label: row.month, amount: row.income, incomplete: row.incomplete }));
+  const amounts = new Map();
+  for (const transaction of periodTransactions(state.transactions, period).filter(isExternalCashflowTransaction)) {
+    const date = String(transaction.date || '').slice(0, 10);
+    if (!date || Number(transaction.incoming || 0) <= 0) continue;
+    amounts.set(date, roundMoney((amounts.get(date) || 0) + Number(transaction.incoming || 0)));
+  }
+  return [...amounts.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([label, amount]) => ({ label, amount, incomplete: false }));
+}
+
+export function reportTextSummary(report) {
+  const largest = report.largestCategory
+    ? `${report.largestCategory.label} is the largest spending category at ${formatCurrency(report.largestCategory.amount)}.`
+    : 'No trusted category spending is available for this period.';
+  return `${formatCurrency(report.summary.income)} in and ${formatCurrency(report.summary.spending)} out. ${largest}`;
+}
+
+function recurringSplit(state, period, budget) {
+  const transactionsById = new Map((state.transactions || []).map((transaction) => [String(transaction.id), transaction]));
+  let committed = 0;
+  let flexible = 0;
+  for (const row of budget.rows) {
+    for (const contribution of row.contributions) {
+      const transaction = transactionsById.get(String(contribution.id));
+      if (transaction?.recurring === true) committed += Number(contribution.amount || 0);
+      else flexible += Number(contribution.amount || 0);
+    }
+  }
+  const uncategorisedIds = new Set(budget.uncategorisedTransactionIds.map(String));
+  for (const transaction of periodTransactions(state.transactions, period)) {
+    if (!uncategorisedIds.has(String(transaction.id))) continue;
+    if (transaction.recurring === true) committed += Number(transaction.outgoing || 0);
+    else flexible += Number(transaction.outgoing || 0);
+  }
+  return { committed: roundMoney(committed), flexible: roundMoney(flexible), evidence: committed > 0 ? 'confirmed' : 'insufficient' };
+}
+
+function monthlyComparison(timeline, period, now) {
+  const current = timeline.find((row) => row.month === period);
+  const previousMonth = offsetMonth(period, -1);
+  const previous = timeline.find((row) => row.month === previousMonth);
+  if (!current || !previous) return { available: false, incomplete: Boolean(current?.incomplete), text: 'A previous complete month is needed for comparison.' };
+  const difference = roundMoney(current.spending - previous.spending);
+  const incomplete = isIncompleteMonth(period, now);
+  return {
+    available: true,
+    incomplete,
+    current: current.spending,
+    previous: previous.spending,
+    difference,
+    direction: difference < 0 ? 'lower' : difference > 0 ? 'higher' : 'same',
+    text: incomplete
+      ? `Current month to date: ${formatCurrency(current.spending)}. Last complete month: ${formatCurrency(previous.spending)}. These are not like-for-like periods.`
+      : difference === 0
+        ? `Spending matched last month at ${formatCurrency(current.spending)}.`
+        : `Spending was ${formatCurrency(Math.abs(difference))} ${difference < 0 ? 'lower' : 'higher'} than last month.`
+  };
+}
+
+function allTimeComparison(timeline) {
+  const complete = timeline.filter((row) => !row.incomplete);
+  const average = complete.length ? roundMoney(complete.reduce((total, row) => total + row.spending, 0) / complete.length) : 0;
+  return {
+    available: complete.length > 0,
+    incomplete: timeline.some((row) => row.incomplete),
+    average,
+    completeMonths: complete.length,
+    text: complete.length ? `Average spending across ${complete.length} complete month${complete.length === 1 ? '' : 's'}: ${formatCurrency(average)}.` : 'A complete month is needed before an average can be shown.'
+  };
+}
+
+function buildProgress(state) {
+  const tracked = [...(state.debts || []).map((item) => ({ ...item, progressKind: 'debt' })), ...(state.overdrafts || []).map((item) => ({ ...item, progressKind: 'overdraft' }))];
+  const debts = tracked.map((item) => {
+    const current = Math.max(0, Number(item.currentBalance || 0));
+    const original = finitePositive(item.originalBalance) ? Number(item.originalBalance) : null;
+    const cleared = original === null ? null : Math.max(0, roundMoney(original - current));
+    const percent = original === null ? null : Math.max(0, Math.min(100, Math.round((cleared / original) * 100)));
+    const limit = finitePositive(item.limit ?? item.creditLimit) ? Number(item.limit ?? item.creditLimit) : null;
+    return { id: item.id, name: item.name || 'Unnamed account', kind: item.progressKind, current, original, cleared, percent, limit };
+  });
+  const savingsCurrent = Math.max(0, Number(state.settings?.emergencyBufferBalance || 0));
+  const savingsTarget = Math.max(0, Number(state.settings?.emergencyBufferTarget || 0));
+  return {
+    debts,
+    savings: {
+      current: savingsCurrent,
+      target: savingsTarget,
+      percent: savingsTarget > 0 ? Math.min(100, Math.round((savingsCurrent / savingsTarget) * 100)) : null
+    }
+  };
+}
+
+function buildFinancialWins(state, comparison) {
+  const wins = [];
+  const totalCleared = [...(state.debts || []), ...(state.overdrafts || [])].reduce((total, item) => {
+    const original = finitePositive(item.originalBalance) ? Number(item.originalBalance) : null;
+    return total + (original === null ? 0 : Math.max(0, original - Number(item.currentBalance || 0)));
+  }, 0);
+  if (totalCleared > 0) wins.push(`${formatCurrency(totalCleared)} cleared from balances with a known starting amount.`);
+  if ((state.overdrafts || []).length && state.overdrafts.every((item) => Number(item.currentBalance || 0) <= 0)) wins.push('Your tracked overdrafts are currently back in credit.');
+  const buffer = Number(state.settings?.emergencyBufferBalance || 0);
+  const milestone = [500, 250, 100].find((value) => buffer >= value);
+  if (milestone) wins.push(`Emergency buffer has passed ${formatCurrency(milestone, { whole: true })}.`);
+  if (comparison.available && !comparison.incomplete && comparison.direction === 'lower') wins.push(comparison.text);
+  return wins;
+}
+
+function isIncompleteMonth(month, now) {
+  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  return month === currentMonth;
+}
+
+function offsetMonth(month, offset) {
+  if (!/^\d{4}-\d{2}$/.test(String(month))) return '';
+  const [year, number] = month.split('-').map(Number);
+  const date = new Date(year, number - 1 + offset, 1);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function finitePositive(value) {
+  return Number.isFinite(Number(value)) && Number(value) > 0;
+}
+
+function sum(rows, field) {
+  return roundMoney(rows.reduce((total, row) => total + (Number.isFinite(Number(row[field])) ? Number(row[field]) : 0), 0));
+}
+
+function roundMoney(value) {
+  return Math.round((Number(value) + Number.EPSILON) * 100) / 100;
+}

--- a/index.html
+++ b/index.html
@@ -51,7 +51,8 @@
           <div class="brand-copy"><strong><span>OneStep</span> <span>Money</span></strong><span>One clear move at a time.</span></div>
         </div>
         <nav aria-label="Main navigation">
-          <button class="nav-button active" type="button" data-view="today"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 11.5 12 4l9 7.5"/><path d="M5.5 10.5V20h13v-9.5"/><path d="M9.5 20v-6h5v6"/></svg><span class="nav-label">Today</span></button>
+          <button class="nav-button active" type="button" data-view="dashboard"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="4" rx="1"/><rect x="14" y="11" width="7" height="10" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg><span class="nav-label">Dashboard</span></button>
+          <button class="nav-button" type="button" data-view="today"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 11.5 12 4l9 7.5"/><path d="M5.5 10.5V20h13v-9.5"/><path d="M9.5 20v-6h5v6"/></svg><span class="nav-label">Today</span></button>
           <button class="nav-button" type="button" data-view="review"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4h12v16H6z"/><path d="M9 8h6M9 12h6M9 16h4"/></svg><span class="nav-label">Review <span id="reviewNavCount" class="nav-count" aria-label="0 active review items" hidden>0</span></span></button>
           <button class="nav-button" type="button" data-view="transactions"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 4v16M3.5 7.5 7 4l3.5 3.5M17 20V4m-3.5 12.5L17 20l3.5-3.5"/></svg><span class="nav-label">Payments</span></button>
           <button class="nav-button" type="button" data-view="pay"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6.5 8.5a5.5 5.5 0 1 1 0 7"/><path d="M4 12h9M4 16h9"/></svg><span class="nav-label">Pay</span></button>
@@ -70,14 +71,69 @@
 
       <main class="main-content">
         <header class="topbar">
-          <div class="title-stack"><p class="eyebrow" id="viewEyebrow">ONE CLEAR MOVE</p><h1 id="viewTitle">Today</h1></div>
+          <div class="title-stack"><p class="eyebrow" id="viewEyebrow">YOUR MONEY AT A GLANCE</p><h1 id="viewTitle">Dashboard</h1></div>
           <div class="topbar-actions">
             <label class="compact-field">Period<select id="monthSelect" aria-label="Reporting period"></select></label>
             <div class="streak-chip" title="Weeks with a completed check-in"><span class="streak-icon" aria-hidden="true">◆</span><span><strong id="streakValue">0</strong> week streak</span></div>
           </div>
         </header>
 
-        <section id="view-today" class="view active" aria-labelledby="viewTitle">
+        <section id="view-dashboard" class="view active" aria-labelledby="viewTitle">
+          <div class="dashboard-toolbar">
+            <div class="segmented-control" role="group" aria-label="Dashboard detail">
+              <button id="dashboardSimpleButton" type="button" data-dashboard-mode="simple">Simple</button>
+              <button id="dashboardDetailedButton" type="button" data-dashboard-mode="detailed">Detailed</button>
+            </div>
+            <button id="customiseDashboardButton" class="secondary-button" type="button">Customise dashboard</button>
+          </div>
+          <p id="dashboardStatus" class="sr-only" role="status" aria-live="polite"></p>
+          <div id="dashboardModules" class="dashboard-grid">
+            <article class="dashboard-module dashboard-next-move" data-dashboard-module="next-move" aria-labelledby="dashboardNextMoveTitle">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">NEXT MOVE</p><h2 id="dashboardNextMoveTitle">Loading your next move…</h2></div><span id="dashboardNextMoveBand" class="next-move-band">Important</span></div>
+              <p id="dashboardNextMoveDetail" class="dashboard-lead"></p>
+              <div class="dashboard-module-footer"><span id="dashboardNextMoveTime" class="time-chip">10 min</span><button id="dashboardOpenNextMove" class="primary-button" type="button">Open Next Move</button></div>
+            </article>
+            <article class="dashboard-module" data-dashboard-module="balance">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">MONEY POSITION</p><h2>Balance overview</h2></div></div>
+              <div class="dashboard-stat-pair"><div><span>Account balances</span><strong id="dashboardBalanceValue">£0.00</strong></div><div><span>Money available</span><strong id="dashboardAvailableValue">£0.00</strong></div></div>
+              <p id="dashboardCashFlowText" class="muted">No trusted cash-flow data yet.</p>
+            </article>
+            <article class="dashboard-module" data-dashboard-module="upcoming">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">COMING UP</p><h2>Upcoming commitments</h2></div></div>
+              <strong id="dashboardUpcomingValue" class="dashboard-hero-value">£0.00</strong><p id="dashboardUpcomingText" class="muted">No upcoming commitments recorded.</p>
+            </article>
+            <article class="dashboard-module" data-dashboard-module="budget">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">PLAN VERSUS ACTUAL</p><h2>Budget health</h2></div></div>
+              <strong id="dashboardBudgetValue" class="dashboard-hero-value">£0.00</strong><p id="dashboardBudgetText" class="muted"></p><div class="progress-track" aria-hidden="true"><span id="dashboardBudgetProgress"></span></div>
+            </article>
+            <article class="dashboard-module" data-dashboard-module="alerts">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">IMPORTANT</p><h2>Warnings and checks</h2></div></div>
+              <div id="dashboardAlerts" class="dashboard-list"></div>
+            </article>
+            <article class="dashboard-module" data-dashboard-module="progress">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">REAL PROGRESS</p><h2>Debt and savings progress</h2></div></div>
+              <div id="dashboardProgress" class="progress-list"></div><div id="dashboardWins" class="financial-wins"></div>
+            </article>
+            <article class="dashboard-module" data-dashboard-module="spending">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">TRUSTED SPENDING</p><h2>Spending trend</h2></div><button class="text-button" type="button" data-view-target="transactions">Open Payments</button></div>
+              <div id="dashboardSpendingChart" class="chart chart-compact"></div><p id="dashboardSpendingSummary" class="chart-summary"></p>
+            </article>
+            <article class="dashboard-module" data-dashboard-module="income">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">MONEY RECEIVED</p><h2>Income trend</h2></div></div>
+              <div id="dashboardIncomeChart" class="chart chart-compact"></div><p id="dashboardIncomeSummary" class="chart-summary"></p>
+            </article>
+            <article class="dashboard-module" data-dashboard-module="review">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">UNRESOLVED WORK</p><h2>Review Inbox</h2></div></div>
+              <strong id="dashboardReviewValue" class="dashboard-hero-value">0</strong><p id="dashboardReviewText" class="muted">Nothing needs review.</p><button class="secondary-button" type="button" data-view-target="review">Open Review Inbox</button>
+            </article>
+            <article class="dashboard-module" data-dashboard-module="recent">
+              <div class="dashboard-module-heading"><div><p class="eyebrow">LATEST ACTIVITY</p><h2>Recent trusted payments</h2></div><button class="text-button" type="button" data-view-target="transactions">View all</button></div>
+              <div id="dashboardRecentPayments" class="dashboard-list"></div>
+            </article>
+          </div>
+        </section>
+
+        <section id="view-today" class="view" hidden aria-labelledby="viewTitle">
           <article id="welcomeBackPanel" class="welcome-back" hidden><div><p class="eyebrow">WELCOME BACK</p><h2>Welcome back</h2><p id="welcomeBackText">A few things are worth checking.</p></div><button id="welcomeBackReviewButton" class="secondary-button" type="button">Open Review Inbox</button></article>
           <p id="todayProgressStatus" class="sr-only" role="status" aria-live="polite"></p>
           <article class="focus-panel" aria-labelledby="nextActionTitle">
@@ -121,6 +177,15 @@
             <div><h2>Payment ledger</h2><p>Incoming, outgoing and running balance. Confirmed transfers are excluded from real spending.</p></div>
             <div class="button-row"><label class="compact-field">Import to<select id="statementAccountSelect"></select></label><button id="importStatementButton" class="primary-button" type="button">Import statement</button><button class="secondary-button" type="button" data-add="transaction">Add payment</button><button id="exportCsvButton" class="secondary-button" type="button">Export CSV</button></div>
           </div>
+          <section class="payment-insights" aria-labelledby="paymentInsightsTitle">
+            <div class="section-heading"><div><p class="eyebrow">VISUAL SUMMARY</p><h2 id="paymentInsightsTitle">Understand this period</h2><p id="paymentInsightsSummary">Trusted financial activity only.</p></div></div>
+            <div class="payment-chart-grid">
+              <article class="chart-card"><h3>Money in vs money out</h3><div id="moneyInOutChart" class="chart"></div><p id="moneyInOutSummary" class="chart-summary"></p></article>
+              <article class="chart-card chart-card-wide"><h3>Spending over time</h3><div id="spendingTrendChart" class="chart"></div><p id="spendingTrendSummary" class="chart-summary"></p></article>
+              <article class="chart-card chart-card-wide"><div class="chart-card-heading"><h3>Spending by category</h3><button id="chartReviewUncategorisedButton" class="text-button" type="button" hidden>Review uncategorised</button></div><div id="categoryChart" class="category-chart"></div><p id="categoryChartSummary" class="chart-summary"></p></article>
+              <article class="chart-card"><h3>Committed vs flexible</h3><div id="recurringChart" class="chart"></div><p id="recurringChartSummary" class="chart-summary"></p></article>
+            </div>
+          </section>
           <div class="filter-bar">
             <label>Search<input id="transactionSearch" type="search" placeholder="Merchant, category or note" /></label>
             <label>Account<select id="transactionAccountFilter"><option value="all">All accounts</option></select></label>
@@ -174,6 +239,7 @@
           <div class="settings-grid">
             <article class="panel"><div class="panel-heading"><div><h2>Accounts</h2><p class="muted">Add an account before importing its statements.</p></div><button class="secondary-button" type="button" data-add="account">Add account</button></div><div id="accountCards" class="compact-card-list"></div></article>
             <article class="panel"><h2>Planning</h2><label>Dependable monthly income<input id="dependableIncomeInput" type="number" min="0" step="0.01" /></label><label>Payday day · optional<input id="paydayDayInput" type="number" min="1" max="31" step="1" placeholder="Leave blank if not known" /></label><p class="muted">Used only for “Snooze until payday”. Full payday automation remains a later feature.</p><label>Extra debt-payment target<input id="extraPaymentInput" type="number" min="0" step="10" /></label><label>Emergency-buffer target<input id="bufferTargetInput" type="number" min="0" step="50" /></label><label>Current emergency buffer<input id="bufferBalanceInput" type="number" min="0" step="1" /></label><button id="saveSettingsButton" class="primary-button" type="button">Save settings</button></article>
+            <article class="panel"><h2>Appearance</h2><label>Theme<select id="themeSelect"><option value="system">Follow system</option><option value="light">Light</option><option value="dark">Dark</option></select></label><p class="muted">System follows Windows appearance and updates while OneStep is open.</p><button id="openDashboardSettingsButton" class="secondary-button" type="button">Customise dashboard</button></article>
             <article class="panel"><h2>Local model</h2><label>Ollama model<input id="llmModelInput" type="text" value="qwen2.5:1.5b" /></label><p class="muted">Recommended small model: qwen2.5:1.5b. The app connects only to Ollama on 127.0.0.1.</p><button id="checkModelButton" class="secondary-button" type="button">Check model</button></article>
             <article class="panel"><h2>Encrypted backup</h2><p class="muted">A portable backup includes one verified snapshot of your financial data and encrypted document vault. Use a password you will remember.</p><label>Backup password<input id="backupPassphrase" type="password" minlength="8" autocomplete="new-password" /></label><div class="button-row"><button id="createBackupButton" class="primary-button" type="button">Create backup</button><button id="restoreBackupButton" class="secondary-button" type="button">Restore backup</button></div><p id="backupStatus" class="muted" aria-live="polite"></p></article>
             <article class="panel"><h2>Updates</h2><p id="updateStatus" class="muted" aria-live="polite">Updates are checked automatically. Downloads and installation only start when you choose.</p><progress id="settingsUpdateProgress" class="update-progress" max="100" value="0" aria-label="Update download 0% complete" hidden></progress><div class="update-action-grid"><button id="checkUpdateButton" class="secondary-button" type="button">Check for updates</button><button class="secondary-button" type="button" data-view-update hidden>View on GitHub</button><button class="primary-button update-primary-action" type="button" data-download-update hidden>Download update</button><button class="primary-button update-primary-action" type="button" data-restart-update hidden>Restart and install</button></div></article>
@@ -186,6 +252,8 @@
     </div>
 
     <dialog id="editDialog" class="modal" aria-labelledby="editTitle"><form id="editForm" method="dialog"><div class="modal-heading"><div><p class="eyebrow" id="editEyebrow">EDIT</p><h2 id="editTitle">Edit item</h2></div><button class="icon-button" type="submit" value="cancel" aria-label="Close">×</button></div><div id="editFields" class="form-grid"></div><div class="modal-actions"><button type="submit" value="cancel" class="secondary-button">Cancel</button><button id="saveEditButton" type="button" class="primary-button">Save</button></div></form></dialog>
+
+    <dialog id="dashboardDialog" class="modal" aria-labelledby="dashboardDialogTitle"><form method="dialog"><div class="modal-heading"><div><p class="eyebrow">PERSONALISE</p><h2 id="dashboardDialogTitle">Customise dashboard</h2></div><button class="icon-button" type="submit" value="cancel" aria-label="Close">×</button></div><p class="muted">Choose what you see. The supported default remains ready whenever you reset.</p><div id="dashboardCustomisationList" class="dashboard-customisation-list"></div><div class="modal-actions split-actions"><button id="resetDashboardButton" type="button" class="danger-button">Reset dashboard</button><button type="submit" value="done" class="primary-button">Done</button></div></form></dialog>
 
     <dialog id="importDialog" class="modal wide" aria-labelledby="importTitle"><form method="dialog"><div class="modal-heading"><div><p class="eyebrow">IMPORT PREVIEW</p><h2 id="importTitle">Review before importing</h2></div><button class="icon-button" type="submit" value="cancel" aria-label="Close">×</button></div><div id="importSummary" class="import-summary"></div><div id="importChanges" class="import-changes" hidden></div><div id="importWarnings" class="warning-box" hidden></div><div class="table-wrap preview-table"><table><thead id="importPreviewHead"></thead><tbody id="importPreviewRows"></tbody></table></div><div class="modal-actions"><button type="submit" value="cancel" class="secondary-button">Keep document only</button><button id="confirmImportButton" type="button" class="primary-button">Import reviewed records</button></div></form></dialog>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onestep-money",
-  "version": "2.1.23",
+  "version": "2.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.23",
+      "version": "2.1.24",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.23",
+  "version": "2.1.24",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",

--- a/presentation-settings.js
+++ b/presentation-settings.js
@@ -1,0 +1,99 @@
+export const THEMES = Object.freeze(['system', 'light', 'dark']);
+export const DASHBOARD_MODES = Object.freeze(['simple', 'detailed']);
+
+export const DASHBOARD_MODULES = Object.freeze([
+  { id: 'next-move', label: 'Next Move', required: true, simple: true, defaultSize: 'wide' },
+  { id: 'balance', label: 'Balance overview', simple: true, defaultSize: 'standard' },
+  { id: 'upcoming', label: 'Upcoming commitments', simple: true, defaultSize: 'standard' },
+  { id: 'budget', label: 'Budget health', simple: true, defaultSize: 'standard' },
+  { id: 'alerts', label: 'Important warnings', simple: true, defaultSize: 'standard' },
+  { id: 'progress', label: 'Debt and savings progress', simple: true, defaultSize: 'wide' },
+  { id: 'spending', label: 'Spending trend', simple: false, defaultSize: 'wide' },
+  { id: 'income', label: 'Income trend', simple: false, defaultSize: 'standard' },
+  { id: 'review', label: 'Review Inbox summary', simple: false, defaultSize: 'standard' },
+  { id: 'recent', label: 'Recent payments', simple: false, defaultSize: 'wide' }
+]);
+
+const MODULE_IDS = new Set(DASHBOARD_MODULES.map((module) => module.id));
+const REQUIRED_IDS = new Set(DASHBOARD_MODULES.filter((module) => module.required).map((module) => module.id));
+const DEFAULT_ORDER = DASHBOARD_MODULES.map((module) => module.id);
+
+export function defaultAppearanceSettings() {
+  return { theme: 'system' };
+}
+
+export function defaultDashboardSettings() {
+  return {
+    mode: 'simple',
+    order: [...DEFAULT_ORDER],
+    hidden: [],
+    pinned: ['next-move'],
+    sizes: Object.fromEntries(DASHBOARD_MODULES.map((module) => [module.id, module.defaultSize]))
+  };
+}
+
+export function normaliseAppearanceSettings(value) {
+  const appearance = isPlainObject(value) ? value : {};
+  return { theme: THEMES.includes(appearance.theme) ? appearance.theme : 'system' };
+}
+
+export function normaliseDashboardSettings(value) {
+  if (!isPlainObject(value)) return defaultDashboardSettings();
+  const suppliedOrder = uniqueKnownIds(value.order);
+  const order = [...suppliedOrder, ...DEFAULT_ORDER.filter((id) => !suppliedOrder.includes(id))];
+  if (!isValidOrder(value.order, suppliedOrder)) return defaultDashboardSettings();
+
+  const hidden = uniqueKnownIds(value.hidden).filter((id) => !REQUIRED_IDS.has(id));
+  const pinned = uniqueKnownIds(value.pinned);
+  const rawSizes = isPlainObject(value.sizes) ? value.sizes : {};
+  const sizes = Object.fromEntries(DASHBOARD_MODULES.map((module) => [
+    module.id,
+    ['standard', 'wide'].includes(rawSizes[module.id]) ? rawSizes[module.id] : module.defaultSize
+  ]));
+  return {
+    mode: DASHBOARD_MODES.includes(value.mode) ? value.mode : 'simple',
+    order,
+    hidden,
+    pinned: pinned.includes('next-move') ? pinned : ['next-move', ...pinned],
+    sizes
+  };
+}
+
+export function visibleDashboardModules(settings) {
+  const dashboard = normaliseDashboardSettings(settings);
+  const modules = new Map(DASHBOARD_MODULES.map((module) => [module.id, module]));
+  const visible = dashboard.order.filter((id) => {
+    const module = modules.get(id);
+    return module && !dashboard.hidden.includes(id) && (dashboard.mode === 'detailed' || module.simple);
+  });
+  return [...dashboard.pinned.filter((id) => visible.includes(id)), ...visible.filter((id) => !dashboard.pinned.includes(id))];
+}
+
+export function moveDashboardModule(settings, moduleId, direction) {
+  const dashboard = normaliseDashboardSettings(settings);
+  const index = dashboard.order.indexOf(moduleId);
+  const target = direction === 'up' ? index - 1 : index + 1;
+  if (index < 0 || target < 0 || target >= dashboard.order.length) return dashboard;
+  const order = [...dashboard.order];
+  [order[index], order[target]] = [order[target], order[index]];
+  return { ...dashboard, order };
+}
+
+export function compareLabels(left, right) {
+  return String(left || '').localeCompare(String(right || ''), 'en-GB', { sensitivity: 'base', numeric: true });
+}
+
+function uniqueKnownIds(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter((id) => typeof id === 'string' && MODULE_IDS.has(id)))];
+}
+
+function isValidOrder(raw, cleaned) {
+  if (raw === undefined) return true;
+  if (!Array.isArray(raw) || raw.length > DASHBOARD_MODULES.length) return false;
+  return raw.length === cleaned.length;
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/renderer-app.js
+++ b/renderer-app.js
@@ -1,8 +1,8 @@
 import {
-  ALL_TIME_PERIOD, availableReportingMonths, buildFallbackAnswer, buildFinancialChecks, calculateBudgetAnalysis,
+  ALL_TIME_PERIOD, availableReportingMonths, buildFallbackAnswer, buildFinancialChecks,
   calculatePeriodSummary, calculateStreak, createId, debtPlan, debtSafetyAssessment, exportTransactionsCsv,
   findSavingsOpportunities, formatCurrency, formatDate, hasCompletedCheckIn, INCOME_PAYMENT_CATEGORY, isIncomePayment,
-  removeBudgetCategory, reportingPeriodMonthCount, resolvePossibleDuplicate
+  periodTransactions, removeBudgetCategory, reportingPeriodMonthCount, resolvePossibleDuplicate
 } from './finance-core.js';
 import { applyCreditReportImportPlan, buildCreditReportImportPlan } from './credit-report-intelligence.js';
 import { applyStatementImportPlan, buildStatementImportPlan } from './statement-intelligence.js';
@@ -22,6 +22,11 @@ import {
 import {
   PRIORITY_DIAGNOSTIC_CODES, prioritisedReviewGroups, prioritySnapshot, selectFiveMinuteCheckIn
 } from './next-move-priority.js';
+import { buildFinancialReport, reportTextSummary } from './financial-reporting.js';
+import {
+  compareLabels, DASHBOARD_MODULES, defaultDashboardSettings, moveDashboardModule,
+  normaliseDashboardSettings, THEMES, visibleDashboardModules
+} from './presentation-settings.js';
 
 let state;
 let encryption;
@@ -45,8 +50,10 @@ let transactionPage = 1;
 let financialViewCache = null;
 let reviewGroupsById = new Map();
 let welcomeBack = false;
+const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
 
 const viewMeta = {
+  dashboard: ['YOUR MONEY AT A GLANCE', 'Dashboard'],
   today: ['ONE CLEAR MOVE', 'Today'], review: ['UNFINISHED FINANCIAL WORK', 'Review Inbox'], transactions: ['MONEY IN AND OUT', 'Payments'], pay: ['WHERE GROSS PAY GOES', 'Pay'],
   debts: ['LOANS, CARDS AND FINANCE', 'Debts'], overdrafts: ['BANK BORROWING', 'Overdrafts'], budget: ['DEPENDABLE INCOME FIRST', 'Budget'],
   guide: ['PRIVATE AND LOCAL', 'Guide'], documents: ['ENCRYPTED ON THIS DEVICE', 'Documents'], settings: ['CONTROL AND PRIVACY', 'Settings']
@@ -87,6 +94,7 @@ function renderAppVersion(value) {
 function activateNormalMode(loaded) {
   state = loaded.state;
   synchroniseReviewItems(state);
+  applyTheme();
   welcomeBack = Boolean(state.meta?.updatedAt && Date.now() - Date.parse(state.meta.updatedAt) >= 3 * 86_400_000);
   encryption = loaded.encryption;
   recoveryResult = null;
@@ -296,6 +304,21 @@ function formatRecoveryDate(value) {
 function bindEvents() {
   bindRestoreEvents();
   document.querySelectorAll('.nav-button').forEach((button) => button.addEventListener('click', () => selectView(button.dataset.view)));
+  document.querySelectorAll('[data-view-target]').forEach((button) => button.addEventListener('click', () => selectView(button.dataset.viewTarget)));
+  byId('dashboardOpenNextMove').addEventListener('click', () => selectView('today'));
+  document.querySelectorAll('[data-dashboard-mode]').forEach((button) => button.addEventListener('click', async () => {
+    state.settings.dashboard.mode = button.dataset.dashboardMode;
+    await saveAndRender();
+    byId('dashboardStatus').textContent = `${titleCase(button.dataset.dashboardMode)} dashboard enabled.`;
+  }));
+  [byId('customiseDashboardButton'), byId('openDashboardSettingsButton')].forEach((button) => button.addEventListener('click', openDashboardCustomisation));
+  byId('dashboardCustomisationList').addEventListener('click', handleDashboardCustomisation);
+  byId('dashboardCustomisationList').addEventListener('change', handleDashboardCustomisation);
+  byId('resetDashboardButton').addEventListener('click', resetDashboard);
+  byId('themeSelect').addEventListener('change', saveThemePreference);
+  systemTheme.addEventListener('change', () => {
+    if (state?.settings?.appearance?.theme === 'system') applyTheme();
+  });
   byId('monthSelect').addEventListener('change', async () => {
     state.settings.selectedMonth = byId('monthSelect').value;
     transactionPage = 1;
@@ -334,6 +357,11 @@ function bindEvents() {
     byId('transactionCategoryFilter').value = 'uncategorised';
     selectView('transactions');
     renderTransactions();
+  });
+  byId('chartReviewUncategorisedButton').addEventListener('click', () => {
+    byId('transactionCategoryFilter').value = 'uncategorised';
+    renderTransactions();
+    focusTransactionTable();
   });
   byId('welcomeBackReviewButton').addEventListener('click', () => selectView('review'));
   byId('reviewActiveList').addEventListener('click', handleReviewAction);
@@ -426,6 +454,7 @@ function render() {
   byId('completeActionButton').textContent = pendingAction.actionLabel || 'Do it';
   byId('completeActionButton').hidden = Boolean(pendingAction.passive);
   byId('snoozeActionButton').hidden = Boolean(pendingAction.passive);
+  renderDashboard();
   renderDailyCompletion();
   renderTodaySupporting();
   byId('marginValue').textContent = formatCurrency(summary.plannedMargin);
@@ -447,6 +476,7 @@ function render() {
   renderMomentum();
   renderReviewInbox();
   renderTransactions();
+  renderPaymentInsights();
   renderPay();
   renderDebts();
   renderCreditReports();
@@ -456,6 +486,216 @@ function render() {
   renderAccounts();
   renderSettings();
   renderPrivacy();
+}
+
+function renderDashboard() {
+  const dashboard = normaliseDashboardSettings(state.settings.dashboard);
+  state.settings.dashboard = dashboard;
+  const report = getFinancialViewCache().report;
+  const visible = new Set(visibleDashboardModules(dashboard));
+  const container = byId('dashboardModules');
+  const visualOrder = [...visibleDashboardModules(dashboard), ...dashboard.order.filter((moduleId) => !visible.has(moduleId))];
+  for (const moduleId of visualOrder) {
+    const module = container.querySelector(`[data-dashboard-module="${moduleId}"]`);
+    if (!module) continue;
+    module.hidden = !visible.has(moduleId);
+    module.classList.toggle('module-wide', dashboard.sizes[moduleId] === 'wide');
+    container.append(module);
+  }
+  document.querySelectorAll('[data-dashboard-mode]').forEach((button) => {
+    const selected = button.dataset.dashboardMode === dashboard.mode;
+    button.classList.toggle('active', selected);
+    button.setAttribute('aria-pressed', String(selected));
+  });
+
+  byId('dashboardNextMoveTitle').textContent = pendingAction.title;
+  byId('dashboardNextMoveDetail').textContent = pendingAction.detail || '';
+  byId('dashboardNextMoveTime').textContent = pendingAction.timeframe || '10 min';
+  byId('dashboardNextMoveBand').textContent = pendingAction.unavailable ? 'Unavailable' : pendingAction.priorityBand ? priorityBandLabel(pendingAction.priorityBand) : 'Caught up';
+  byId('dashboardNextMoveBand').className = `next-move-band band-${pendingAction.unavailable ? 'unavailable' : pendingAction.priorityBand || 'done'}`;
+  byId('dashboardOpenNextMove').textContent = pendingAction.passive ? 'Open Today' : 'Open Next Move';
+
+  byId('dashboardBalanceValue').textContent = formatCurrency(report.accountBalance);
+  const available = prioritySafety?.currentCashCapacity ?? prioritySafety?.plannedCapacity ?? 0;
+  byId('dashboardAvailableValue').textContent = formatCurrency(available);
+  byId('dashboardCashFlowText').textContent = `${formatCurrency(report.summary.income)} in · ${formatCurrency(report.summary.spending)} out · ${formatCurrency(report.summary.netCashFlow)} net.`;
+  byId('dashboardUpcomingValue').textContent = formatCurrency(report.upcomingCommitments);
+  const payday = nextPaydayLabel(state.profile?.paydayDay);
+  byId('dashboardUpcomingText').textContent = [
+    report.upcomingCommitments > 0 ? 'Recorded commitments that are not marked paid or cancelled.' : 'No upcoming commitments recorded.',
+    payday ? `Next recorded payday: ${payday}.` : 'Add an optional payday in Settings to show the next expected income date.'
+  ].join(' ');
+  byId('dashboardBudgetValue').textContent = report.budget.remaining < 0 ? `${formatCurrency(Math.abs(report.budget.remaining))} over` : `${formatCurrency(report.budget.remaining)} left`;
+  byId('dashboardBudgetText').textContent = `${formatCurrency(report.budget.actual)} spent of ${formatCurrency(report.budget.planned)} planned. ${report.budget.coveragePercent}% categorised.`;
+  const budgetPercent = report.budget.planned > 0 ? Math.max(0, Math.min(100, Math.round((report.budget.actual / report.budget.planned) * 100))) : 0;
+  byId('dashboardBudgetProgress').style.width = `${budgetPercent}%`;
+
+  const alerts = byId('dashboardAlerts'); clear(alerts);
+  const checks = buildFinancialChecks(state).slice(0, 3);
+  for (const check of checks) {
+    const row = element('div', `dashboard-list-row tone-${check.tone}`);
+    append(row, element('strong', '', check.title), element('span', '', check.text)); alerts.append(row);
+  }
+  if (!checks.length) alerts.append(element('p', 'muted', 'No important warnings for this period.'));
+
+  renderDashboardProgress(report);
+  renderLineChart(byId('dashboardSpendingChart'), report.spendingTimeline, 'spending', 'Trusted spending over time');
+  byId('dashboardSpendingSummary').textContent = report.comparison.text;
+  renderLineChart(byId('dashboardIncomeChart'), report.incomeTimeline, 'income', 'Trusted income over time');
+  byId('dashboardIncomeSummary').textContent = report.incomeTimeline.length ? `${formatCurrency(report.summary.income)} received in the selected period.` : 'No trusted income is available for this period.';
+
+  const review = reviewInboxSummary(state);
+  byId('dashboardReviewValue').textContent = String(review.total);
+  byId('dashboardReviewText').textContent = review.total ? `${review.total} unresolved ${review.total === 1 ? 'item needs' : 'items need'} your judgement.` : 'Nothing needs review.';
+  const recent = byId('dashboardRecentPayments'); clear(recent);
+  const recentRows = periodTransactions(state.transactions, state.settings.selectedMonth).slice(-5).reverse();
+  for (const transaction of recentRows) {
+    const row = element('div', 'dashboard-list-row horizontal');
+    const direction = Number(transaction.outgoing || 0) > 0 ? -Number(transaction.outgoing) : Number(transaction.incoming || 0);
+    append(row, element('span', '', transaction.userDescription || transaction.description || 'Payment'), element('strong', direction < 0 ? 'outgoing' : 'incoming', `${direction < 0 ? '−' : '+'}${formatCurrency(Math.abs(direction))}`));
+    recent.append(row);
+  }
+  if (!recentRows.length) recent.append(element('p', 'muted', 'No trusted payments in this period.'));
+}
+
+function renderDashboardProgress(report) {
+  const container = byId('dashboardProgress'); clear(container);
+  const items = report.progress.debts.filter((item) => item.current > 0).slice(0, 4);
+  for (const item of items) {
+    const row = element('div', 'progress-item');
+    const heading = element('div', 'progress-item-heading');
+    const overdraftMilestone = item.kind === 'overdraft' && item.limit ? overdraftProgressLabel(item.current, item.limit) : '';
+    const detail = overdraftMilestone || (item.cleared === null ? `${formatCurrency(item.current)} remaining · starting balance not recorded` : `${formatCurrency(item.current)} remaining · ${formatCurrency(item.cleared)} cleared`);
+    append(heading, element('strong', '', item.name), element('span', '', detail)); row.append(heading);
+    if (item.percent !== null) {
+      const track = element('div', 'progress-track'); const bar = document.createElement('span'); bar.style.width = `${item.percent}%`; track.append(bar); row.append(track);
+    }
+    container.append(row);
+  }
+  const savings = report.progress.savings;
+  if (savings.target > 0) {
+    const row = element('div', 'progress-item');
+    const heading = element('div', 'progress-item-heading');
+    append(heading, element('strong', '', 'Emergency buffer'), element('span', '', `${formatCurrency(savings.current)} / ${formatCurrency(savings.target)}`));
+    const track = element('div', 'progress-track'); const bar = document.createElement('span'); bar.style.width = `${savings.percent}%`; track.append(bar);
+    append(row, heading, track); container.append(row);
+  }
+  if (!items.length && savings.target <= 0) container.append(element('p', 'muted', 'Add a known starting balance or savings target to show progress.'));
+  const wins = byId('dashboardWins'); clear(wins);
+  for (const message of report.wins.slice(0, 3)) wins.append(element('div', 'financial-win', `✓ ${message}`));
+}
+
+function renderPaymentInsights() {
+  const report = getFinancialViewCache().report;
+  byId('paymentInsightsSummary').textContent = reportTextSummary(report);
+  renderBarChart(byId('moneyInOutChart'), [
+    { label: 'Money in', amount: report.summary.income, tone: 'income' },
+    { label: 'Money out', amount: report.summary.spending, tone: 'spending' }
+  ], 'Money in compared with money out');
+  byId('moneyInOutSummary').textContent = `${formatCurrency(report.summary.income)} in; ${formatCurrency(report.summary.spending)} out; ${formatCurrency(report.summary.netCashFlow)} net cash flow.`;
+  renderLineChart(byId('spendingTrendChart'), report.spendingTimeline, 'spending', 'Trusted spending over time');
+  byId('spendingTrendSummary').textContent = report.comparison.text;
+  renderCategoryChart(report.categories);
+  renderBarChart(byId('recurringChart'), [
+    { label: 'Confirmed recurring', amount: report.recurring.committed, tone: 'committed' },
+    { label: 'Flexible / not confirmed', amount: report.recurring.flexible, tone: 'flexible' }
+  ], 'Confirmed recurring compared with flexible spending');
+  byId('recurringChartSummary').textContent = report.recurring.evidence === 'confirmed'
+    ? `${formatCurrency(report.recurring.committed)} is confirmed recurring; ${formatCurrency(report.recurring.flexible)} is flexible or not confirmed recurring.`
+    : 'No spending is confirmed as recurring in this period; uncertain items remain flexible rather than being labelled commitments.';
+}
+
+function renderBarChart(container, rows, ariaLabel) {
+  clear(container);
+  container.setAttribute('role', 'img');
+  container.setAttribute('aria-label', ariaLabel);
+  const max = Math.max(1, ...rows.map((row) => Math.max(0, Number(row.amount || 0))));
+  for (const item of rows) {
+    const row = element('div', 'chart-bar-row');
+    const label = element('div', 'chart-bar-label');
+    append(label, element('span', '', item.label), element('strong', '', formatCurrency(item.amount)));
+    const track = element('div', 'chart-bar-track');
+    const bar = element('span', `chart-bar-fill tone-${item.tone || 'default'}`); bar.style.width = `${Math.max(0, Number(item.amount || 0)) / max * 100}%`; track.append(bar);
+    append(row, label, track); container.append(row);
+  }
+}
+
+function renderLineChart(container, points, tone, ariaLabel) {
+  clear(container);
+  if (!points.length) { container.append(element('p', 'chart-empty', 'No trusted data for this period.')); return; }
+  const namespace = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(namespace, 'svg');
+  svg.setAttribute('viewBox', '0 0 600 190'); svg.setAttribute('role', 'img'); svg.setAttribute('aria-label', ariaLabel);
+  const max = Math.max(1, ...points.map((point) => Math.max(0, Number(point.amount || 0))));
+  for (const y of [30, 90, 150]) {
+    const line = document.createElementNS(namespace, 'line'); line.setAttribute('x1', '26'); line.setAttribute('x2', '580'); line.setAttribute('y1', String(y)); line.setAttribute('y2', String(y)); line.setAttribute('class', 'chart-grid-line'); svg.append(line);
+  }
+  const coordinates = points.map((point, index) => {
+    const x = points.length === 1 ? 300 : 28 + (index / (points.length - 1)) * 548;
+    const y = 158 - (Math.max(0, Number(point.amount || 0)) / max) * 126;
+    return { ...point, x, y };
+  });
+  const line = document.createElementNS(namespace, 'polyline'); line.setAttribute('points', coordinates.map((point) => `${point.x},${point.y}`).join(' ')); line.setAttribute('class', `chart-line tone-${tone}`); svg.append(line);
+  for (const point of coordinates) {
+    const circle = document.createElementNS(namespace, 'circle'); circle.setAttribute('cx', String(point.x)); circle.setAttribute('cy', String(point.y)); circle.setAttribute('r', '5'); circle.setAttribute('class', `chart-point tone-${tone}`); circle.setAttribute('tabindex', '0');
+    const title = document.createElementNS(namespace, 'title'); title.textContent = `${shortPeriodLabel(point.label)}: ${formatCurrency(point.amount)}${point.incomplete ? ' · incomplete period' : ''}`; circle.append(title); svg.append(circle);
+  }
+  container.append(svg, chartDataTable(points));
+}
+
+function renderCategoryChart(categories) {
+  const container = byId('categoryChart'); clear(container);
+  const button = byId('chartReviewUncategorisedButton');
+  button.hidden = !categories.some((category) => category.needsReview);
+  if (!categories.length) {
+    container.append(element('p', 'chart-empty', 'No trusted spending categories for this period.'));
+    byId('categoryChartSummary').textContent = 'Income and transfers are not shown as expenditure.';
+    return;
+  }
+  const max = Math.max(1, ...categories.map((category) => Math.max(0, category.amount)));
+  for (const category of categories.slice(0, 10)) {
+    const row = element('div', `category-chart-row${category.needsReview ? ' needs-review' : ''}`);
+    const heading = element('div', 'category-chart-heading'); append(heading, element('span', '', category.label), element('strong', '', formatCurrency(category.amount)));
+    const track = element('div', 'chart-bar-track'); const bar = element('span', category.needsReview ? 'chart-bar-fill tone-warning' : 'chart-bar-fill tone-category'); bar.style.width = `${Math.max(0, category.amount) / max * 100}%`; track.append(bar);
+    append(row, heading, track); container.append(row);
+  }
+  const largest = categories[0];
+  byId('categoryChartSummary').textContent = `${largest.label} is largest at ${formatCurrency(largest.amount)}. Income, confirmed transfers and savings transfers are excluded.`;
+}
+
+function chartDataTable(points) {
+  const details = element('details', 'chart-data'); details.append(element('summary', '', 'View chart data'));
+  const table = document.createElement('table'); const head = document.createElement('thead'); const header = document.createElement('tr'); append(header, element('th', '', 'Period'), element('th', '', 'Amount')); head.append(header);
+  const body = document.createElement('tbody');
+  for (const point of points) { const row = document.createElement('tr'); append(row, cell(`${shortPeriodLabel(point.label)}${point.incomplete ? ' · incomplete' : ''}`), amountCell(point.amount)); body.append(row); }
+  append(table, head, body); details.append(table); return details;
+}
+
+function shortPeriodLabel(value) {
+  if (/^\d{4}-\d{2}$/.test(String(value))) return monthLabel(value);
+  return formatDate(value);
+}
+
+function nextPaydayLabel(value, now = new Date()) {
+  const day = knownPaydayDay(value);
+  if (!day) return '';
+  let year = now.getFullYear(); let month = now.getMonth();
+  let lastDay = new Date(year, month + 1, 0).getDate();
+  let candidate = new Date(year, month, Math.min(day, lastDay), 12);
+  if (candidate < new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0)) {
+    month += 1;
+    if (month > 11) { month = 0; year += 1; }
+    lastDay = new Date(year, month + 1, 0).getDate();
+    candidate = new Date(year, month, Math.min(day, lastDay), 12);
+  }
+  return new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }).format(candidate);
+}
+
+function overdraftProgressLabel(current, limit) {
+  if (current <= 0) return 'Back in credit';
+  const usage = Math.round((current / limit) * 100);
+  const milestone = usage <= 25 ? 'below 25%' : usage <= 50 ? 'below 50%' : usage <= 75 ? 'below 75%' : usage <= 100 ? 'within the arranged limit' : 'over the arranged limit';
+  return `${formatCurrency(current)} of ${formatCurrency(limit)} used · ${milestone}`;
 }
 
 function renderChecks() {
@@ -876,7 +1116,7 @@ function renderDebts() {
     planCard.append(why);
   }
   container.append(planCard);
-  for (const item of state.debts) container.append(entityCard('debt', item, [stat('Balance', formatCurrency(item.currentBalance)), stat('APR', item.apr == null ? 'Unknown' : `${(item.apr * 100).toFixed(2)}%`), stat('Required / arrangement', paymentStatusLabel(item), true)]));
+  for (const item of [...state.debts].sort((left, right) => compareLabels(left.name, right.name))) container.append(entityCard('debt', item, [stat('Balance', formatCurrency(item.currentBalance)), stat('APR', item.apr == null ? 'Unknown' : `${(item.apr * 100).toFixed(2)}%`), stat('Required / arrangement', paymentStatusLabel(item), true)]));
 }
 
 function renderCreditReports() {
@@ -905,7 +1145,7 @@ function renderOverdrafts() {
     container.append(empty);
     return;
   }
-  for (const item of state.overdrafts) container.append(entityCard('overdraft', item, [stat('Used', formatCurrency(item.currentBalance)), stat('Limit / APR', limitAprLabel(item)), stat('Required / arrangement', paymentStatusLabel(item), true)]));
+  for (const item of [...state.overdrafts].sort((left, right) => compareLabels(left.name, right.name))) container.append(entityCard('overdraft', item, [stat('Used', formatCurrency(item.currentBalance)), stat('Limit / APR', limitAprLabel(item)), stat('Required / arrangement', paymentStatusLabel(item), true)]));
 }
 
 function renderBudget() {
@@ -997,7 +1237,7 @@ function renderAccounts() {
     container.append(element('p', 'muted', 'No accounts yet. Add one account to begin importing statements.'));
     return;
   }
-  for (const account of state.accounts) {
+  for (const account of [...state.accounts].sort((left, right) => compareLabels(left.name, right.name))) {
     container.append(entityCard('account', account, [
       stat('Type', titleCase(account.type || 'current')),
       stat('Balance', account.currentBalance == null ? 'Unknown' : formatCurrency(account.currentBalance)),
@@ -1013,6 +1253,7 @@ function renderSettings() {
   byId('bufferTargetInput').value = state.settings.emergencyBufferTarget;
   byId('bufferBalanceInput').value = state.settings.emergencyBufferBalance;
   byId('llmModelInput').value = state.settings.llmModel;
+  byId('themeSelect').value = state.settings.appearance.theme;
 }
 
 function renderPrivacy() {
@@ -1376,16 +1617,13 @@ function editorDefinitions(type) {
     ['notes', 'Notes', 'textarea', '', 'wide-field']
   ];
   if (type === 'transaction') return [
-    ['accountId', 'Account', 'select', state.accounts.map((account) => [account.id, account.name])], ['date', 'Date', 'date'],
+    ['accountId', 'Account', 'select', alphabeticalOptions(state.accounts.map((account) => [account.id, account.name]))], ['date', 'Date', 'date'],
     ['description', 'Statement / payment description', 'text', 'Required', 'wide-field'], ['userDescription', 'Your description', 'text', 'Optional clearer name', 'wide-field'],
     ['incoming', 'Incoming', 'number'], ['outgoing', 'Outgoing', 'number'], ['runningBalance', 'Running balance', 'number'],
-    ['budgetCategoryId', 'Payment category', 'select', [
-      ['','Uncategorised'], [INCOME_PAYMENT_CATEGORY_VALUE, INCOME_PAYMENT_CATEGORY],
-      ...state.budgets.filter((budget) => !isIncomePayment({ category: budget.category })).map((budget) => [budget.id, budget.category])
-    ]],
+    ['budgetCategoryId', 'Payment category', 'select', paymentCategoryOptions()],
     ['category', 'Statement category label', 'text'],
     ['budgetTreatment', 'Budget treatment', 'select', [['auto','Automatic'],['spending','Spending'],['refund','Refund'],['reversal','Reversal'],['transfer','Internal transfer'],['savings_transfer','Savings transfer'],['debt_payment','Debt payment'],['ignored','Do not include']]],
-    ['transferStatus', 'Internal transfer match', 'select', [['no','No'],['possible','Possible'],['confirmed','Confirmed']]], ['recurring', 'Recurring payment', 'checkbox'], ['notes', 'Notes', 'textarea', '', 'wide-field']
+    ['transferStatus', 'Internal transfer match', 'select', [['no','No'],['possible','Possible'],['confirmed','Confirmed']], '', 'semantic'], ['recurring', 'Recurring payment', 'checkbox'], ['notes', 'Notes', 'textarea', '', 'wide-field']
   ];
   if (type === 'payslip') return [
     ['period', 'Pay month', 'month'], ['payDate', 'Pay date', 'date'],
@@ -1401,10 +1639,10 @@ function editorDefinitions(type) {
     ['niEmployeeYtd', 'Employee NI YTD', 'number'], ['niEmployerYtd', 'Employer NI YTD', 'number'],
     ['notes', 'Notes', 'textarea', '', 'wide-field']
   ];
-  if (type === 'budget') return [['section','Section','select',[['Essentials','Essentials'],['Debt minimums','Debt minimums'],['Flexible','Flexible'],['Goals','Goals']]], ['category','Category','text'], ['planned','Planned monthly amount','number'], ['notes','Notes','textarea','','wide-field']];
-  const base = [['name','Name','text'], ['type','Type','text'], ['accountReference','Account reference / last four digits','text'], ['openedDate','Opened date','date'], ['defaultDate','Default date','date'], ['lastReportedAt','Last reported date','date'], ['currentBalance','Current balance','number'], ['aprPercent','APR (%) - leave blank if unknown','number'], ['contractualPayment','Contractual / minimum payment','number'], ['arrearsAmount','Known arrears amount','number'], ['status','Status','select',[['unknown','Unknown'],['current','Current'],['arrears','Arrears'],['defaulted','Defaulted'],['over_limit','Over limit']]], ['arrangementStatus','Payment arrangement','select',[['unknown','Unknown'],['none','Confirmed none'],['confirmed','Confirmed arrangement']]], ['arrangementPayment','Agreed arrangement payment','number'], ['includeInPlan','Include in payoff plan','checkbox'], ['statusConflict','Status information conflicts / needs checking','checkbox'], ['interestFrozen','Interest or charges frozen','checkbox'], ['description','Description','textarea','','wide-field'], ['notes','Notes','textarea','','wide-field']];
+  if (type === 'budget') return [['section','Section','select',[['Essentials','Essentials'],['Debt minimums','Debt minimums'],['Flexible','Flexible'],['Goals','Goals']], '', 'semantic'], ['category','Category','text'], ['planned','Planned monthly amount','number'], ['notes','Notes','textarea','','wide-field']];
+  const base = [['name','Name','text'], ['type','Type','text'], ['accountReference','Account reference / last four digits','text'], ['openedDate','Opened date','date'], ['defaultDate','Default date','date'], ['lastReportedAt','Last reported date','date'], ['currentBalance','Current balance','number'], ['aprPercent','APR (%) - leave blank if unknown','number'], ['contractualPayment','Contractual / minimum payment','number'], ['arrearsAmount','Known arrears amount','number'], ['status','Status','select',[['unknown','Unknown'],['current','Current'],['arrears','Arrears'],['defaulted','Defaulted'],['over_limit','Over limit']], '', 'semantic'], ['arrangementStatus','Payment arrangement','select',[['unknown','Unknown'],['none','Confirmed none'],['confirmed','Confirmed arrangement']], '', 'semantic'], ['arrangementPayment','Agreed arrangement payment','number'], ['includeInPlan','Include in payoff plan','checkbox'], ['statusConflict','Status information conflicts / needs checking','checkbox'], ['interestFrozen','Interest or charges frozen','checkbox'], ['description','Description','textarea','','wide-field'], ['notes','Notes','textarea','','wide-field']];
   if (type === 'overdraft') {
-    base.splice(1, 0, ['accountId', 'Linked account', 'select', [['','Not linked'], ...state.accounts.map((account) => [account.id, account.name])]]);
+    base.splice(1, 0, ['accountId', 'Linked account', 'select', [['','Not linked'], ...alphabeticalOptions(state.accounts.map((account) => [account.id, account.name]))]]);
     base.splice(8, 0, ['limit','Overdraft limit','number']);
   } else {
     base.splice(7, 0, ['originalBalance','Original balance / amount','number'], ['creditLimit','Credit limit','number']);
@@ -1413,12 +1651,13 @@ function editorDefinitions(type) {
 }
 
 function buildField(definition, item) {
-  const [name, labelText, type, options, className] = definition;
+  const [name, labelText, type, options, className, order] = definition;
   const label = element('label', className || ''); label.append(document.createTextNode(labelText));
   let input;
   if (type === 'select') {
     input = document.createElement('select');
-    for (const [value, text] of options) { const option = document.createElement('option'); option.value = value; option.textContent = text; input.append(option); }
+    const orderedOptions = order === 'semantic' ? options : alphabeticalOptions(options);
+    for (const [value, text] of orderedOptions) { const option = document.createElement('option'); option.value = value; option.textContent = text; input.append(option); }
   } else if (type === 'textarea') { input = document.createElement('textarea'); input.rows = 4; }
   else { input = document.createElement('input'); input.type = type; if (type === 'number') input.step = '0.01'; }
   input.name = name;
@@ -1850,13 +2089,86 @@ async function deleteDiagnostics() {
 
 function getFinancialViewCache() {
   if (financialViewCache?.state === state) return financialViewCache;
-  const budgetAnalysis = calculateBudgetAnalysis(state);
+  const report = buildFinancialReport(state);
+  const budgetAnalysis = report.budget;
   financialViewCache = {
     state,
+    report,
     budgetAnalysis,
     ledgerIndex: buildTransactionLedgerIndex(state, budgetAnalysis)
   };
   return financialViewCache;
+}
+
+function openDashboardCustomisation() {
+  renderDashboardCustomisation();
+  byId('dashboardDialog').showModal();
+}
+
+function renderDashboardCustomisation() {
+  const dashboard = normaliseDashboardSettings(state.settings.dashboard);
+  const container = byId('dashboardCustomisationList'); clear(container);
+  const modules = new Map(DASHBOARD_MODULES.map((module) => [module.id, module]));
+  dashboard.order.forEach((moduleId, index) => {
+    const module = modules.get(moduleId);
+    const row = element('div', 'dashboard-customisation-row');
+    const visibility = document.createElement('input'); visibility.type = 'checkbox'; visibility.checked = !dashboard.hidden.includes(moduleId); visibility.disabled = module.required; visibility.dataset.dashboardVisibility = moduleId; visibility.setAttribute('aria-label', `Show ${module.label}`);
+    const copy = element('div', 'dashboard-customisation-copy'); append(copy, element('strong', '', module.label), element('span', '', module.simple ? 'Simple and Detailed' : 'Detailed only'));
+    const pin = element('button', 'text-button', module.required ? 'Pinned' : dashboard.pinned.includes(moduleId) ? 'Unpin' : 'Pin'); pin.type = 'button'; pin.dataset.dashboardPin = moduleId; pin.disabled = module.required; pin.setAttribute('aria-pressed', String(dashboard.pinned.includes(moduleId)));
+    const size = document.createElement('select'); size.dataset.dashboardSize = moduleId; size.setAttribute('aria-label', `${module.label} size`);
+    for (const [value, label] of [['standard', 'Standard'], ['wide', 'Wide']]) { const option = document.createElement('option'); option.value = value; option.textContent = label; size.append(option); }
+    size.value = dashboard.sizes[moduleId];
+    const controls = element('div', 'dashboard-order-controls');
+    const up = element('button', 'icon-button', '↑'); up.type = 'button'; up.dataset.dashboardMove = moduleId; up.dataset.direction = 'up'; up.disabled = index === 0; up.setAttribute('aria-label', `Move ${module.label} up`);
+    const down = element('button', 'icon-button', '↓'); down.type = 'button'; down.dataset.dashboardMove = moduleId; down.dataset.direction = 'down'; down.disabled = index === dashboard.order.length - 1; down.setAttribute('aria-label', `Move ${module.label} down`);
+    append(controls, up, down); append(row, visibility, copy, pin, size, controls); container.append(row);
+  });
+}
+
+async function handleDashboardCustomisation(event) {
+  const move = event.target.closest('[data-dashboard-move]');
+  const pin = event.target.closest('[data-dashboard-pin]');
+  const visibility = event.target.closest('[data-dashboard-visibility]');
+  const size = event.target.closest('[data-dashboard-size]');
+  if (!move && !pin && !visibility && !size) return;
+  let dashboard = normaliseDashboardSettings(state.settings.dashboard);
+  if (move) dashboard = moveDashboardModule(dashboard, move.dataset.dashboardMove, move.dataset.direction);
+  if (pin) {
+    const moduleId = pin.dataset.dashboardPin;
+    dashboard.pinned = dashboard.pinned.includes(moduleId) ? dashboard.pinned.filter((id) => id !== moduleId) : [...dashboard.pinned, moduleId];
+  }
+  if (visibility) dashboard.hidden = visibility.checked ? dashboard.hidden.filter((id) => id !== visibility.dataset.dashboardVisibility) : [...dashboard.hidden, visibility.dataset.dashboardVisibility];
+  if (size) dashboard.sizes[size.dataset.dashboardSize] = size.value;
+  state.settings.dashboard = normaliseDashboardSettings(dashboard);
+  await saveAndRender();
+  renderDashboardCustomisation();
+  byId('dashboardStatus').textContent = 'Dashboard layout saved.';
+}
+
+async function resetDashboard() {
+  if (!window.confirm('Reset the dashboard layout? Financial data, budgets, payments and review state will not change.')) return;
+  state.settings.dashboard = defaultDashboardSettings();
+  await saveAndRender();
+  renderDashboardCustomisation();
+  byId('dashboardStatus').textContent = 'Default dashboard restored. Financial data was unchanged.';
+  showToast('Dashboard reset. Your financial data was not changed.');
+}
+
+async function saveThemePreference() {
+  const theme = byId('themeSelect').value;
+  state.settings.appearance.theme = THEMES.includes(theme) ? theme : 'system';
+  applyTheme();
+  await saveState();
+  renderSettings();
+  showToast(`${titleCase(state.settings.appearance.theme)} theme saved.`);
+}
+
+function applyTheme() {
+  const preference = THEMES.includes(state?.settings?.appearance?.theme) ? state.settings.appearance.theme : 'system';
+  const resolved = preference === 'system' ? (systemTheme.matches ? 'dark' : 'light') : preference;
+  document.documentElement.dataset.theme = resolved;
+  document.documentElement.dataset.themePreference = preference;
+  document.documentElement.style.colorScheme = resolved;
 }
 
 function focusTransactionTable() {
@@ -1904,7 +2216,8 @@ function populateAccountOptions() {
   for (const id of ['statementAccountSelect', 'transactionAccountFilter']) {
     const select = byId(id); const preserveAll = id === 'transactionAccountFilter'; clear(select);
     if (preserveAll) { const all = document.createElement('option'); all.value = 'all'; all.textContent = 'All accounts'; select.append(all); }
-    for (const account of state.accounts.filter((item) => item.active !== false)) { const option = document.createElement('option'); option.value = account.id; option.textContent = account.name; select.append(option); }
+    const accounts = state.accounts.filter((item) => item.active !== false).sort((left, right) => compareLabels(left.name, right.name));
+    for (const account of accounts) { const option = document.createElement('option'); option.value = account.id; option.textContent = account.name; select.append(option); }
   }
 }
 
@@ -1913,13 +2226,22 @@ function populatePaymentCategoryOptions() {
   if (!select) return;
   const selected = select.value || 'all';
   clear(select);
-  for (const [value, label] of [
-    ['all', 'All categories'], ['uncategorised', 'Uncategorised'], [INCOME_PAYMENT_CATEGORY_VALUE, INCOME_PAYMENT_CATEGORY],
-    ...state.budgets.filter((budget) => !isIncomePayment({ category: budget.category })).map((budget) => [budget.id, budget.category])
-  ]) {
+  for (const [value, label] of [['all', 'All categories'], ...paymentCategoryOptions(true)]) {
     const option = document.createElement('option'); option.value = value; option.textContent = label; select.append(option);
   }
   select.value = [...select.options].some((option) => option.value === selected) ? selected : 'all';
+}
+
+function paymentCategoryOptions(forFilter = false) {
+  return alphabeticalOptions([
+    [forFilter ? 'uncategorised' : '', 'Uncategorised'],
+    [INCOME_PAYMENT_CATEGORY_VALUE, INCOME_PAYMENT_CATEGORY],
+    ...state.budgets.filter((budget) => !isIncomePayment({ category: budget.category })).map((budget) => [budget.id, budget.category])
+  ]);
+}
+
+function alphabeticalOptions(options) {
+  return [...options].sort((left, right) => compareLabels(left[1], right[1]));
 }
 
 function transactionEditorItem(transaction) {

--- a/seed-data.json
+++ b/seed-data.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 8,
+  "schemaVersion": 9,
   "meta": {
     "createdAt": "",
     "updatedAt": "",
@@ -38,6 +38,27 @@
       "weeklyDay": "monday",
       "hour": 9
     },
-    "snoozedActions": {}
+    "snoozedActions": {},
+    "appearance": {
+      "theme": "system"
+    },
+    "dashboard": {
+      "mode": "simple",
+      "order": ["next-move", "balance", "upcoming", "budget", "alerts", "progress", "spending", "income", "review", "recent"],
+      "hidden": [],
+      "pinned": ["next-move"],
+      "sizes": {
+        "next-move": "wide",
+        "balance": "standard",
+        "upcoming": "standard",
+        "budget": "standard",
+        "alerts": "standard",
+        "progress": "wide",
+        "spending": "wide",
+        "income": "standard",
+        "review": "standard",
+        "recent": "wide"
+      }
+    }
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -833,6 +833,145 @@ tr:last-child td { border-bottom: 0; }
 .toast { position: relative; width: min(380px, calc(100vw - 36px)); max-width: 380px; padding: 0.82rem 1rem 0.82rem 2.7rem; pointer-events: auto; color: #fff; background: linear-gradient(125deg, #071d43, #0b3e65); border: 1px solid rgba(91, 224, 200, 0.2); border-radius: 14px; box-shadow: 0 19px 50px rgba(4, 25, 56, 0.28); animation: toastIn 260ms cubic-bezier(0.2, 0.8, 0.2, 1) both; }
 .toast::before { position: absolute; top: 50%; left: 0.9rem; width: 21px; height: 21px; display: grid; place-items: center; content: "✓"; color: var(--navy-deep); background: #55ddc5; border-radius: 50%; font-size: 0.72rem; font-weight: 900; transform: translateY(-50%); }
 
+.dashboard-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.segmented-control { display: inline-flex; padding: 0.22rem; background: var(--navy-soft); border: 1px solid var(--line); border-radius: 12px; }
+.segmented-control button { min-height: 36px; padding: 0.45rem 0.85rem; color: var(--ink-soft); background: transparent; border: 0; border-radius: 9px; font-size: 0.78rem; font-weight: 780; }
+.segmented-control button.active { color: #fff; background: var(--navy); box-shadow: var(--shadow-sm); }
+.dashboard-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; align-items: start; }
+.dashboard-module { min-width: 0; padding: 1.15rem; background: var(--panel); border: 1px solid var(--line); border-radius: 17px; box-shadow: var(--shadow-sm); }
+.dashboard-module.module-wide { grid-column: 1 / -1; }
+.dashboard-next-move { position: relative; overflow: hidden; border-color: rgba(24, 185, 158, 0.48); box-shadow: 0 17px 44px rgba(12, 41, 93, 0.1); }
+.dashboard-next-move::before { position: absolute; inset: 0 auto 0 0; width: 5px; content: ''; background: var(--teal); }
+.dashboard-module-heading, .chart-card-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.8rem; }
+.dashboard-module-heading h2, .chart-card-heading h3 { margin-bottom: 0; }
+.dashboard-lead { max-width: 760px; margin: 0.65rem 0 0; color: var(--ink-soft); line-height: 1.55; }
+.dashboard-module-footer { display: flex; align-items: center; justify-content: flex-end; gap: 0.65rem; margin-top: 1rem; }
+.dashboard-stat-pair { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.7rem; margin: 0.8rem 0; }
+.dashboard-stat-pair > div { display: grid; gap: 0.22rem; padding: 0.78rem; background: var(--panel-soft); border: 1px solid var(--line); border-radius: 12px; }
+.dashboard-stat-pair span, .progress-item-heading span { color: var(--muted); font-size: 0.72rem; }
+.dashboard-stat-pair strong { color: var(--navy); font-size: 1.18rem; font-variant-numeric: tabular-nums; }
+.dashboard-hero-value { display: block; margin: 0.8rem 0 0.35rem; color: var(--navy); font-size: 1.55rem; font-variant-numeric: tabular-nums; }
+.dashboard-list, .progress-list, .financial-wins { display: grid; gap: 0.48rem; margin-top: 0.7rem; }
+.dashboard-list-row { display: grid; gap: 0.18rem; padding: 0.68rem 0.72rem; background: var(--panel-soft); border-left: 3px solid var(--line-strong); border-radius: 9px; }
+.dashboard-list-row.tone-warning, .dashboard-list-row.tone-attention { border-left-color: var(--amber); }
+.dashboard-list-row.tone-danger { border-left-color: var(--red); }
+.dashboard-list-row.tone-good { border-left-color: var(--green); }
+.dashboard-list-row span { color: var(--muted); font-size: 0.74rem; line-height: 1.4; }
+.dashboard-list-row.horizontal { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.dashboard-list-row.horizontal > span { color: var(--ink-soft); }
+.dashboard-list-row .outgoing { color: var(--red); }
+.dashboard-list-row .incoming { color: var(--green); }
+.progress-item { display: grid; gap: 0.42rem; }
+.progress-item-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 0.8rem; }
+.financial-wins { margin-top: 0.9rem; }
+.financial-win { padding: 0.62rem 0.72rem; color: var(--green); background: var(--green-soft); border: 1px solid color-mix(in srgb, var(--green) 22%, transparent); border-radius: 10px; font-size: 0.78rem; font-weight: 720; }
+.text-button { min-height: auto; padding: 0.1rem; color: var(--teal-dark); background: transparent; border: 0; font-size: 0.75rem; font-weight: 800; text-decoration: underline; text-underline-offset: 0.2rem; }
+.text-button:hover { color: var(--navy); }
+
+.payment-insights { margin-bottom: 1.1rem; }
+.payment-chart-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.85rem; }
+.chart-card { min-width: 0; padding: 1rem; background: var(--panel); border: 1px solid var(--line); border-radius: 15px; box-shadow: var(--shadow-sm); }
+.chart-card-wide { grid-column: 1 / -1; }
+.chart { min-height: 150px; margin-top: 0.7rem; }
+.chart.chart-compact { min-height: 132px; }
+.chart svg { width: 100%; height: auto; max-height: 210px; overflow: visible; }
+.chart-grid-line { stroke: var(--line); stroke-width: 1; }
+.chart-line { fill: none; stroke-width: 4; stroke-linejoin: round; stroke-linecap: round; }
+.chart-line.tone-spending { stroke: var(--red); }
+.chart-line.tone-income { stroke: var(--green); }
+.chart-point { stroke: var(--panel); stroke-width: 3; }
+.chart-point.tone-spending { fill: var(--red); }
+.chart-point.tone-income { fill: var(--green); }
+.chart-point:focus { outline: none; stroke: var(--teal); stroke-width: 5; }
+.chart-bar-row, .category-chart-row { display: grid; gap: 0.35rem; margin-bottom: 0.7rem; }
+.chart-bar-label, .category-chart-heading { display: flex; align-items: center; justify-content: space-between; gap: 0.8rem; color: var(--ink-soft); font-size: 0.76rem; }
+.chart-bar-label strong, .category-chart-heading strong { color: var(--navy); font-variant-numeric: tabular-nums; }
+.chart-bar-track { height: 10px; overflow: hidden; background: var(--navy-soft); border-radius: 999px; }
+.chart-bar-fill { display: block; min-width: 2px; height: 100%; background: var(--teal); border-radius: inherit; }
+.chart-bar-fill.tone-income { background: var(--green); }
+.chart-bar-fill.tone-spending { background: var(--red); }
+.chart-bar-fill.tone-committed { background: var(--navy); }
+.chart-bar-fill.tone-flexible, .chart-bar-fill.tone-category { background: var(--teal); }
+.chart-bar-fill.tone-warning { background: var(--amber); }
+.category-chart { margin-top: 0.7rem; }
+.category-chart-row.needs-review { padding: 0.58rem; background: var(--amber-soft); border: 1px solid color-mix(in srgb, var(--amber) 28%, transparent); border-radius: 10px; }
+.chart-summary { margin: 0.6rem 0 0; color: var(--muted); font-size: 0.77rem; line-height: 1.5; }
+.chart-empty { margin: 0; padding: 2rem 0; color: var(--muted); text-align: center; }
+.chart-data { margin-top: 0.45rem; }
+.chart-data summary { color: var(--teal-dark); font-size: 0.72rem; font-weight: 760; cursor: pointer; }
+.chart-data table { margin-top: 0.45rem; }
+
+.dashboard-customisation-list { display: grid; gap: 0.55rem; margin-top: 1rem; }
+.dashboard-customisation-row { display: grid; grid-template-columns: auto minmax(130px, 1fr) auto minmax(105px, auto) auto; align-items: center; gap: 0.65rem; padding: 0.65rem; background: var(--panel-soft); border: 1px solid var(--line); border-radius: 11px; }
+.dashboard-customisation-row > input { width: 18px; height: 18px; }
+.dashboard-customisation-copy { display: grid; gap: 0.15rem; }
+.dashboard-customisation-copy span { color: var(--muted); font-size: 0.68rem; }
+.dashboard-order-controls { display: flex; gap: 0.3rem; }
+.dashboard-order-controls .icon-button { width: 34px; height: 34px; color: var(--ink-soft); background: var(--panel); border: 1px solid var(--line); }
+.split-actions { justify-content: space-between; }
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --ink: #edf4fb;
+  --ink-soft: #c7d5e3;
+  --muted: #9baec2;
+  --canvas: #0b1420;
+  --panel: #121f2d;
+  --panel-soft: #172636;
+  --line: #2b3d50;
+  --line-strong: #3a5067;
+  --navy: #b8d8ff;
+  --navy-deep: #07111c;
+  --navy-soft: #1d3045;
+  --teal: #42d4bb;
+  --teal-dark: #7ce4d3;
+  --teal-soft: #123b39;
+  --green: #65d7a9;
+  --green-soft: #13372c;
+  --red: #ff8f9e;
+  --red-soft: #43232a;
+  --amber: #f0c76d;
+  --amber-soft: #3c321d;
+  --shadow-sm: 0 3px 14px rgba(0, 0, 0, 0.22);
+  --shadow: 0 16px 45px rgba(0, 0, 0, 0.28);
+  --shadow-strong: 0 28px 75px rgba(0, 0, 0, 0.48);
+}
+:root[data-theme="dark"] body { background: radial-gradient(circle at 82% -10%, rgba(66, 212, 187, 0.08), transparent 29rem), linear-gradient(145deg, #0d1825, var(--canvas) 54%, #0b1721); }
+:root[data-theme="dark"] body::before { background-image: radial-gradient(rgba(184, 216, 255, 0.13) 0.65px, transparent 0.65px); }
+:root[data-theme="dark"] .topbar { background: rgba(11, 20, 32, 0.86); }
+:root[data-theme="dark"] .panel,
+:root[data-theme="dark"] .metric-card,
+:root[data-theme="dark"] .focus-panel,
+:root[data-theme="dark"] .entity-card,
+:root[data-theme="dark"] .payslip-card,
+:root[data-theme="dark"] .welcome-back,
+:root[data-theme="dark"] .review-card,
+:root[data-theme="dark"] .modal,
+:root[data-theme="dark"] .desktop-required,
+:root[data-theme="dark"] .recovery-card,
+:root[data-theme="dark"] .chat-messages { background: var(--panel); border-color: var(--line); }
+:root[data-theme="dark"] input,
+:root[data-theme="dark"] select,
+:root[data-theme="dark"] textarea { color: var(--ink); background: var(--panel-soft); border-color: var(--line-strong); }
+:root[data-theme="dark"] table { color: var(--ink-soft); }
+:root[data-theme="dark"] th { color: var(--muted); background: #162535; }
+:root[data-theme="dark"] td { border-color: var(--line); }
+:root[data-theme="dark"] tr:hover td { background: #162535; }
+:root[data-theme="dark"] .import-summary div,
+:root[data-theme="dark"] .import-change,
+:root[data-theme="dark"] .restore-metadata div,
+:root[data-theme="dark"] .check-in-review-item { background: var(--panel-soft); border-color: var(--line); }
+:root[data-theme="dark"] .review-group-row { border-color: var(--line); }
+:root[data-theme="dark"] .modal::backdrop { background: rgba(0, 5, 10, 0.76); }
+:root[data-theme="dark"] .primary-button { color: #061d28; }
+:root[data-theme="dark"] .secondary-button { color: var(--ink); background: var(--panel-soft); border-color: var(--line-strong); }
+:root[data-theme="dark"] .secondary-button:hover { background: var(--navy-soft); }
+:root[data-theme="dark"] .band-critical .review-priority { color: #ffd6d9; background: #5a2930; }
+:root[data-theme="dark"] .priority-high .review-priority,
+:root[data-theme="dark"] .band-important .review-priority { color: #ffe0a0; background: #4b3619; }
+:root[data-theme="dark"] .band-low .review-priority { color: #d0deeb; background: #28394b; }
+:root[data-theme="dark"] .diagnostic-preview { border-color: var(--line); }
+
 @keyframes viewIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes modalIn { from { opacity: 0; transform: translateY(14px) scale(0.985); } to { opacity: 1; transform: translateY(0) scale(1); } }
 @keyframes messageIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
@@ -867,7 +1006,7 @@ tr:last-child td { border-bottom: 0; }
   .notification-layer { padding-bottom: 76px; }
   .sidebar { position: fixed; inset: auto 0 0 0; z-index: 6; width: 100%; height: auto; padding: 0.45rem; }
   .sidebar::before, .sidebar::after, .brand, .sidebar-footer { display: none; }
-  .sidebar nav { grid-template-columns: repeat(10, minmax(58px, 1fr)); overflow-x: auto; }
+  .sidebar nav { grid-template-columns: repeat(11, minmax(58px, 1fr)); overflow-x: auto; }
   .nav-button { min-width: 56px; min-height: 48px; }
   .main-content { padding-bottom: 5rem; }
   .topbar, .section-actions, .focus-panel { align-items: flex-start; flex-direction: column; }
@@ -875,7 +1014,10 @@ tr:last-child td { border-bottom: 0; }
   .focus-copy { gap: 0.8rem; }
   .focus-actions { width: 100%; }
   .topbar-actions { width: 100%; justify-content: space-between; }
-  .metric-grid, .metric-grid.three, .two-column, .settings-grid, .filter-bar, .today-supporting-list { grid-template-columns: 1fr; }
+  .metric-grid, .metric-grid.three, .two-column, .settings-grid, .filter-bar, .today-supporting-list, .dashboard-grid, .payment-chart-grid { grid-template-columns: 1fr; }
+  .dashboard-module.module-wide, .chart-card-wide { grid-column: auto; }
+  .dashboard-customisation-row { grid-template-columns: auto minmax(0, 1fr) auto; }
+  .dashboard-customisation-row > select, .dashboard-order-controls { grid-column: 2 / -1; }
   .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .budget-summary { grid-template-columns: 1fr; }
   .budget-summary div { border-right: 0; border-bottom: 1px solid var(--line); }
@@ -899,6 +1041,8 @@ tr:last-child td { border-bottom: 0; }
   .main-content { padding-inline: 0.78rem; }
   .metric-grid { grid-template-columns: 1fr; }
   .topbar-actions, .button-row { width: 100%; align-items: stretch; flex-direction: column; }
+  .dashboard-toolbar, .dashboard-module-footer, .progress-item-heading { align-items: stretch; flex-direction: column; }
+  .dashboard-stat-pair { grid-template-columns: 1fr; }
   .section-actions .button-row, .section-actions .primary-button { width: 100%; }
   .focus-panel { border-radius: 20px; }
   .focus-copy { display: block; }

--- a/tests/budget-payment-sync.test.js
+++ b/tests/budget-payment-sync.test.js
@@ -349,7 +349,8 @@ test('payment editing and filtering expose Income as a standard category', () =>
   const ledger = fs.readFileSync(new URL('../transaction-ledger.js', import.meta.url), 'utf8');
 
   assert.match(html, /<label>Payment category<select id="transactionCategoryFilter">/);
-  assert.match(renderer, /\['','Uncategorised'\], \[INCOME_PAYMENT_CATEGORY_VALUE, INCOME_PAYMENT_CATEGORY\]/);
+  assert.match(renderer, /\[forFilter \? 'uncategorised' : '', 'Uncategorised'\]/);
+  assert.match(renderer, /alphabeticalOptions\(/);
   assert.match(renderer, /item\.category = INCOME_PAYMENT_CATEGORY/);
   assert.match(ledger, /category === INCOME_PAYMENT_CATEGORY_VALUE && !isIncomePayment\(item\)/);
   assert.match(renderer, /isIncomePayment\(item\) \? INCOME_PAYMENT_CATEGORY/);

--- a/tests/data-store-recovery.test.js
+++ b/tests/data-store-recovery.test.js
@@ -15,7 +15,7 @@ test('a genuine first launch creates one valid initial state and starts normally
   const first = await harness.store.loadState();
   assert.equal(first.status, 'normal');
   assert.equal(first.source, 'first_install');
-  assert.equal(first.state.schemaVersion, 8);
+  assert.equal(first.state.schemaVersion, 9);
 
   const firstBytes = await fs.readFile(harness.store.statePath);
   const second = await harness.store.loadState();
@@ -38,6 +38,23 @@ test('a valid existing state opens normally without rewriting it', async (t) => 
   assert.deepEqual(await fs.readFile(harness.store.statePath), original);
 });
 
+test('malformed dashboard preferences reset without putting financial data into recovery', async (t) => {
+  const harness = await createHarness(t);
+  const original = validState({
+    accounts: [{ id: 'fictional-account', name: 'Fictional account', currentBalance: 321 }],
+    settings: { ...validState().settings, appearance: { theme: 'ultraviolet' }, dashboard: { mode: 'detailed', order: ['unknown-module'], hidden: 'all' } }
+  });
+  await fs.writeFile(harness.store.statePath, stateEnvelope(original));
+
+  const result = await harness.store.loadState();
+
+  assert.equal(result.status, 'normal');
+  assert.equal(result.state.accounts[0].currentBalance, 321);
+  assert.equal(result.state.settings.appearance.theme, 'system');
+  assert.equal(result.state.settings.dashboard.mode, 'simple');
+  assert.equal(result.state.settings.dashboard.order[0], 'next-move');
+});
+
 test('legacy debt safety fields migrate conservatively and persist across restart', async (t) => {
   const harness = await createHarness(t);
   const original = stateEnvelope(validState({
@@ -51,7 +68,7 @@ test('legacy debt safety fields migrate conservatively and persist across restar
 
   const loaded = await harness.store.loadState();
 
-  assert.equal(loaded.state.schemaVersion, 8);
+  assert.equal(loaded.state.schemaVersion, 9);
   assert.equal(loaded.state.debts[0].arrangementStatus, 'unknown');
   assert.equal(loaded.state.debts[0].arrangementPayment, null);
   assert.equal(loaded.state.debts[0].statusConflict, false);
@@ -184,7 +201,7 @@ test('restoring a validated backup exits recovery only after the restored state 
   assert.equal(restored.status, 'normal');
   assert.equal(restored.source, 'restored_backup');
   assert.equal(restored.state.profile.name, 'Restored User');
-  assert.equal(restored.state.schemaVersion, 8);
+  assert.equal(restored.state.schemaVersion, 9);
   assert.deepEqual(await fs.readFile(backupPath), backup);
   const recoveryCopies = await fs.readdir(harness.store.recoveryPath);
   assert.ok(recoveryCopies.length >= 2);
@@ -263,7 +280,7 @@ test('fresh start requires a live confirmation and cancellation changes nothing'
   const confirmed = await harness.store.confirmFreshStart(confirmedRequest.token);
   assert.equal(confirmed.status, 'normal');
   assert.equal(confirmed.source, 'fresh_start');
-  assert.equal(confirmed.state.schemaVersion, 8);
+  assert.equal(confirmed.state.schemaVersion, 9);
   assert.equal(confirmed.state.accounts.length, 0);
   assert.notDeepEqual(await fs.readFile(harness.store.statePath), original);
   const recoveryCopies = await fs.readdir(harness.store.recoveryPath);

--- a/tests/financial-reporting.test.js
+++ b/tests/financial-reporting.test.js
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import test from 'node:test';
+import { buildFinancialReport } from '../financial-reporting.js';
+
+test('payment charts reconcile with Budget Intelligence and trusted cash-flow rules', () => {
+  const input = reportingState();
+  const report = buildFinancialReport(input, '2026-08', new Date('2026-09-10T12:00:00'));
+
+  assert.equal(report.summary.spending, 110);
+  assert.equal(report.summary.income, 1220);
+  assert.equal(report.budget.actual, 90);
+  assert.deepEqual(report.categories.map(({ label, amount }) => [label, amount]), [['Groceries', 60], ['Uncategorised', 30]]);
+  assert.equal(report.categories.some((category) => category.label === 'Income'), false);
+  assert.deepEqual(report.recurring, { committed: 60, flexible: 30, evidence: 'confirmed' });
+  assert.equal(report.comparison.direction, 'lower');
+  assert.equal(report.comparison.difference, -10);
+});
+
+test('all-time reporting uses trusted multi-month data rather than stretching one month', () => {
+  const report = buildFinancialReport(reportingState(), 'all', new Date('2026-09-10T12:00:00'));
+  assert.equal(report.fullTimeline.length, 2);
+  assert.deepEqual(report.fullTimeline.map((row) => [row.month, row.spending]), [['2026-07', 100], ['2026-08', 90]]);
+  assert.deepEqual(report.categories.map(({ label, amount }) => [label, amount]), [['Groceries', 160], ['Uncategorised', 30]]);
+  assert.equal(report.summary.budgetActualSpending, 190);
+});
+
+test('the current month is explicitly incomplete rather than used as a like-for-like win', () => {
+  const report = buildFinancialReport(reportingState(), '2026-08', new Date('2026-08-09T12:00:00'));
+  assert.equal(report.comparison.incomplete, true);
+  assert.match(report.comparison.text, /not like-for-like/i);
+  assert.equal(report.wins.some((message) => /lower than last month/i.test(message)), false);
+});
+
+test('reporting stays practical with thousands of fictional transactions', () => {
+  const input = reportingState();
+  input.transactions = Array.from({ length: 5000 }, (_, index) => transaction({
+    id: `fictional-${index}`, date: `2026-${String(index % 12 + 1).padStart(2, '0')}-${String(index % 28 + 1).padStart(2, '0')}`,
+    budgetMonth: `2026-${String(index % 12 + 1).padStart(2, '0')}`, outgoing: 1, budgetCategoryId: 'groceries'
+  }));
+  const started = performance.now();
+  const report = buildFinancialReport(input, 'all', new Date('2027-01-10T12:00:00'));
+  assert.equal(report.summary.budgetActualSpending, 5000);
+  assert.equal(report.fullTimeline.length, 12);
+  assert.ok(performance.now() - started < 2000);
+});
+
+function reportingState() {
+  return {
+    profile: { dependableIncome: 2000 },
+    accounts: [{ id: 'current', type: 'current', currentBalance: 400, active: true }],
+    payslips: [], debts: [], overdrafts: [], scheduledPayments: [], reviewItems: [],
+    settings: { selectedMonth: '2026-08', emergencyBufferBalance: 100, emergencyBufferTarget: 500 },
+    budgets: [{ id: 'groceries', category: 'Groceries', planned: 300 }],
+    transactions: [
+      transaction({ id: 'july-spend', date: '2026-07-04', budgetMonth: '2026-07', outgoing: 100, budgetCategoryId: 'groceries' }),
+      transaction({ id: 'july-income', date: '2026-07-01', budgetMonth: '2026-07', incoming: 1000, category: 'Income' }),
+      transaction({ id: 'purchase', date: '2026-08-02', outgoing: 80, budgetCategoryId: 'groceries', recurring: true }),
+      transaction({ id: 'refund', date: '2026-08-03', incoming: 20, refundOfTransactionId: 'purchase', budgetTreatment: 'refund', recurring: true }),
+      transaction({ id: 'uncategorised', date: '2026-08-04', outgoing: 30 }),
+      transaction({ id: 'income', date: '2026-08-01', incoming: 1200, category: 'Income' }),
+      transaction({ id: 'internal', date: '2026-08-05', outgoing: 200, transferStatus: 'confirmed' }),
+      transaction({ id: 'savings', date: '2026-08-06', outgoing: 100, budgetTreatment: 'savings_transfer' }),
+      transaction({ id: 'pending', date: '2026-08-07', outgoing: 999, financiallyActive: false, duplicateStatus: 'possible', reviewStatus: 'pending' })
+    ]
+  };
+}
+
+function transaction(overrides = {}) {
+  return {
+    id: 'transaction', date: '2026-08-01', budgetMonth: '2026-08', incoming: 0, outgoing: 0,
+    category: '', budgetCategoryId: '', budgetTreatment: 'auto', transferStatus: 'no', duplicateStatus: 'none',
+    reviewStatus: 'not_required', importReviewStatus: 'trusted', financiallyActive: true, ...overrides
+  };
+}

--- a/tests/interaction-ui.test.js
+++ b/tests/interaction-ui.test.js
@@ -26,7 +26,7 @@ test('primary controls have explicit button behaviour and dialogs expose accessi
 
   for (const [dialogId, titleId] of [
     ['editDialog', 'editTitle'], ['importDialog', 'importTitle'], ['importResultDialog', 'importResultTitle'],
-    ['diagnosticsDialog', 'diagnosticsDialogTitle'], ['restoreDialog', 'restoreDialogTitle'], ['freshStartDialog', 'freshStartDialogTitle']
+    ['dashboardDialog', 'dashboardDialogTitle'], ['diagnosticsDialog', 'diagnosticsDialogTitle'], ['restoreDialog', 'restoreDialogTitle'], ['freshStartDialog', 'freshStartDialogTitle']
   ]) {
     assert.match(html, new RegExp(`id="${dialogId}"[^>]*aria-labelledby="${titleId}"`));
     assert.match(html, new RegExp(`id="${titleId}"`));
@@ -106,4 +106,36 @@ test('Today exposes one explainable Next Move, supporting work and a genuine cau
   assert.match(css, /\.next-move-band\.band-critical/);
   assert.match(css, /\.today-supporting-list/);
   assert.match(css, /summary:focus-visible/);
+});
+
+test('Dashboard supports persisted modes, accessible personalisation and authoritative chart summaries', async () => {
+  const [html, renderer, css] = await Promise.all([
+    fs.readFile(new URL('../index.html', import.meta.url), 'utf8'),
+    fs.readFile(new URL('../renderer-app.js', import.meta.url), 'utf8'),
+    fs.readFile(new URL('../styles.css', import.meta.url), 'utf8')
+  ]);
+  assert.match(html, /data-view="dashboard"/);
+  assert.match(html, /id="view-dashboard"[\s\S]*id="dashboardNextMoveTitle"/);
+  assert.match(html, /data-dashboard-mode="simple"[\s\S]*data-dashboard-mode="detailed"/);
+  assert.match(html, /id="dashboardCustomisationList"/);
+  assert.match(renderer, /visibleDashboardModules\(dashboard\)/);
+  assert.match(renderer, /await saveAndRender\(\)/);
+  assert.match(renderer, /prioritySafety\?\.currentCashCapacity/);
+  assert.match(css, /\.dashboard-grid/);
+  assert.match(css, /\.dashboard-customisation-row/);
+});
+
+test('Payments charts, text alternatives and complete theme controls are present without remote assets', async () => {
+  const [html, renderer, css] = await Promise.all([
+    fs.readFile(new URL('../index.html', import.meta.url), 'utf8'),
+    fs.readFile(new URL('../renderer-app.js', import.meta.url), 'utf8'),
+    fs.readFile(new URL('../styles.css', import.meta.url), 'utf8')
+  ]);
+  for (const id of ['moneyInOutChart', 'spendingTrendChart', 'categoryChart', 'recurringChart']) assert.match(html, new RegExp(`id="${id}"`));
+  assert.match(renderer, /buildFinancialReport\(state\)/);
+  assert.match(renderer, /chartDataTable\(points\)/);
+  assert.match(html, /id="themeSelect"[\s\S]*value="system"[\s\S]*value="light"[\s\S]*value="dark"/);
+  assert.match(renderer, /matchMedia\('\(prefers-color-scheme: dark\)'\)/);
+  assert.match(css, /:root\[data-theme="dark"\]/);
+  assert.doesNotMatch(html, /https?:\/\//);
 });

--- a/tests/presentation-settings.test.js
+++ b/tests/presentation-settings.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  compareLabels, defaultDashboardSettings, moveDashboardModule, normaliseAppearanceSettings,
+  normaliseDashboardSettings, visibleDashboardModules
+} from '../presentation-settings.js';
+
+test('dashboard defaults keep Next Move prominent and give new users a low-overwhelm layout', () => {
+  const dashboard = defaultDashboardSettings();
+  assert.equal(dashboard.mode, 'simple');
+  assert.equal(dashboard.order[0], 'next-move');
+  assert.ok(dashboard.pinned.includes('next-move'));
+  assert.deepEqual(visibleDashboardModules(dashboard), ['next-move', 'balance', 'upcoming', 'budget', 'alerts', 'progress']);
+});
+
+test('valid dashboard choices persist while malformed layout state resets only presentation settings', () => {
+  const valid = normaliseDashboardSettings({
+    mode: 'detailed', order: ['review', 'next-move'], hidden: ['income'], pinned: ['review'], sizes: { review: 'wide' }
+  });
+  assert.equal(valid.mode, 'detailed');
+  assert.equal(valid.order[0], 'review');
+  assert.ok(valid.pinned.includes('next-move'));
+  assert.ok(valid.hidden.includes('income'));
+  assert.equal(valid.sizes.review, 'wide');
+
+  const malformed = normaliseDashboardSettings({ mode: 'detailed', order: ['not-a-module'], hidden: 'everything' });
+  assert.deepEqual(malformed, defaultDashboardSettings());
+  assert.deepEqual(normaliseAppearanceSettings({ theme: 'not-a-theme' }), { theme: 'system' });
+});
+
+test('dashboard modules support keyboard-equivalent ordering without a freeform canvas', () => {
+  const moved = moveDashboardModule(defaultDashboardSettings(), 'balance', 'down');
+  assert.equal(moved.order.indexOf('balance'), 2);
+  assert.equal(moved.order.indexOf('upcoming'), 1);
+});
+
+test('alphabetical choice ordering is case-insensitive and numeric-aware', () => {
+  const labels = ['Fuel 10', 'groceries', 'Fuel 2', 'Bills'].sort(compareLabels);
+  assert.deepEqual(labels, ['Bills', 'Fuel 2', 'Fuel 10', 'groceries']);
+});


### PR DESCRIPTION
### Purpose

Deliver OneStep Money v2.1.24 as a presentation-focused release that makes the trusted financial intelligence already built easier to understand and personalise without changing Financial Safety rules, financial balances, or transaction treatment.

The branch adds a first-class dashboard, useful Payments visualisation, persistent Light/Dark/System themes, controlled dashboard personalisation, clearer financial progress, and alphabetically ordered user-choice lists such as Payment Category.

### Work completed

#### Dashboard

- Added Dashboard as the default first-class view while preserving Today as the authoritative detailed action workflow.
- Kept Next Move first and prominent, using the existing v2.1.23 priority/lifecycle result rather than duplicating its state.
- Added controlled modules for Next Move, balance and available money, upcoming commitments/payday, budget health, warnings, debt/savings progress, spending, income, Review Inbox, and recent trusted payments.
- Added Simple mode for lower-overwhelm essentials and Detailed mode for the complete supported module set.
- Added deliberate Customise Dashboard mode with show/hide, pin, keyboard-operable up/down reordering, Standard/Wide sizing, and reset.
- Added a responsive two-column controlled grid that collapses safely at narrower supported sizes.
- Added a safe default layout with Next Move pinned first.
- Added reset that changes presentation settings only.

#### Payments visualisation

- Added trusted money-in versus money-out comparison.
- Added daily selected-month and monthly All-Time spending trends.
- Added ranked category expenditure with Uncategorised visibly identified and linked back to Payments review.
- Added confirmed-recurring versus flexible/not-confirmed spending without promoting uncertain recurrence to commitments.
- Added complete-month comparisons, current-month incomplete-period wording, and All-Time complete-month averages.
- Added native local SVG/CSS rendering with no chart dependency, CDN, remote asset, or persisted chart totals.
- Added keyboard-focusable data points, textual summaries, and expandable accessible data tables.

#### Financial progress

- Added debt progress only where a known starting balance exists.
- Added arranged-limit overdraft milestones without inventing an original balance.
- Added emergency-buffer progress against the user's existing target.
- Added restrained financial wins based on trusted starting balances, overdraft position, savings milestones, and complete-period spending comparisons.
- Added no usage/opening streaks or engagement rewards.

#### Night Mode and appearance

- Added persisted Light, Dark, and Follow System themes.
- Added live OS theme-change handling while the app is open.
- Added theme-aware panels, tables, forms, dialogs, notifications, charts, tooltips/focus states, and financial warning colours.
- Retained non-colour labels and visible status text.
- Added no external fonts, themes, assets, or services.

#### Personalisation, migration, and safety

- Moved the state schema from 8 to 9 for presentation settings only.
- Added allowlisted `settings.appearance` and `settings.dashboard` normalisation.
- Added idempotent defaults and presentation-only fallback: malformed dashboard state resets the layout without causing financial recovery.
- Preserved valid unrelated settings and existing backup/restore behaviour.
- Cached the derived reporting model per loaded state so dashboard and chart calculations are not repeatedly rebuilt during a render.
- Added no chart-specific financial state, telemetry, analytics, or cloud processing.

#### Alphabetical choices

- Alphabetised Payment Category choices in filters and payment editing.
- Alphabetised account selections and other non-semantic editor choices.
- Preserved deliberate priority, lifecycle, chronological, risk, reporting-period, and snooze ordering where alphabetical order would make the workflow less safe or understandable.

### Files changed

- `data-store.js` — schema 9 migration, presentation-setting normalisers, and migrated-state validation.
- `finance-core.js` — schema version update and export of the existing authoritative external-cashflow predicate for shared reporting.
- `financial-reporting.js` — new derived reporting model for trusted timelines, categories, comparisons, recurrence, progress, and wins.
- `index.html` — Dashboard view, Payments chart surfaces, appearance controls, and accessible dashboard customisation dialog.
- `package.json` — application version 2.1.24.
- `package-lock.json` — lockfile version metadata 2.1.24; no dependency changes.
- `presentation-settings.js` — new controlled dashboard/theme defaults, validation, visibility, ordering, and label comparison helpers.
- `renderer-app.js` — dashboard/chart rendering, personalisation persistence, live theme handling, progress components, payday summary, and alphabetical options.
- `seed-data.json` — schema 9 and safe presentation defaults for new users.
- `styles.css` — responsive dashboard/chart styling, customisation UI, accessible focus states, and complete dark-theme overrides.
- `tests/budget-payment-sync.test.js` — updated Payment Category UI contract for the alphabetical shared option builder.
- `tests/data-store-recovery.test.js` — schema 9 expectations and presentation-corruption isolation regression.
- `tests/financial-reporting.test.js` — new trusted-total, transfer, savings-transfer, refund, uncategorised, All-Time, incomplete-period, and 5,000-row reporting tests.
- `tests/interaction-ui.test.js` — new Dashboard, chart accessibility, theme, local-only asset, and customisation contracts.
- `tests/presentation-settings.test.js` — new default, malformed-layout, reordering, visibility, and alphabetical-order tests.

No files were renamed or deleted.

### User-facing changes

- OneStep opens on a clearer Dashboard with Next Move first.
- Users can choose Simple or Detailed detail.
- Users can show, hide, pin, reorder, resize supported modules, and restore the default.
- Payments now explains cash movement, spending trends, categories, uncategorised work, and confirmed recurring/flexible expenditure visually and in text.
- Debt, overdraft, emergency-buffer, and genuine financial progress are clearer.
- Users can select Light, Dark, or Follow System.
- Payment Category and other non-semantic choice lists are alphabetical.

### Technical changes

- Dashboard and Payments charts consume `calculatePeriodSummary`, `calculateBudgetAnalysis`, active-transaction filtering, and the finance-core external-cashflow predicate.
- Native SVG/CSS keeps the feature offline, lightweight, themeable, and package-safe.
- Presentation settings are allowlisted, migrated, validated, backed up, and restored with normal application settings.
- Invalid presentation state is normalised independently and cannot trigger financial recovery.
- Derived report results are cached for the current state reference.
- No dependencies were added, removed, or updated.
- No financial schema, balance, transaction, debt, budget, document, import, export, or Financial Safety rule changed.

### Testing and verification

#### Automated and static checks

- **Passed** — ESLint: `npm run lint`.
- **Passed** — full suite: 276/276 tests via `npm test`.
- **Passed** — dashboard defaults, modes, visibility, ordering, pinning, sizing, and malformed-layout recovery tests.
- **Passed** — money-in/out, category, refunds, transfers, savings transfers, pending review exclusion, recurring-confidence, monthly comparison, incomplete period, and All-Time reporting tests.
- **Passed** — Budget/Payments/reporting consistency tests.
- **Passed** — Next Move, Review Inbox, Financial Safety, backup/restore, recovery, update-notification, single-click, and version-consistency regressions.
- **Passed** — 5,000 fictional transaction report test (approximately 36–44 ms in this runner).
- **Passed** — existing 1k/5k/10k ledger scalability tests.
- **Passed** — project validation: `npm run check`.
- **Passed** — privacy scan: 66 files checked; no sensitive-data or prohibited-network pattern found.
- **Passed** — `git diff --check`.
- **Passed** — Windows x64 unpacked Electron build using `electron-builder --win --dir`; `OneStep Money.exe` and `app.asar` produced.
- **Unavailable** — NSIS installer completion on this Linux runner: application packaging completed, then electron-builder could not launch missing Wine (`spawn wine ENOENT`).
- **Unavailable** — interactive Electron launch and visual capture: this runner has no X/desktop display; headless Electron could not initialise Chromium. No source/build failure was observed.

#### Required manual verification

The graphical checks below are **Unavailable** in this non-graphical runner and should be completed on Windows before release:

1. Dashboard opens cleanly — **Unavailable**.
2. Next Move remains prominent — **Unavailable**.
3. Simple mode is genuinely simpler — **Unavailable**.
4. Detailed mode exposes useful detail — **Unavailable**.
5. Dashboard cards can be customised — **Unavailable**.
6. Layout persists after restart — **Unavailable**.
7. Reset restores the default layout — **Unavailable**.
8. Money-in/out chart matches Payments totals — **Unavailable** visually; **Passed** by automated calculation test.
9. Category chart matches Budget/Payments — **Unavailable** visually; **Passed** by automated calculation test.
10. Income is excluded from expenditure charts — **Unavailable** visually; **Passed** by automated calculation test.
11. Uncategorised spending remains visible — **Unavailable** visually; **Passed** by automated calculation test.
12. Transfers do not inflate spending — **Unavailable** visually; **Passed** by automated calculation test.
13. Refunds use existing treatment — **Unavailable** visually; **Passed** by automated calculation test.
14. All-Time charts work — **Unavailable** visually; **Passed** by automated calculation test.
15. Current incomplete month is not misleading — **Unavailable** visually; **Passed** by wording/comparison test.
16. Light theme across screens — **Unavailable**.
17. Dark theme across screens — **Unavailable**.
18. Charts in dark mode — **Unavailable**.
19. Warnings remain clear — **Unavailable**.
20. Theme persists — **Unavailable** interactively; **Passed** by settings migration/static contract.
21. System theme follows OS — **Unavailable** interactively; **Passed** by live matchMedia contract.
22. Minimum-window layout — **Unavailable** visually; responsive rules and 980×680 minimum are retained.
23. Large fictional dataset remains usable — **Unavailable** visually; **Passed** by automated 5k/10k performance tests.
24. Notifications remain above dashboard/dialogs — **Unavailable** visually; **Passed** by top-layer regression test.
25. Diagnostics contain no sensitive data — **Passed** by privacy and diagnostics tests.

### Data and migration impact

Only presentation/settings metadata changed.

Schema 9 adds normalised `settings.appearance` and `settings.dashboard` values. Migration is idempotent, preserves valid unrelated settings, and resets only malformed presentation preferences.

**Installing v2.1.24 does not change financial balances, transactions, debts, budgets or imported documents.**

### Known limitations

- Final visual/manual QA and NSIS installer creation must run in a Windows graphical environment.
- Historical budget-revision comparisons are not available because OneStep does not yet store budget snapshots.
- Advanced chart types, freeform dashboard canvases, drag-only reordering, mobile dashboard work, and long-range goal forecasts were deliberately not added.
- Goal completion estimates appear only when existing data can support them; no speculative multi-year countdowns are introduced.
- Full financial calendar remains deferred.

### Excluded work

- Browser Demo v2.1.25.
- Payday automation v2.2.0 (the existing optional payday setting is only displayed).
- AI Companion v2.2.1.
- Accounts/cloud services.
- Game functionality or online competitions.
- New import formats, Financial Safety rules, advanced budgeting methods, and mobile redesign.
- Optional accent colour, density, and larger-text controls.

### Branch details

- Branch: `ui/dashboard-visualisation`
- Commit SHA: `a66d3ae7007822648b16b713edd99ede7269ce8d`
- Local equivalent commit: `4a733fc` (normal HTTPS push was unavailable; the connected GitHub app published the identical tree)
- Pull request: this draft pull request
- Target branch: `main`

### Confirmations

- No changes were committed or pushed directly to `main`.
- The pull request has not been merged.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs were committed.
- No analytics, telemetry, CDN dependency, cloud financial processing, or external chart service was introduced.
- Only files relevant to v2.1.24 were changed.
