### PR TITLE
[v2.1.26][Bug] Restore GitHub Pages demo interactivity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,15 @@ jobs:
       - run: npm test
       - run: npm run check
       - run: npm run lint
+      - name: Built Pages artifact runtime smoke test
+        timeout-minutes: 2
+        run: npm run smoke:pages
+      - name: Current public Pages runtime diagnostic
+        continue-on-error: true
+        timeout-minutes: 2
+        run: npm run smoke:pages
+        env:
+          PAGES_SMOKE_URL: https://cntintheslk-onestepmoney.github.io/onestep-money/
       - name: Electron desktop startup smoke test
         timeout-minutes: 2
         run: npm run capture

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "capture": "electron . --capture-ui",
     "dist:win": "electron-builder --win nsis",
     "release:win": "electron-builder --win nsis --publish always",
-    "build:pages": "node scripts/build-pages-site.mjs"
+    "build:pages": "node scripts/build-pages-site.mjs",
+    "smoke:pages": "electron scripts/pages-runtime-smoke.mjs"
   },
   "dependencies": {
     "@napi-rs/canvas": "^1.0.3",

--- a/scripts/pages-runtime-smoke.mjs
+++ b/scripts/pages-runtime-smoke.mjs
@@ -1,0 +1,139 @@
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import { app, BrowserWindow } from 'electron';
+import { buildPagesSite } from './build-pages-site.mjs';
+
+app.disableHardwareAcceleration();
+
+const publicUrl = String(process.env.PAGES_SMOKE_URL || '').trim();
+let server;
+
+try {
+  const targetUrl = publicUrl || await startBuiltPagesServer();
+  await app.whenReady();
+
+  const runtimeErrors = [];
+  const window = new BrowserWindow({
+    show: false,
+    width: 1280,
+    height: 900,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true
+    }
+  });
+
+  window.webContents.on('console-message', (_event, level, message) => {
+    if (level >= 3) runtimeErrors.push(String(message || 'Browser console error'));
+  });
+  window.webContents.on('render-process-gone', (_event, details) => {
+    runtimeErrors.push(`Renderer stopped: ${details.reason}`);
+  });
+
+  await window.loadURL(targetUrl);
+  const result = await window.webContents.executeJavaScript(`
+    (async () => {
+      const wait = () => new Promise((resolve) => setTimeout(resolve, 50));
+      const requireNode = (selector, label) => {
+        const node = document.querySelector(selector);
+        if (!node) throw new Error('Missing ' + label);
+        return node;
+      };
+      const click = async (selector, label) => {
+        requireNode(selector, label).click();
+        await wait();
+      };
+      const expect = (condition, message) => {
+        if (!condition) throw new Error(message);
+      };
+
+      expect(Boolean(document.querySelector('.demo-badge')), 'Expected the allowlisted Browser Demo artifact.');
+      const welcome = requireNode('#demoWelcome', 'welcome dialog');
+      expect(welcome.open, 'Welcome dialog did not open.');
+      expect(welcome.matches(':modal'), 'Welcome dialog is not modal.');
+
+      await click('#enterDemoButton', 'Explore the demo button');
+      expect(!welcome.open, 'Welcome dialog did not close.');
+
+      await click('[data-view="today"]', 'Today navigation');
+      expect(document.querySelector('#view-today:not([hidden])'), 'Today view did not open.');
+      expect(requireNode('#viewTitle', 'view title').textContent === 'Today', 'Today title did not update.');
+
+      await click('[data-view="payments"]', 'Payments navigation');
+      expect(document.querySelector('#view-payments:not([hidden])'), 'Payments view did not open.');
+
+      await click('#showImportButton', 'fictional import button');
+      const importDialog = requireNode('#importPreviewDialog', 'fictional import dialog');
+      expect(importDialog.open && importDialog.matches(':modal'), 'Fictional import dialog did not open modally.');
+      await click('#cancelImportButton', 'close fictional import button');
+      expect(!importDialog.open, 'Fictional import dialog did not close.');
+
+      const previousTheme = document.documentElement.dataset.theme;
+      await click('#quickThemeButton', 'quick theme button');
+      expect(document.documentElement.dataset.theme !== previousTheme, 'Theme control did not change presentation.');
+
+      await click('#resetDemoButton', 'reset demo button');
+      expect(document.querySelector('#view-dashboard:not([hidden])'), 'Reset did not return to Dashboard.');
+      expect(requireNode('#viewTitle', 'view title').textContent === 'Dashboard', 'Dashboard title was not restored.');
+
+      return { ready: true };
+    })()
+  `, true);
+
+  if (!result?.ready) throw new Error('Pages runtime smoke did not complete.');
+  if (runtimeErrors.length) throw new Error(`Pages runtime emitted ${runtimeErrors.length} browser error(s): ${runtimeErrors[0]}`);
+
+  console.log(publicUrl ? 'Public Pages runtime smoke passed.' : 'Built Pages artifact runtime smoke passed.');
+  window.destroy();
+} catch (error) {
+  console.error(`Pages runtime smoke failed: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  await closeServer();
+  app.quit();
+}
+
+async function startBuiltPagesServer() {
+  const { output } = await buildPagesSite();
+  server = http.createServer(async (request, response) => {
+    try {
+      const requestPath = decodeURIComponent(new URL(request.url, 'http://127.0.0.1').pathname);
+      const relativePath = requestPath === '/' ? 'index.html' : requestPath.replace(/^\/+/, '');
+      const filePath = path.resolve(output, relativePath);
+      const relative = path.relative(output, filePath);
+      if (relative.startsWith('..') || path.isAbsolute(relative)) throw new Error('Invalid path');
+      const body = await fs.readFile(filePath);
+      response.writeHead(200, {
+        'Content-Type': contentType(filePath),
+        'Cache-Control': 'no-store',
+        'X-Content-Type-Options': 'nosniff'
+      });
+      response.end(body);
+    } catch {
+      response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('Not found');
+    }
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Pages smoke server did not start.');
+  return `http://127.0.0.1:${address.port}/`;
+}
+
+function contentType(filePath) {
+  if (filePath.endsWith('.html')) return 'text/html; charset=utf-8';
+  if (filePath.endsWith('.css')) return 'text/css; charset=utf-8';
+  if (filePath.endsWith('.js')) return 'text/javascript; charset=utf-8';
+  if (filePath.endsWith('.png')) return 'image/png';
+  return 'application/octet-stream';
+}
+
+async function closeServer() {
+  if (!server) return;
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/scripts/pages-runtime-smoke.mjs
+++ b/scripts/pages-runtime-smoke.mjs
@@ -135,5 +135,5 @@ function contentType(filePath) {
 
 async function closeServer() {
   if (!server) return;
-  await new Promise((resolve) => server.close(resolve));
+  await new Promise((resolve) => { server.close(resolve); });
 }


### PR DESCRIPTION
### Purpose

Restore the deployed v2.1.26 GitHub Pages demo after the public site rendered an inert Dashboard and incorrectly presented dialog.

Closes #101 when the corrected Pages deployment is verified.

### Work completed

- Added an executable Electron-controlled browser diagnostic for the exact built Pages artifact.
- Added a temporary diagnostic run against the currently deployed public URL.
- Covered welcome-dialog modality/dismissal, Today and Payments navigation, import-dialog modality/dismissal, theme switching and reset.
- Captures browser console errors and renderer termination without logging financial content.

This draft is still under active diagnosis. Production corrections and the final verification record will be added after the first runtime results identify the failing layer.

### Files changed

- `scripts/pages-runtime-smoke.mjs`
- `package.json`
- `.github/workflows/release.yml`

### User-facing changes

None yet. This first draft state reproduces and diagnoses the reported public failure.

### Technical changes

- `npm run smoke:pages` builds and serves the exact Pages allowlist, then drives it in a sandboxed hidden Electron window.
- Windows PR CI runs the artifact smoke as a required check.
- The current production URL is also checked temporarily as a non-blocking diagnostic so configuration/deployment mismatches are visible.

### Testing and verification

- Source inspection: **Passed**
- Static Pages allowlist tests from existing suite: **Previously passed**
- New built-artifact runtime smoke: **Pending GitHub Windows CI**
- Current public Pages runtime diagnostic: **Pending GitHub Windows CI**
- Full Linux/Windows tests, privacy/check, lint, Electron startup and NSIS packaging: **Pending GitHub CI**
- Manual public walkthrough: **Failed — user report; inert controls and incorrect dialog**

### Data and migration impact

No stored-data migration. No personal data, real documents, credentials or secrets. The diagnostic uses only the existing fictional demo and does not emit financial values or content.

### Known limitations

- This draft is intentionally diagnostic until CI captures the exact runtime/deployment difference.
- Public GitHub Pages cannot be corrected until a verified fix is merged and deployed.
- Project-v2 field editing is unavailable through the connected integration.

### Excluded work

- Desktop financial behaviour changes
- New demo features
- Cloud storage, backend, telemetry or analytics
- Release version changes
- Merging or changing `main`

### Branch details

- Branch: `fix/github-pages-demo-runtime`
- Commit SHA: `1285744cd76ea73d41fd00bdeaba5bd44bc6dbe2`
- Pull request: pending creation
- Target branch: `main`

### Confirmations

- No changes committed/pushed directly to `main`.
- PR not merged by this workflow.
- No personal financial data, imported documents, credentials, secrets or sensitive logs committed.
- Only relevant files changed.
