### PR TITLE
[v2.1.26][Bug] Fix browser demo module startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
   test-windows:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/fix/github-pages-demo-recovery'
     runs-on: windows-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -38,14 +41,68 @@ jobs:
       - run: npm run check
       - run: npm run lint
       - name: Built Pages artifact runtime smoke test
-        timeout-minutes: 2
-        run: npm run smoke:pages
-      - name: Current public Pages runtime diagnostic
+        id: built_pages_smoke
         continue-on-error: true
         timeout-minutes: 2
-        run: npm run smoke:pages
+        shell: pwsh
+        run: |
+          npm run smoke:pages 2>&1 | Tee-Object -FilePath built-pages-smoke.log
+          "exit_code=$LASTEXITCODE" >> $env:GITHUB_OUTPUT
+          exit 0
+      - name: Current public Pages runtime diagnostic
+        id: public_pages_smoke
+        continue-on-error: true
+        timeout-minutes: 2
+        shell: pwsh
+        run: |
+          npm run smoke:pages 2>&1 | Tee-Object -FilePath public-pages-smoke.log
+          "exit_code=$LASTEXITCODE" >> $env:GITHUB_OUTPUT
+          exit 0
         env:
           PAGES_SMOKE_URL: https://cntintheslk-onestepmoney.github.io/onestep-money/
+      - name: Report recovery-branch Pages diagnostics
+        if: github.ref == 'refs/heads/fix/github-pages-demo-recovery' && always()
+        uses: actions/github-script@v8
+        env:
+          BUILT_EXIT: ${{ steps.built_pages_smoke.outputs.exit_code }}
+          PUBLIC_EXIT: ${{ steps.public_pages_smoke.outputs.exit_code }}
+        with:
+          script: |
+            const fs = require('fs');
+            const tail = (file) => fs.existsSync(file)
+              ? fs.readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).slice(-12).join('\n')
+              : 'Diagnostic did not produce a log.';
+            const body = [
+              '### Recovery branch Pages diagnostic',
+              '',
+              `Commit: ${context.sha}`,
+              `Built artifact exit: ${process.env.BUILT_EXIT || 'not-run'}`,
+              `Public URL exit: ${process.env.PUBLIC_EXIT || 'not-run'}`,
+              '',
+              '<details><summary>Built artifact technical tail</summary>',
+              '',
+              '~~~text',
+              tail('built-pages-smoke.log'),
+              '~~~',
+              '</details>',
+              '',
+              '<details><summary>Public URL technical tail</summary>',
+              '',
+              '~~~text',
+              tail('public-pages-smoke.log'),
+              '~~~',
+              '</details>'
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 101,
+              body
+            });
+      - name: Enforce built Pages runtime result
+        if: steps.built_pages_smoke.outputs.exit_code != '0'
+        shell: pwsh
+        run: exit 1
       - name: Electron desktop startup smoke test
         timeout-minutes: 2
         run: npm run capture

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Test and release
 
 on:
   push:
-    branches: [main, fix/github-pages-demo-recovery]
+    branches: [main]
     tags: ['v*']
   pull_request:
     branches: [main]
@@ -20,19 +20,13 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - id: tests
-        run: npm test
-      - id: checks
-        run: npm run check
-      - id: lint
-        run: npm run lint
+      - run: npm test
+      - run: npm run check
+      - run: npm run lint
 
   test-windows:
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/fix/github-pages-demo-recovery'
+    if: github.event_name == 'pull_request'
     runs-on: windows-latest
-    permissions:
-      contents: read
-      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -40,136 +34,21 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - id: tests
-        run: npm test
-      - id: checks
-        run: npm run check
-      - id: lint
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          npm run lint 2>&1 | Tee-Object -FilePath lint.log
-          "exit_code=$LASTEXITCODE" >> $env:GITHUB_OUTPUT
-          exit 0
+      - run: npm test
+      - run: npm run check
+      - run: npm run lint
       - name: Built Pages artifact runtime smoke test
-        if: always()
-        id: built_pages_smoke
-        continue-on-error: true
         timeout-minutes: 2
-        shell: pwsh
-        run: |
-          npm run smoke:pages 2>&1 | Tee-Object -FilePath built-pages-smoke.log
-          "exit_code=$LASTEXITCODE" >> $env:GITHUB_OUTPUT
-          exit 0
-      - name: Current public Pages runtime diagnostic
-        if: always()
-        id: public_pages_smoke
-        continue-on-error: true
-        timeout-minutes: 2
-        shell: pwsh
-        run: |
-          npm run smoke:pages 2>&1 | Tee-Object -FilePath public-pages-smoke.log
-          "exit_code=$LASTEXITCODE" >> $env:GITHUB_OUTPUT
-          exit 0
-        env:
-          PAGES_SMOKE_URL: https://cntintheslk-onestepmoney.github.io/onestep-money/
-      - name: Report recovery-branch Pages diagnostics
-        if: github.ref == 'refs/heads/fix/github-pages-demo-recovery' && always()
-        uses: actions/github-script@v8
-        env:
-          TEST_OUTCOME: ${{ steps.tests.outcome }}
-          CHECK_OUTCOME: ${{ steps.checks.outcome }}
-          LINT_OUTCOME: ${{ steps.lint.outcome }}
-          LINT_EXIT: ${{ steps.lint.outputs.exit_code }}
-          BUILT_EXIT: ${{ steps.built_pages_smoke.outputs.exit_code }}
-          PUBLIC_EXIT: ${{ steps.public_pages_smoke.outputs.exit_code }}
-        with:
-          script: |
-            const fs = require('fs');
-            const tail = (file) => fs.existsSync(file)
-              ? fs.readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).slice(-12).join('\n')
-              : 'Diagnostic did not produce a log.';
-            const body = [
-              '### Recovery branch Pages diagnostic',
-              '',
-              `Commit: ${context.sha}`,
-              `Tests: ${process.env.TEST_OUTCOME || 'not-run'}`,
-              `Project/privacy checks: ${process.env.CHECK_OUTCOME || 'not-run'}`,
-              `Lint step: ${process.env.LINT_OUTCOME || 'not-run'}; exit: ${process.env.LINT_EXIT || 'not-run'}`,
-              `Built artifact exit: ${process.env.BUILT_EXIT || 'not-run'}`,
-              `Public URL exit: ${process.env.PUBLIC_EXIT || 'not-run'}`,
-              '',
-              '<details><summary>Built artifact technical tail</summary>',
-              '',
-              '~~~text',
-              tail('built-pages-smoke.log'),
-              '~~~',
-              '</details>',
-              '',
-              '<details><summary>Lint technical tail</summary>',
-              '',
-              '~~~text',
-              tail('lint.log'),
-              '~~~',
-              '</details>',
-              '',
-              '<details><summary>Public URL technical tail</summary>',
-              '',
-              '~~~text',
-              tail('public-pages-smoke.log'),
-              '~~~',
-              '</details>'
-            ].join('\n');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: 101,
-              body
-            });
-      - name: Enforce built Pages runtime result
-        if: steps.built_pages_smoke.outputs.exit_code != '0'
-        shell: pwsh
-        run: exit 1
+        run: npm run smoke:pages
       - name: Electron desktop startup smoke test
-        id: electron_startup
         timeout-minutes: 2
         run: npm run capture
         env:
           FINANCE_CAPTURE_PATH: ${{ runner.temp }}/onestep-money-startup.png
           FINANCE_USER_DATA_PATH: ${{ runner.temp }}/onestep-money-user-data
       - name: Windows packaging smoke test
-        id: windows_packaging
         timeout-minutes: 15
         run: npm run dist:win -- --publish never
-      - name: Report final recovery-branch verification
-        if: github.ref == 'refs/heads/fix/github-pages-demo-recovery' && always()
-        uses: actions/github-script@v8
-        env:
-          TEST_OUTCOME: ${{ steps.tests.outcome }}
-          CHECK_OUTCOME: ${{ steps.checks.outcome }}
-          LINT_EXIT: ${{ steps.lint.outputs.exit_code }}
-          BUILT_EXIT: ${{ steps.built_pages_smoke.outputs.exit_code }}
-          ELECTRON_OUTCOME: ${{ steps.electron_startup.outcome }}
-          PACKAGING_OUTCOME: ${{ steps.windows_packaging.outcome }}
-        with:
-          script: |
-            const body = [
-              '### Final recovery-branch verification',
-              '',
-              `Commit: ${context.sha}`,
-              `Tests: ${process.env.TEST_OUTCOME || 'not-run'}`,
-              `Project/privacy checks: ${process.env.CHECK_OUTCOME || 'not-run'}`,
-              `Lint exit: ${process.env.LINT_EXIT || 'not-run'}`,
-              `Built Pages runtime exit: ${process.env.BUILT_EXIT || 'not-run'}`,
-              `Electron desktop startup: ${process.env.ELECTRON_OUTCOME || 'not-run'}`,
-              `Windows packaging: ${process.env.PACKAGING_OUTCOME || 'not-run'}`
-            ].join('\n');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: 101,
-              body
-            });
 
   release-windows:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -184,12 +63,9 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - id: tests
-        run: npm test
-      - id: checks
-        run: npm run check
-      - id: lint
-        run: npm run lint
+      - run: npm test
+      - run: npm run check
+      - run: npm run lint
       - run: npm run release:win
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,12 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npm test
-      - run: npm run check
-      - run: npm run lint
+      - id: tests
+        run: npm test
+      - id: checks
+        run: npm run check
+      - id: lint
+        run: npm run lint
 
   test-windows:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/fix/github-pages-demo-recovery'
@@ -37,10 +40,14 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npm test
-      - run: npm run check
-      - run: npm run lint
+      - id: tests
+        run: npm test
+      - id: checks
+        run: npm run check
+      - id: lint
+        run: npm run lint
       - name: Built Pages artifact runtime smoke test
+        if: always()
         id: built_pages_smoke
         continue-on-error: true
         timeout-minutes: 2
@@ -50,6 +57,7 @@ jobs:
           "exit_code=$LASTEXITCODE" >> $env:GITHUB_OUTPUT
           exit 0
       - name: Current public Pages runtime diagnostic
+        if: always()
         id: public_pages_smoke
         continue-on-error: true
         timeout-minutes: 2
@@ -64,6 +72,9 @@ jobs:
         if: github.ref == 'refs/heads/fix/github-pages-demo-recovery' && always()
         uses: actions/github-script@v8
         env:
+          TEST_OUTCOME: ${{ steps.tests.outcome }}
+          CHECK_OUTCOME: ${{ steps.checks.outcome }}
+          LINT_OUTCOME: ${{ steps.lint.outcome }}
           BUILT_EXIT: ${{ steps.built_pages_smoke.outputs.exit_code }}
           PUBLIC_EXIT: ${{ steps.public_pages_smoke.outputs.exit_code }}
         with:
@@ -76,6 +87,9 @@ jobs:
               '### Recovery branch Pages diagnostic',
               '',
               `Commit: ${context.sha}`,
+              `Tests: ${process.env.TEST_OUTCOME || 'not-run'}`,
+              `Project/privacy checks: ${process.env.CHECK_OUTCOME || 'not-run'}`,
+              `Lint: ${process.env.LINT_OUTCOME || 'not-run'}`,
               `Built artifact exit: ${process.env.BUILT_EXIT || 'not-run'}`,
               `Public URL exit: ${process.env.PUBLIC_EXIT || 'not-run'}`,
               '',
@@ -126,9 +140,12 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npm test
-      - run: npm run check
-      - run: npm run lint
+      - id: tests
+        run: npm test
+      - id: checks
+        run: npm run check
+      - id: lint
+        run: npm run lint
       - run: npm run release:win
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,12 @@ jobs:
       - id: checks
         run: npm run check
       - id: lint
-        run: npm run lint
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          npm run lint 2>&1 | Tee-Object -FilePath lint.log
+          "exit_code=$LASTEXITCODE" >> $env:GITHUB_OUTPUT
+          exit 0
       - name: Built Pages artifact runtime smoke test
         if: always()
         id: built_pages_smoke
@@ -75,6 +80,7 @@ jobs:
           TEST_OUTCOME: ${{ steps.tests.outcome }}
           CHECK_OUTCOME: ${{ steps.checks.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
+          LINT_EXIT: ${{ steps.lint.outputs.exit_code }}
           BUILT_EXIT: ${{ steps.built_pages_smoke.outputs.exit_code }}
           PUBLIC_EXIT: ${{ steps.public_pages_smoke.outputs.exit_code }}
         with:
@@ -89,7 +95,7 @@ jobs:
               `Commit: ${context.sha}`,
               `Tests: ${process.env.TEST_OUTCOME || 'not-run'}`,
               `Project/privacy checks: ${process.env.CHECK_OUTCOME || 'not-run'}`,
-              `Lint: ${process.env.LINT_OUTCOME || 'not-run'}`,
+              `Lint step: ${process.env.LINT_OUTCOME || 'not-run'}; exit: ${process.env.LINT_EXIT || 'not-run'}`,
               `Built artifact exit: ${process.env.BUILT_EXIT || 'not-run'}`,
               `Public URL exit: ${process.env.PUBLIC_EXIT || 'not-run'}`,
               '',
@@ -97,6 +103,13 @@ jobs:
               '',
               '~~~text',
               tail('built-pages-smoke.log'),
+              '~~~',
+              '</details>',
+              '',
+              '<details><summary>Lint technical tail</summary>',
+              '',
+              '~~~text',
+              tail('lint.log'),
               '~~~',
               '</details>',
               '',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,14 +131,45 @@ jobs:
         shell: pwsh
         run: exit 1
       - name: Electron desktop startup smoke test
+        id: electron_startup
         timeout-minutes: 2
         run: npm run capture
         env:
           FINANCE_CAPTURE_PATH: ${{ runner.temp }}/onestep-money-startup.png
           FINANCE_USER_DATA_PATH: ${{ runner.temp }}/onestep-money-user-data
       - name: Windows packaging smoke test
+        id: windows_packaging
         timeout-minutes: 15
         run: npm run dist:win -- --publish never
+      - name: Report final recovery-branch verification
+        if: github.ref == 'refs/heads/fix/github-pages-demo-recovery' && always()
+        uses: actions/github-script@v8
+        env:
+          TEST_OUTCOME: ${{ steps.tests.outcome }}
+          CHECK_OUTCOME: ${{ steps.checks.outcome }}
+          LINT_EXIT: ${{ steps.lint.outputs.exit_code }}
+          BUILT_EXIT: ${{ steps.built_pages_smoke.outputs.exit_code }}
+          ELECTRON_OUTCOME: ${{ steps.electron_startup.outcome }}
+          PACKAGING_OUTCOME: ${{ steps.windows_packaging.outcome }}
+        with:
+          script: |
+            const body = [
+              '### Final recovery-branch verification',
+              '',
+              `Commit: ${context.sha}`,
+              `Tests: ${process.env.TEST_OUTCOME || 'not-run'}`,
+              `Project/privacy checks: ${process.env.CHECK_OUTCOME || 'not-run'}`,
+              `Lint exit: ${process.env.LINT_EXIT || 'not-run'}`,
+              `Built Pages runtime exit: ${process.env.BUILT_EXIT || 'not-run'}`,
+              `Electron desktop startup: ${process.env.ELECTRON_OUTCOME || 'not-run'}`,
+              `Windows packaging: ${process.env.PACKAGING_OUTCOME || 'not-run'}`
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 101,
+              body
+            });
 
   release-windows:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Test and release
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix/github-pages-demo-recovery]
     tags: ['v*']
   pull_request:
     branches: [main]
@@ -25,7 +25,7 @@ jobs:
       - run: npm run lint
 
   test-windows:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/fix/github-pages-demo-recovery'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/demo/demo-app.js
+++ b/demo/demo-app.js
@@ -30,6 +30,7 @@ bindEvents();
 applyTheme();
 renderAll();
 openWelcome();
+window.dispatchEvent(new Event('onestep-demo-ready'));
 if (loaded.recovered) showToast('The demo state was malformed, so the fictional baseline was restored safely.');
 
 function bindEvents() {

--- a/demo/demo-app.js
+++ b/demo/demo-app.js
@@ -1,7 +1,7 @@
 import {
-  calculateStreak, compareLabels, formatCurrency, formatDate, isTransactionFinanciallyActive,
-  periodTransactions
+  calculateStreak, formatCurrency, formatDate, isTransactionFinanciallyActive, periodTransactions
 } from '../finance-core.js';
+import { compareLabels } from '../presentation-settings.js';
 import { reviewItemPresentation } from '../review-lifecycle.js';
 import {
   actOnDemoReviewItem, applySimulatedImport, categoriseDemoTransaction, deriveDemoView,

--- a/demo/demo-app.js
+++ b/demo/demo-app.js
@@ -30,7 +30,7 @@ bindEvents();
 applyTheme();
 renderAll();
 openWelcome();
-window.dispatchEvent(new Event('onestep-demo-ready'));
+window.dispatchEvent(new window.Event('onestep-demo-ready'));
 if (loaded.recovered) showToast('The demo state was malformed, so the fictional baseline was restored safely.');
 
 function bindEvents() {

--- a/demo/demo-bootstrap.js
+++ b/demo/demo-bootstrap.js
@@ -1,0 +1,25 @@
+(() => {
+  const failureDelay = 2500;
+  const timer = window.setTimeout(showStartupFailure, failureDelay);
+
+  window.addEventListener('onestep-demo-ready', () => {
+    window.clearTimeout(timer);
+    document.documentElement.dataset.demoStartup = 'ready';
+    const failure = document.getElementById('demoStartupError');
+    if (failure) failure.hidden = true;
+  }, { once: true });
+
+  function showStartupFailure() {
+    if (document.documentElement.dataset.demoStartup === 'ready') return;
+    document.documentElement.dataset.demoStartup = 'failed';
+    const welcome = document.getElementById('demoWelcome');
+    if (welcome) welcome.removeAttribute('open');
+    const shell = document.getElementById('demoShell');
+    if (shell) {
+      shell.hidden = true;
+      shell.setAttribute('aria-hidden', 'true');
+    }
+    const failure = document.getElementById('demoStartupError');
+    if (failure) failure.hidden = false;
+  }
+})();

--- a/demo/demo-bootstrap.js
+++ b/demo/demo-bootstrap.js
@@ -1,6 +1,7 @@
 (() => {
   const failureDelay = 2500;
   const timer = window.setTimeout(showStartupFailure, failureDelay);
+  document.getElementById('refreshDemoButton')?.addEventListener('click', () => window.location.reload());
 
   window.addEventListener('onestep-demo-ready', () => {
     window.clearTimeout(timer);

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -1,3 +1,24 @@
+.demo-startup-error {
+  position: fixed;
+  z-index: 2000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: var(--bg);
+}
+.demo-startup-error[hidden] { display: none; }
+.demo-startup-error-card {
+  width: min(560px, 100%);
+  padding: clamp(1.4rem, 5vw, 2.4rem);
+  color: var(--ink);
+  background: var(--panel);
+  border: 1px solid var(--line-strong);
+  border-radius: 24px;
+  box-shadow: var(--shadow-strong);
+}
+.demo-startup-error-card p:not(.eyebrow) { color: var(--ink-soft); line-height: 1.6; }
+
 .skip-link {
   position: fixed;
   z-index: 1000;

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,15 @@
     <link rel="stylesheet" href="./demo/demo.css" />
   </head>
   <body>
+    <section id="demoStartupError" class="demo-startup-error" role="alert" hidden>
+      <div class="demo-startup-error-card">
+        <p class="eyebrow">DEMO STARTUP</p>
+        <h1>The browser demo couldn’t start</h1>
+        <p>No financial information was loaded or sent anywhere. Refresh the page to try again. If this continues, the Windows app remains available as the full private local-first experience.</p>
+        <button class="primary-button" type="button" onclick="location.reload()">Refresh demo</button>
+      </div>
+    </section>
+
     <a class="skip-link" href="#demoMain">Skip to demo content</a>
 
     <dialog id="demoWelcome" class="demo-welcome" open aria-labelledby="demoWelcomeTitle">
@@ -142,6 +151,7 @@
     </dialog>
 
     <div id="demoToast" class="toast demo-toast" role="status" aria-live="polite" aria-atomic="true" hidden></div>
+    <script src="./demo/demo-bootstrap.js"></script>
     <script type="module" src="./demo/demo-app.js"></script>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,7 +15,7 @@
         <p class="eyebrow">DEMO STARTUP</p>
         <h1>The browser demo couldn’t start</h1>
         <p>No financial information was loaded or sent anywhere. Refresh the page to try again. If this continues, the Windows app remains available as the full private local-first experience.</p>
-        <button class="primary-button" type="button" onclick="location.reload()">Refresh demo</button>
+        <button id="refreshDemoButton" class="primary-button" type="button">Refresh demo</button>
       </div>
     </section>
 

--- a/scripts/build-pages-site.mjs
+++ b/scripts/build-pages-site.mjs
@@ -9,6 +9,7 @@ export const PAGE_FILES = Object.freeze([
   ['styles.css', 'styles.css'],
   ['demo/demo.css', 'demo/demo.css'],
   ['demo/demo-app.js', 'demo/demo-app.js'],
+  ['demo/demo-bootstrap.js', 'demo/demo-bootstrap.js'],
   ['demo/demo-data.js', 'demo/demo-data.js'],
   ['demo/demo-state.js', 'demo/demo-state.js'],
   ['assets/onestep-money-icon.png', 'assets/onestep-money-icon.png'],

--- a/scripts/pages-runtime-smoke.cjs
+++ b/scripts/pages-runtime-smoke.cjs
@@ -36,14 +36,17 @@ async function runSmoke() {
     }
   });
 
-  browserWindow.webContents.on('console-message', (_event, level, message) => {
-    if (level >= 3) runtimeErrors.push(String(message || 'Browser console error'));
+  browserWindow.webContents.on('console-message', (_event, details) => {
+    const level = Number(details?.level ?? 0);
+    if (level >= 3) runtimeErrors.push(String(details?.message || 'Browser console error'));
   });
   browserWindow.webContents.on('render-process-gone', (_event, details) => {
     runtimeErrors.push(`Renderer stopped: ${details.reason}`);
   });
 
   await browserWindow.loadURL(targetUrl);
+  await new Promise((resolve) => { setTimeout(resolve, 100); });
+  if (runtimeErrors.length) throw new Error(`Pages runtime emitted ${runtimeErrors.length} browser error(s): ${runtimeErrors[0]}`);
   const result = await browserWindow.webContents.executeJavaScript(`
     (async () => {
       const wait = () => new Promise((resolve) => setTimeout(resolve, 50));

--- a/scripts/pages-runtime-smoke.cjs
+++ b/scripts/pages-runtime-smoke.cjs
@@ -37,7 +37,9 @@ async function runSmoke() {
   });
 
   browserWindow.webContents.on('console-message', (details) => {
-    if (details?.level === 'error') runtimeErrors.push(String(details.message || 'Browser console error'));
+    const message = String(details?.message || 'Browser console error');
+    const ignoredMetaPolicyWarning = message.includes("The Content Security Policy directive 'frame-ancestors' is ignored");
+    if (details?.level === 'error' && !ignoredMetaPolicyWarning) runtimeErrors.push(message);
   });
   browserWindow.webContents.on('render-process-gone', (_event, details) => {
     runtimeErrors.push(`Renderer stopped: ${details.reason}`);

--- a/scripts/pages-runtime-smoke.cjs
+++ b/scripts/pages-runtime-smoke.cjs
@@ -36,9 +36,8 @@ async function runSmoke() {
     }
   });
 
-  browserWindow.webContents.on('console-message', (_event, details) => {
-    const level = Number(details?.level ?? 0);
-    if (level >= 3) runtimeErrors.push(String(details?.message || 'Browser console error'));
+  browserWindow.webContents.on('console-message', (details) => {
+    if (details?.level === 'error') runtimeErrors.push(String(details.message || 'Browser console error'));
   });
   browserWindow.webContents.on('render-process-gone', (_event, details) => {
     runtimeErrors.push(`Renderer stopped: ${details.reason}`);

--- a/scripts/pages-runtime-smoke.cjs
+++ b/scripts/pages-runtime-smoke.cjs
@@ -104,7 +104,7 @@ async function startBuiltPagesServer() {
   server = http.createServer(async (request, response) => {
     try {
       const requestPath = decodeURIComponent(new URL(request.url, 'http://127.0.0.1').pathname);
-      const relativePath = requestPath === '/' ? 'index.html' : requestPath.replace(/^\\/+/, '');
+      const relativePath = requestPath === '/' ? 'index.html' : requestPath.replace(/^\/+/, '');
       const filePath = path.resolve(output, relativePath);
       const relative = path.relative(output, filePath);
       if (relative.startsWith('..') || path.isAbsolute(relative)) throw new Error('Invalid path');

--- a/scripts/pages-runtime-smoke.cjs
+++ b/scripts/pages-runtime-smoke.cjs
@@ -65,6 +65,8 @@ async function runSmoke() {
       };
 
       expect(Boolean(document.querySelector('.demo-badge')), 'Expected the allowlisted Browser Demo artifact.');
+      expect(document.documentElement.dataset.demoStartup === 'ready', 'Demo did not report successful startup.');
+      expect(requireNode('#demoStartupError', 'startup failure panel').hidden, 'Startup failure panel remained visible.');
       const welcome = requireNode('#demoWelcome', 'welcome dialog');
       expect(welcome.open, 'Welcome dialog did not open.');
       expect(welcome.matches(':modal'), 'Welcome dialog is not modal.');


### PR DESCRIPTION
### Purpose

Restore the v2.1.26 GitHub Pages demo after a browser ES-module import failure prevented startup, left the initial dialog non-modal and made the rendered Dashboard controls inert.

Closes #101 when merged and deployed.

### Work completed

- Corrected the demo entry module to import `compareLabels` from `presentation-settings.js`, where it is actually exported.
- Added an executable browser runtime smoke test for the exact allowlisted Pages artifact.
- Added that runtime smoke as a permanent required Windows PR check.
- Added a safe startup fallback that replaces an inert/raw UI with a clear refresh panel if the demo module does not report readiness.
- Kept the fallback script inside the explicit Pages public allowlist and restrictive CSP.
- Removed all temporary recovery-branch triggers, public diagnostics, issue-write permissions and reporting hooks used during investigation.
- Preserved the fictional dataset, session-only state, privacy boundary and financial calculations unchanged.

### Files changed

- `.github/workflows/release.yml`
- `demo/demo-app.js`
- `demo/demo-bootstrap.js`
- `demo/demo.css`
- `demo/index.html`
- `scripts/build-pages-site.mjs`
- `scripts/pages-runtime-smoke.cjs`

### User-facing changes

- The welcome panel opens as a proper modal.
- **Explore the demo** dismisses it.
- Sidebar navigation changes views.
- Theme, reset and fictional import-dialog controls work.
- A future startup failure shows a calm recovery panel instead of an inert Dashboard and malformed dialog.

### Technical changes

- Root cause: `demo-app.js` requested a named export that `finance-core.js` does not provide. Browser ES-module linking rejected the complete entry graph before event binding or rendering.
- The import now comes from the existing authoritative `presentation-settings.js` export.
- `npm run smoke:pages` launches a sandboxed Electron browser against the exact `npm run build:pages` artifact and verifies:
  - successful readiness;
  - hidden fallback state;
  - modal welcome entry/dismissal;
  - Today and Payments navigation;
  - modal fictional import open/close;
  - theme switching;
  - exact reset to Dashboard;
  - absence of unhandled browser errors.
- The lightweight bootstrap uses no backend, telemetry, analytics, remote logging or financial content.

### Testing and verification

Final clean PR workflow run #137 at commit `bbe4ed450cf54694e9bf72308318b2a8b0ba42ff`:

- Full tests: **Passed — 294/294 on Linux and Windows**
- Project/privacy checks: **Passed on Linux and Windows**
- Lint: **Passed on Linux and Windows**
- Built Pages artifact runtime smoke: **Passed**
- Electron desktop startup smoke: **Passed**
- Windows NSIS packaging smoke: **Passed**
- Public URL before merge: **Failed as expected — it still serves the old import until this PR is merged and Pages redeploys**
- Original manual walkthrough: **Failed before fix — user report reproduced**
- Post-deployment public walkthrough: **Pending merge and Pages deployment**

All PR gates completed successfully on Linux and Windows.

### Data and migration impact

No stored-data format or migration. No personal financial data, real documents, accounts, credentials, keys, secrets or sensitive logs. Demo state remains fictional and session-only.

### Known limitations

- The public URL cannot contain this correction until the PR is merged and the Pages workflow deploys `main`.
- A post-deployment public walkthrough is still required to confirm GitHub has served the new artifact.
- The HTML meta CSP cannot enforce `frame-ancestors`; GitHub hosting headers remain authoritative for framing policy. This browser warning is unrelated to the startup defect.
- Project-v2 fields remain unavailable through the connected integration.

### Excluded work

- New demo features
- Desktop financial behaviour changes
- Cloud accounts, backend, telemetry, analytics or remote logging
- Custom domain or hosting changes
- Version changes
- Merge execution by this workflow

### Branch details

- Branch: `fix/github-pages-demo-recovery`
- Commit SHA: `bbe4ed450cf54694e9bf72308318b2a8b0ba42ff`
- Pull request: #104
- Target branch: `main`

### Confirmations

- No changes committed/pushed directly to `main` by this workflow.
- PR not merged by this workflow.
- No personal financial data, imported documents, credentials, secrets or sensitive logs committed.
- Only relevant files changed.
