### PR TITLE
[v2.1.25][Bug] Packaged dashboard runtime repair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onestep-money",
-  "version": "2.1.24",
+  "version": "2.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onestep-money",
-      "version": "2.1.24",
+      "version": "2.1.25",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onestep-money",
-  "version": "2.1.24",
+  "version": "2.1.25",
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",
@@ -50,6 +50,7 @@
       "document-import.js",
       "document-deduplication.js",
       "finance-core.js",
+      "financial-reporting.js",
       "index.html",
       "local-llm-service.js",
       "main-process.js",
@@ -57,6 +58,7 @@
       "pdf-service.js",
       "payslip-record.js",
       "preload-bridge.cjs",
+      "presentation-settings.js",
       "renderer-app.js",
       "review-lifecycle.js",
       "credit-report-intelligence.js",

--- a/scripts/check-project.mjs
+++ b/scripts/check-project.mjs
@@ -25,6 +25,7 @@ if (Number(seed.settings?.extraDebtPayment || 0) !== 0) throw new Error('Public 
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
 if (packageJson.name !== 'onestep-money' || packageJson.build?.productName !== 'OneStep Money') throw new Error('Package branding is inconsistent.');
 if (!packageJson.dependencies?.['electron-updater']) throw new Error('The installed update channel is not configured.');
+verifyPackagedRuntimeDependencies(packageJson.build?.files || []);
 if (!packageJson.build?.files?.includes('diagnostic-logger.js')) throw new Error('The diagnostic logger is missing from packaged builds.');
 if (!packageJson.build?.files?.includes('transaction-ledger.js')) throw new Error('The paginated transaction ledger is missing from packaged builds.');
 if (!packageJson.build?.files?.includes('review-lifecycle.js')) throw new Error('The persisted review lifecycle is missing from packaged builds.');
@@ -40,4 +41,44 @@ function walk(directory) {
     if (entry.isDirectory()) walk(target);
     else if (entry.name.endsWith('.js') || entry.name.endsWith('.mjs') || entry.name.endsWith('.cjs')) javascript.push(target);
   }
+}
+
+function verifyPackagedRuntimeDependencies(packagedEntries) {
+  const missing = [];
+  for (const entry of packagedEntries) {
+    if (!entry.endsWith('.js') && !entry.endsWith('.cjs')) continue;
+    const importerPath = path.join(root, entry);
+    if (!fs.existsSync(importerPath)) continue;
+    const source = fs.readFileSync(importerPath, 'utf8');
+    for (const specifier of localRuntimeSpecifiers(source)) {
+      const dependencyPath = resolveLocalRuntimeDependency(importerPath, specifier);
+      if (!dependencyPath) continue;
+      const relativeDependency = path.relative(root, dependencyPath).replaceAll(path.sep, '/');
+      if (!isPackaged(relativeDependency, packagedEntries)) missing.push(`${entry} -> ${relativeDependency}`);
+    }
+  }
+  if (missing.length) {
+    throw new Error(`Packaged runtime dependencies are missing from build.files:\n${[...new Set(missing)].sort().join('\n')}`);
+  }
+}
+
+function localRuntimeSpecifiers(source) {
+  const patterns = [
+    /\b(?:import|export)\s+(?:[^'\"]*?\s+from\s*)?['\"](\.[^'\"]+)['\"]/g,
+    /\bimport\s*\(\s*['\"](\.[^'\"]+)['\"]\s*\)/g,
+    /\brequire\s*\(\s*['\"](\.[^'\"]+)['\"]\s*\)/g
+  ];
+  return patterns.flatMap((pattern) => [...source.matchAll(pattern)].map((match) => match[1]));
+}
+
+function resolveLocalRuntimeDependency(importerPath, specifier) {
+  const candidate = path.resolve(path.dirname(importerPath), specifier);
+  for (const resolved of [candidate, `${candidate}.js`, `${candidate}.cjs`, path.join(candidate, 'index.js')]) {
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) return resolved;
+  }
+  return null;
+}
+
+function isPackaged(relativePath, packagedEntries) {
+  return packagedEntries.some((entry) => entry === relativePath || (entry.endsWith('/**') && relativePath.startsWith(entry.slice(0, -2))));
 }


### PR DESCRIPTION
### Purpose

Repair the v2.1.24 packaged-launch regression and publish the correction as v2.1.25. The v2.1.24 Electron package omitted two locally imported runtime modules from the electron-builder allowlist: `presentation-settings.js`, which prevents startup when `data-store.js` loads, and `financial-reporting.js`, which would prevent the dashboard renderer from loading after startup.

### Work completed

#### Release packaging

- Added `presentation-settings.js` to the packaged-file allowlist.
- Added `financial-reporting.js` to the packaged-file allowlist.
- Bumped the application version from `2.1.24` to `2.1.25` so the corrected package can be distributed as a distinct release and detected by the updater.

#### Regression prevention

- Extended the project integrity check to inspect packaged JavaScript and CommonJS entry files.
- Detects local static imports, re-exports, dynamic imports, and `require()` calls.
- Resolves direct files, implicit `.js` and `.cjs` extensions, and local `index.js` modules.
- Fails the project check with an importer-to-dependency report whenever a local runtime dependency is omitted from `build.files`.

### Files changed

- `package.json` — moved the release version to v2.1.25 and added both missing dashboard runtime modules to the electron-builder `build.files` allowlist.
- `package-lock.json` — kept root package metadata aligned with v2.1.25; no dependency versions or integrity records changed.
- `scripts/check-project.mjs` — added the general packaged-runtime dependency validation that prevents future allowlist omissions.

No files were added, renamed, or deleted.

### User-facing changes

- The packaged Windows application can load the presentation settings required by the data store instead of terminating during launch.
- The packaged dashboard renderer can load its financial reporting module.
- The visible dashboard, charts, night mode, personalisation, and financial behaviour remain as delivered in v2.1.24.
- The displayed/release version becomes v2.1.25.

### Technical changes

- The electron-builder allowlist now contains the complete v2.1.24 dashboard runtime dependency chain.
- Package integrity validation now derives local runtime dependencies from the source instead of relying only on one-off module assertions.
- No dependencies were added, removed, or updated.
- No updater behaviour, network service, telemetry, analytics, cloud storage, security boundary, import flow, export flow, or financial calculation was changed.

### Testing and verification

- **Passed — automated tests:** `npm test`; 276 tests passed.
- **Passed — project and privacy checks:** `npm run check`; JavaScript syntax, public seed safety, package integrity, packaged dependency coverage, and privacy checks passed.
- **Passed — lint:** `npm run lint`.
- **Passed — Windows package assembly through ASAR creation:** electron-builder produced the unpacked Windows application and packaged ASAR.
- **Passed — packaged-file inspection:** both `presentation-settings.js` and `financial-reporting.js` were confirmed inside the generated ASAR.
- **Passed — extracted-package import verification:** `data-store.js`, `financial-reporting.js`, and `presentation-settings.js` imported successfully from the exact extracted ASAR contents.
- **Unavailable — complete NSIS installer build:** the Linux environment does not have Wine; electron-builder stopped at the NSIS stage after creating the Windows application and ASAR.
- **Unavailable — Electron desktop capture/startup:** this container has no X display or permitted desktop session. Windows desktop startup remains covered by the repository's Windows PR workflow.

### Data and migration impact

No stored financial data, database schema, settings schema, imported document, backup, import format, or export format is changed. No migration is required. Existing local data remains untouched.

### Known limitations

- A complete NSIS installer could not be produced locally because Wine is unavailable.
- Interactive Electron startup could not be performed in this headless Linux environment.
- The Windows pull-request workflow must provide the platform-native build/startup confirmation before release.

### Excluded work

- No dashboard, chart, theme, personalisation, finance, storage, import, export, or updater feature changes.
- No replacement or mutation of the published v2.1.24 artefacts.
- No release artefact publication. A merge to `main` was not requested or invoked by this workflow; GitHub subsequently merged this pull request through a separate remote-side action.

### Branch details

- Branch: `fix/packaged-presentation-settings`
- Commit SHA: `35d506afd095dac598e5f73de9ec12a674e258bb`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/29
- Target branch: `main`
- Merge commit: `329ac66f4709df982f6bf1b52c9e38dcec084d97`

### Confirmations

- The change was committed to `fix/packaged-presentation-settings`, not directly to `main`.
- The pull request was opened and confirmed as a draft, then GitHub merged it at `2026-08-09T14:41:59Z` through a separate remote-side action. This workflow did not call a merge operation.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs were committed.
- Only files relevant to the requested packaging repair were changed.