### PR TITLE
[v2.1.26][Maintenance] Deploy browser demo with GitHub Pages

### DIFF
--- a/.github/workflows/deploy-demo-pages.yml
+++ b/.github/workflows/deploy-demo-pages.yml
@@ -1,0 +1,59 @@
+name: Deploy browser demo to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/deploy-demo-pages.yml'
+      - 'demo/**'
+      - 'assets/onestep-money-icon.png'
+      - 'styles.css'
+      - 'date-utils.js'
+      - 'finance-core.js'
+      - 'financial-reporting.js'
+      - 'next-move-priority.js'
+      - 'presentation-settings.js'
+      - 'review-lifecycle.js'
+      - 'scripts/build-pages-site.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+      - name: Build public demo allowlist
+        run: npm run build:pages
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/pages
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Open `http://127.0.0.1:3000`. The demo uses one canonical fictional dataset and 
 
 The demo does not accept real financial documents, create a OneStep account, store financial data in a cloud backend, load analytics or weaken the Electron desktop vault. Desktop-only workflows are either demonstrated with prepared fictional fixtures or labelled as available only in the Windows app. `npm run preview` remains an alias for the same browser-demo server; the desktop-only preview is available at `/desktop-preview`.
 
+### Public GitHub Pages deployment
+
+The public demo is designed to run at [https://cntintheslk-onestepmoney.github.io/onestep-money/](https://cntintheslk-onestepmoney.github.io/onestep-money/).
+
+After the Pages deployment PR is merged, open **Repository Settings → Pages** and set **Source** to **GitHub Actions**. The `Deploy browser demo to GitHub Pages` workflow then deploys relevant changes from `main` automatically and can also be started manually from the Actions tab.
+
+The workflow builds an explicit public allowlist with `npm run build:pages`. It does not publish the Electron application, private storage/import code, tests, packaging output, documents, credentials or financial data. No Jekyll template, second repository, external host or backend is required.
+
 ## Build Windows installer
 
 ```sh

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,14 +6,14 @@
     <meta name="description" content="Explore OneStep Money with a fictional, private, resettable browser demo." />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'" />
     <title>OneStep Money — Interactive Demo</title>
-    <link rel="stylesheet" href="/styles.css" />
-    <link rel="stylesheet" href="/demo/demo.css" />
+    <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./demo/demo.css" />
   </head>
   <body>
     <a class="skip-link" href="#demoMain">Skip to demo content</a>
 
     <dialog id="demoWelcome" class="demo-welcome" open aria-labelledby="demoWelcomeTitle">
-      <div class="demo-welcome-mark"><img src="/assets/onestep-money-icon.png" alt="" /></div>
+      <div class="demo-welcome-mark"><img src="./assets/onestep-money-icon.png" alt="" /></div>
       <p class="eyebrow">INTERACTIVE FICTIONAL DEMO</p>
       <h1 id="demoWelcomeTitle">See how OneStep makes money feel manageable</h1>
       <p>Explore a made-up financial month for Alex Rowan. Change categories, work through Review Inbox, test Financial Safety and reset whenever you like.</p>
@@ -31,7 +31,7 @@
     <div id="demoShell" class="app-shell demo-shell">
       <aside class="sidebar">
         <div class="brand">
-          <img class="brand-mark" src="/assets/onestep-money-icon.png" alt="" aria-hidden="true" />
+          <img class="brand-mark" src="./assets/onestep-money-icon.png" alt="" aria-hidden="true" />
           <div class="brand-copy"><strong><span>OneStep</span> <span>Money</span></strong><span>One clear move at a time.</span></div>
         </div>
         <div class="demo-badge"><span aria-hidden="true">◆</span><span><strong>Browser Demo</strong>Fictional data only</span></div>
@@ -142,6 +142,6 @@
     </dialog>
 
     <div id="demoToast" class="toast demo-toast" role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script type="module" src="/demo/demo-app.js"></script>
+    <script type="module" src="./demo/demo-app.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "preview": "node static-preview-server.js",
     "capture": "electron . --capture-ui",
     "dist:win": "electron-builder --win nsis",
-    "release:win": "electron-builder --win nsis --publish always"
+    "release:win": "electron-builder --win nsis --publish always",
+    "build:pages": "node scripts/build-pages-site.mjs"
   },
   "dependencies": {
     "@napi-rs/canvas": "^1.0.3",

--- a/scripts/build-pages-site.mjs
+++ b/scripts/build-pages-site.mjs
@@ -1,0 +1,77 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+export const PAGE_FILES = Object.freeze([
+  ['demo/index.html', 'index.html'],
+  ['styles.css', 'styles.css'],
+  ['demo/demo.css', 'demo/demo.css'],
+  ['demo/demo-app.js', 'demo/demo-app.js'],
+  ['demo/demo-data.js', 'demo/demo-data.js'],
+  ['demo/demo-state.js', 'demo/demo-state.js'],
+  ['assets/onestep-money-icon.png', 'assets/onestep-money-icon.png'],
+  ['date-utils.js', 'date-utils.js'],
+  ['finance-core.js', 'finance-core.js'],
+  ['financial-reporting.js', 'financial-reporting.js'],
+  ['next-move-priority.js', 'next-move-priority.js'],
+  ['presentation-settings.js', 'presentation-settings.js'],
+  ['review-lifecycle.js', 'review-lifecycle.js']
+]);
+
+export async function buildPagesSite(options = {}) {
+  const root = path.resolve(options.root || repositoryRoot);
+  const output = path.resolve(options.output || path.join(root, 'dist', 'pages'));
+  if (output === root || output === path.parse(output).root) {
+    throw new Error('Refusing to replace a broad Pages output path.');
+  }
+
+  await fs.rm(output, { recursive: true, force: true });
+  await fs.mkdir(output, { recursive: true });
+
+  for (const [sourcePath, publicPath] of PAGE_FILES) {
+    const source = path.join(root, sourcePath);
+    const target = path.join(output, publicPath);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.copyFile(source, target);
+  }
+  await fs.writeFile(path.join(output, '.nojekyll'), '');
+
+  await validatePagesSite(output);
+  return { output, files: PAGE_FILES.map(([, publicPath]) => publicPath) };
+}
+
+async function validatePagesSite(output) {
+  const html = await fs.readFile(path.join(output, 'index.html'), 'utf8');
+  const resourcePaths = [...html.matchAll(/(?:href|src)="([^"]+)"/g)]
+    .map((match) => match[1])
+    .filter((value) => !value.startsWith('#'));
+  for (const resourcePath of resourcePaths) {
+    if (resourcePath.startsWith('/') || /^[a-z][a-z\d+.-]*:/i.test(resourcePath)) {
+      throw new Error(`Pages resource must be project-relative: ${resourcePath}`);
+    }
+    await fs.access(path.resolve(output, resourcePath));
+  }
+
+  const publicPaths = new Set(PAGE_FILES.map(([, publicPath]) => publicPath));
+  for (const [, publicPath] of PAGE_FILES.filter(([, target]) => target.endsWith('.js'))) {
+    const source = await fs.readFile(path.join(output, publicPath), 'utf8');
+    for (const match of source.matchAll(/(?:from|import)\s*(?:\(|)\s*['"]([^'"]+)['"]/g)) {
+      const specifier = match[1];
+      if (!specifier.startsWith('.')) continue;
+      const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(publicPath), specifier));
+      if (!publicPaths.has(resolved)) throw new Error(`Missing public module ${resolved}, imported by ${publicPath}`);
+    }
+  }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  buildPagesSite()
+    .then(({ output, files }) => console.log(`Built ${files.length} public demo files in ${output}`))
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });
+}

--- a/tests/github-pages.test.js
+++ b/tests/github-pages.test.js
@@ -2,10 +2,11 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import { buildPagesSite, PAGE_FILES } from '../scripts/build-pages-site.mjs';
 
-const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 test('Pages build contains only the explicit public demo allowlist', async (context) => {
   const temporary = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-pages-'));

--- a/tests/github-pages.test.js
+++ b/tests/github-pages.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { buildPagesSite, PAGE_FILES } from '../scripts/build-pages-site.mjs';
+
+const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('Pages build contains only the explicit public demo allowlist', async (context) => {
+  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-pages-'));
+  context.after(() => fs.rm(temporary, { recursive: true, force: true }));
+  const output = path.join(temporary, 'site');
+  await buildPagesSite({ root, output });
+
+  const expected = ['.nojekyll', ...PAGE_FILES.map(([, publicPath]) => publicPath)].sort();
+  assert.deepEqual(await listFiles(output), expected);
+  assert.ok(!expected.some((file) => /(?:main-process|preload|data-store|document-import|test|\.map$)/.test(file)));
+});
+
+test('Pages entry point uses project-relative resources that resolve in the artifact', async (context) => {
+  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-pages-paths-'));
+  context.after(() => fs.rm(temporary, { recursive: true, force: true }));
+  const output = path.join(temporary, 'site');
+  await buildPagesSite({ root, output });
+  const html = await fs.readFile(path.join(output, 'index.html'), 'utf8');
+
+  assert.doesNotMatch(html, /(?:href|src)="\//);
+  assert.match(html, /href="\.\/styles\.css"/);
+  assert.match(html, /src="\.\/demo\/demo-app\.js"/);
+  assert.match(html, /connect-src 'none'/);
+  assert.doesNotMatch(html, /https?:\/\//);
+});
+
+test('Pages workflow deploys the allowlisted artifact from main and supports manual runs', async () => {
+  const workflow = await fs.readFile(path.join(root, '.github/workflows/deploy-demo-pages.yml'), 'utf8');
+  assert.match(workflow, /branches: \[main\]/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /permissions:\n  contents: read\n  pages: write\n  id-token: write/);
+  assert.match(workflow, /npm run build:pages/);
+  assert.match(workflow, /actions\/upload-pages-artifact@v3/);
+  assert.match(workflow, /path: dist\/pages/);
+  assert.match(workflow, /actions\/deploy-pages@v4/);
+});
+
+async function listFiles(directory, prefix = '') {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const relative = path.posix.join(prefix, entry.name);
+    if (entry.isDirectory()) files.push(...await listFiles(path.join(directory, entry.name), relative));
+    else files.push(relative);
+  }
+  return files.sort();
+}

--- a/tests/github-pages.test.js
+++ b/tests/github-pages.test.js
@@ -34,7 +34,7 @@ test('Pages entry point uses project-relative resources that resolve in the arti
 });
 
 test('Pages workflow deploys the allowlisted artifact from main and supports manual runs', async () => {
-  const workflow = await fs.readFile(path.join(root, '.github/workflows/deploy-demo-pages.yml'), 'utf8');
+  const workflow = (await fs.readFile(path.join(root, '.github/workflows/deploy-demo-pages.yml'), 'utf8')).replaceAll('\r\n', '\n');
   assert.match(workflow, /branches: \[main\]/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /permissions:\n  contents: read\n  pages: write\n  id-token: write/);


### PR DESCRIPTION
### Purpose

Make the merged v2.1.26 browser demo deploy correctly as the repository's GitHub Pages project site while preserving OneStep's privacy and local-first boundaries.

Closes #99 when merged and deployed.

### Work completed

- Replaced root-relative demo resource paths with project-relative paths compatible with `/onestep-money/`.
- Added a deterministic Pages build using an explicit public-file allowlist.
- Added an official GitHub Pages Actions workflow with automatic relevant-change deployment from `main` and manual dispatch.
- Added cross-platform contract tests for artifact contents, project-site paths, CSP/privacy boundaries and workflow configuration.
- Documented the one-time Pages setting and public URL.

### Files changed

- `.github/workflows/deploy-demo-pages.yml`
- `demo/index.html`
- `scripts/build-pages-site.mjs`
- `tests/github-pages.test.js`
- `package.json`
- `README.md`

### User-facing changes

After this PR is merged and Pages Source is set to GitHub Actions, the fictional browser demo can be deployed at:

`https://cntintheslk-onestepmoney.github.io/onestep-money/`

The existing local demo command and financial interactions are otherwise unchanged.

### Technical changes

- `npm run build:pages` creates `dist/pages` from 13 explicitly allowed runtime files plus `.nojekyll`.
- The build validates entry-point resource resolution and the complete local ES-module dependency graph.
- The workflow uses `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4`.
- Workflow permissions are limited to `contents: read`, `pages: write` and `id-token: write`.
- Deployment concurrency prevents stale overlapping Pages deployments.
- Tests use cross-platform file-URL and line-ending handling.

### Testing and verification

Final GitHub Actions run #111 (Windows job clean retry):

- Focused Pages contract tests: **Passed**
- Full repository tests: **Passed — 294/294 on Linux and Windows**
- Project/privacy checks: **Passed on Linux and Windows**
- Lint: **Passed on Linux and Windows**
- Electron desktop startup smoke test: **Passed on Windows**
- Windows NSIS packaging smoke test: **Passed**
- GitHub Pages hosted deployment: **Skipped until merge and repository Pages Source configuration**
- Rendered public URL walkthrough: **Unavailable until deployment exists**

The first Windows Electron attempt timed out with runner/runtime `UnknownVizError`. A clean rerun passed Electron startup and packaging without code changes, confirming the first result was transient.

### Data and migration impact

No stored-data format or financial migration. No personal data, real documents, accounts, credentials or secrets are introduced. Demo state remains fictional and session-local.

### Known limitations

- GitHub Pages cannot deploy this branch to the production project-site environment before merge under this workflow.
- The repository owner must make the one-time selection **Settings → Pages → Source → GitHub Actions**.
- GitHub Pages supplies hosting headers; the demo also retains its restrictive HTML CSP. No backend or cloud financial storage exists.

### Excluded work

- Demo financial/UI feature changes
- Custom domain
- Second repository or external hosting
- Cloud accounts/backend
- Telemetry or analytics
- Release version changes
- Merging or enabling repository settings

### Branch details

- Branch: `feature/github-pages-deployment`
- Commit SHAs: `67228e7`, `4be2750`, `ae28355`
- Final head SHA: `ae283559bff2e4e391123ae199fdbbecd9d30bce`
- Pull request: #100
- Target branch: `main`

### Confirmations

- No changes committed or pushed directly to `main`.
- PR not merged by this workflow.
- No personal financial data, imported documents, credentials, secrets or sensitive logs committed.
- Only relevant files changed.