### PR TITLE
[v2.2.0][Feature] Recurring income and commitment detection

### DIFF
--- a/financial-reporting.js
+++ b/financial-reporting.js
@@ -2,6 +2,8 @@ import {
   ALL_TIME_PERIOD, availableReportingMonths, calculateBudgetAnalysis, calculatePeriodSummary,
   formatCurrency, isExternalCashflowTransaction, periodTransactions
 } from './finance-core.js';
+import { confirmedRecurringTransactionIds, deriveRecurringPatterns } from './recurring-finance.js';
+import { renderRecurringActivityPanel } from './recurring-finance-ui.js';
 
 export function buildFinancialReport(state, period = state.settings?.selectedMonth, now = new Date()) {
   const summary = calculatePeriodSummary(state, period);
@@ -24,7 +26,9 @@ export function buildFinancialReport(state, period = state.settings?.selectedMon
     ...(budget.uncategorisedActual > 0 ? [{ id: 'uncategorised', label: 'Uncategorised', amount: budget.uncategorisedActual, needsReview: true }] : [])
   ].filter((row) => row.amount !== 0).sort((left, right) => right.amount - left.amount || left.label.localeCompare(right.label));
   const recurring = recurringSplit(state, period, budget);
+  const recurringPatterns = deriveRecurringPatterns(state, { includeRejected: true });
   const comparison = period === ALL_TIME_PERIOD ? allTimeComparison(timeline) : monthlyComparison(timeline, period, now);
+  renderRecurringActivityPanel(state);
   return {
     period,
     isAllTime: period === ALL_TIME_PERIOD,
@@ -37,6 +41,7 @@ export function buildFinancialReport(state, period = state.settings?.selectedMon
     categories,
     largestCategory: categories[0] || null,
     recurring,
+    recurringPatterns,
     comparison,
     progress: buildProgress(state),
     wins: buildFinancialWins(state, comparison),
@@ -83,19 +88,20 @@ export function reportTextSummary(report) {
 
 function recurringSplit(state, period, budget) {
   const transactionsById = new Map((state.transactions || []).map((transaction) => [String(transaction.id), transaction]));
+  const confirmedIds = confirmedRecurringTransactionIds(state);
   let committed = 0;
   let flexible = 0;
   for (const row of budget.rows) {
     for (const contribution of row.contributions) {
       const transaction = transactionsById.get(String(contribution.id));
-      if (transaction?.recurring === true) committed += Number(contribution.amount || 0);
+      if (confirmedIds.has(String(transaction?.id))) committed += Number(contribution.amount || 0);
       else flexible += Number(contribution.amount || 0);
     }
   }
   const uncategorisedIds = new Set(budget.uncategorisedTransactionIds.map(String));
   for (const transaction of periodTransactions(state.transactions, period)) {
     if (!uncategorisedIds.has(String(transaction.id))) continue;
-    if (transaction.recurring === true) committed += Number(transaction.outgoing || 0);
+    if (confirmedIds.has(String(transaction.id))) committed += Number(transaction.outgoing || 0);
     else flexible += Number(transaction.outgoing || 0);
   }
   return { committed: roundMoney(committed), flexible: roundMoney(flexible), evidence: committed > 0 ? 'confirmed' : 'insufficient' };

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
       "payslip-record.js",
       "preload-bridge.cjs",
       "presentation-settings.js",
+      "recurring-finance.js",
+      "recurring-finance-ui.js",
       "renderer-app.js",
       "review-lifecycle.js",
       "credit-report-intelligence.js",

--- a/recurring-finance-ui.js
+++ b/recurring-finance-ui.js
@@ -1,0 +1,173 @@
+import {
+  applyRecurringPatternDecision, deriveRecurringPatterns, RECURRING_DECISION
+} from './recurring-finance.js';
+
+let latestState = null;
+let renderScheduled = false;
+
+export function renderRecurringActivityPanel(state) {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  latestState = state;
+  if (renderScheduled) return;
+  renderScheduled = true;
+  queueMicrotask(() => {
+    renderScheduled = false;
+    renderPanel();
+  });
+}
+
+function renderPanel() {
+  const table = document.getElementById('transactionTable');
+  if (!table || !latestState) return;
+  const patterns = deriveRecurringPatterns(latestState, { includeRejected: true });
+  let panel = document.getElementById('recurringActivityPanel');
+  if (!panel) {
+    panel = document.createElement('section');
+    panel.id = 'recurringActivityPanel';
+    panel.className = 'chart-card chart-card-wide';
+    panel.setAttribute('aria-labelledby', 'recurringActivityTitle');
+    table.parentElement?.insertBefore(panel, table.parentElement.querySelector('.filter-bar') || table);
+    panel.addEventListener('click', handleDecision);
+  }
+  panel.replaceChildren();
+
+  const heading = document.createElement('div');
+  heading.className = 'chart-card-heading';
+  const headingCopy = document.createElement('div');
+  const eyebrow = document.createElement('p');
+  eyebrow.className = 'eyebrow';
+  eyebrow.textContent = 'RECURRING ACTIVITY';
+  const title = document.createElement('h3');
+  title.id = 'recurringActivityTitle';
+  title.textContent = 'Income and commitments OneStep recognises';
+  headingCopy.append(eyebrow, title);
+  const count = document.createElement('span');
+  count.className = 'badge';
+  count.textContent = `${patterns.filter((item) => item.confirmationState !== 'rejected').length} detected`;
+  heading.append(headingCopy, count);
+  panel.append(heading);
+
+  const intro = document.createElement('p');
+  intro.className = 'muted';
+  intro.textContent = 'Confirmed patterns can feed later reminders and payday planning. Likely or uncertain patterns stay non-authoritative until the evidence is strong or you confirm them.';
+  panel.append(intro);
+
+  const status = document.createElement('p');
+  status.id = 'recurringActivityStatus';
+  status.className = 'muted';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  panel.append(status);
+
+  if (!patterns.length) {
+    const empty = document.createElement('p');
+    empty.className = 'muted';
+    empty.textContent = 'No reliable recurring pattern is visible in trusted payment history yet.';
+    panel.append(empty);
+    return;
+  }
+
+  const list = document.createElement('div');
+  list.className = 'dashboard-list';
+  for (const pattern of patterns.slice(0, 12)) list.append(patternCard(pattern));
+  panel.append(list);
+}
+
+function patternCard(pattern) {
+  const article = document.createElement('article');
+  article.className = 'review-card';
+  article.dataset.recurringPatternId = pattern.id;
+
+  const heading = document.createElement('div');
+  heading.className = 'review-card-heading';
+  const copy = document.createElement('div');
+  const title = document.createElement('strong');
+  title.textContent = pattern.label;
+  const detail = document.createElement('span');
+  detail.className = 'muted';
+  detail.textContent = [titleCase(pattern.direction), titleCase(pattern.cadence), pattern.purpose].filter(Boolean).join(' · ');
+  copy.append(title, detail);
+  const badge = document.createElement('span');
+  badge.className = `badge ${pattern.confirmationState === 'rejected' ? 'red' : ''}`.trim();
+  badge.textContent = pattern.confirmationState === 'rejected' ? 'Rejected' : titleCase(pattern.confidence);
+  heading.append(copy, badge);
+  article.append(heading);
+
+  const amount = document.createElement('p');
+  amount.className = 'muted';
+  amount.textContent = amountSummary(pattern);
+  article.append(amount);
+
+  if (pattern.nextExpected) {
+    const next = document.createElement('p');
+    next.textContent = `Next expected: ${formatDate(pattern.nextExpected.date)} (${formatDate(pattern.nextExpected.windowStart)}–${formatDate(pattern.nextExpected.windowEnd)} window)`;
+    article.append(next);
+  }
+
+  const why = document.createElement('details');
+  const summary = document.createElement('summary');
+  summary.textContent = 'Why?';
+  const explanation = document.createElement('p');
+  explanation.className = 'muted';
+  explanation.textContent = pattern.why;
+  why.append(summary, explanation);
+  article.append(why);
+
+  if (pattern.confirmationState !== RECURRING_DECISION.REJECTED) {
+    const actions = document.createElement('div');
+    actions.className = 'inline-actions';
+    if (pattern.confirmationState !== RECURRING_DECISION.CONFIRMED) {
+      actions.append(decisionButton('Confirm pattern', pattern.id, RECURRING_DECISION.CONFIRMED, 'primary-button'));
+    }
+    actions.append(decisionButton('Reject pattern', pattern.id, RECURRING_DECISION.REJECTED, 'secondary-button'));
+    article.append(actions);
+  }
+  return article;
+}
+
+function decisionButton(label, patternId, decision, className) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = className;
+  button.textContent = label;
+  button.dataset.recurringDecision = decision;
+  button.dataset.recurringPatternId = patternId;
+  return button;
+}
+
+async function handleDecision(event) {
+  const button = event.target.closest('[data-recurring-decision]');
+  if (!button || !latestState || !window.financeAPI?.saveState) return;
+  const status = document.getElementById('recurringActivityStatus');
+  button.disabled = true;
+  if (status) status.textContent = button.dataset.recurringDecision === RECURRING_DECISION.CONFIRMED ? 'Confirming this pattern…' : 'Rejecting this pattern…';
+  try {
+    const next = applyRecurringPatternDecision(latestState, button.dataset.recurringPatternId, button.dataset.recurringDecision, new Date());
+    latestState = await window.financeAPI.saveState(next);
+    if (status) status.textContent = button.dataset.recurringDecision === RECURRING_DECISION.CONFIRMED
+      ? 'Pattern confirmed. Its expected window can now be used by later financial automation.'
+      : 'Pattern rejected. Identical evidence will stay rejected unless the underlying history materially changes.';
+    renderPanel();
+    window.setTimeout(() => window.location.reload(), 150);
+  } catch (error) {
+    button.disabled = false;
+    if (status) status.textContent = error?.message || 'The recurring-pattern decision could not be saved.';
+  }
+}
+
+function amountSummary(pattern) {
+  const range = pattern.amountRange;
+  if (!range) return `${pattern.occurrences} occurrence${pattern.occurrences === 1 ? '' : 's'}`;
+  const amount = range.min === range.max ? formatMoney(range.min) : `${formatMoney(range.min)}–${formatMoney(range.max)}`;
+  return `${pattern.occurrences} occurrence${pattern.occurrences === 1 ? '' : 's'} · typical ${formatMoney(range.typical)} · observed ${amount}`;
+}
+
+function formatMoney(value) {
+  return new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(Number(value || 0));
+}
+function formatDate(value) {
+  const [year, month, day] = String(value || '').split('-').map(Number);
+  const date = new Date(year, month - 1, day, 12);
+  return Number.isNaN(date.getTime()) ? 'date unavailable' : new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }).format(date);
+}
+function titleCase(value) { return String(value || '').replace(/-/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase()); }

--- a/recurring-finance.js
+++ b/recurring-finance.js
@@ -1,0 +1,311 @@
+const CADENCES = Object.freeze({
+  WEEKLY: 'weekly',
+  FORTNIGHTLY: 'fortnightly',
+  FOUR_WEEKLY: 'four-weekly',
+  MONTHLY: 'monthly',
+  QUARTERLY: 'quarterly',
+  ANNUAL: 'annual'
+});
+
+export const RECURRING_CADENCE = CADENCES;
+export const RECURRING_CONFIDENCE = Object.freeze({ CONFIRMED: 'confirmed', LIKELY: 'likely', UNCERTAIN: 'uncertain' });
+export const RECURRING_DECISION = Object.freeze({ CONFIRMED: 'confirmed', REJECTED: 'rejected' });
+
+export function deriveRecurringPatterns(state = {}, options = {}) {
+  const transactions = (state.transactions || []).filter(isEligibleTransaction);
+  const groups = new Map();
+  for (const transaction of transactions) {
+    const identity = transactionIdentity(transaction);
+    if (!identity) continue;
+    const key = [identity.direction, identity.accountId, identity.merchantKey, identity.purposeKey].join('|');
+    if (!groups.has(key)) groups.set(key, { identity, transactions: [] });
+    groups.get(key).transactions.push(transaction);
+  }
+
+  const patterns = [];
+  for (const group of groups.values()) {
+    const rows = uniqueTransactions(group.transactions).sort((a, b) => localDateKey(a.date).localeCompare(localDateKey(b.date)));
+    if (rows.length < 2) continue;
+    const dates = unique(rows.map((row) => localDateKey(row.date)).filter(Boolean));
+    if (dates.length < 2) continue;
+    const cadence = detectCadence(dates);
+    if (!cadence) continue;
+    const amounts = rows.map(transactionAmount).filter((value) => Number.isFinite(value) && value >= 0);
+    const sourceTransactionIds = rows.map((row) => String(row.id || '')).filter(Boolean);
+    const patternId = stableId('recurring', [group.identity.direction, group.identity.accountId, group.identity.merchantKey, group.identity.purposeKey, cadence].join('|'));
+    const evidenceFingerprint = stableId('evidence', rows.map((row) => [
+      String(row.id || ''),
+      localDateKey(row.date),
+      moneyFingerprint(transactionAmount(row)),
+      String(row.providerTransactionId || ''),
+      String(row.reference || '')
+    ].join(':')).join('|'));
+    const decision = matchingDecision(rows, patternId, evidenceFingerprint);
+    const inferredConfidence = inferConfidence(rows, dates, cadence);
+    const confidence = decision === RECURRING_DECISION.CONFIRMED ? RECURRING_CONFIDENCE.CONFIRMED : inferredConfidence;
+    const amountRange = moneyRange(amounts);
+    const nextExpected = expectedNextOccurrence({ cadence, dates, lastDate: dates.at(-1) });
+    const purpose = displayPurpose(rows, group.identity.purposeKey);
+    const label = displayIdentity(rows, group.identity.merchantKey);
+    patterns.push({
+      id: patternId,
+      evidenceFingerprint,
+      direction: group.identity.direction,
+      accountId: group.identity.accountId,
+      merchantKey: group.identity.merchantKey,
+      purposeKey: group.identity.purposeKey,
+      label,
+      purpose,
+      cadence,
+      confidence,
+      confirmationState: decision || 'unconfirmed',
+      occurrences: dates.length,
+      dates,
+      sourceTransactionIds,
+      amountRange,
+      nextExpected: confidence === RECURRING_CONFIDENCE.CONFIRMED ? nextExpected : null,
+      why: recurringPatternExplanation({ cadence, occurrences: dates.length, label, purpose, amountRange, decision, confidence })
+    });
+  }
+
+  const includeRejected = options.includeRejected !== false;
+  return patterns
+    .filter((pattern) => includeRejected || pattern.confirmationState !== RECURRING_DECISION.REJECTED)
+    .sort(comparePatterns);
+}
+
+export function confirmedRecurringPatterns(state = {}) {
+  return deriveRecurringPatterns(state, { includeRejected: false }).filter((pattern) => pattern.confidence === RECURRING_CONFIDENCE.CONFIRMED);
+}
+
+export function confirmedRecurringTransactionIds(state = {}) {
+  const ids = new Set(confirmedRecurringPatterns(state).flatMap((pattern) => pattern.sourceTransactionIds));
+  for (const transaction of state.transactions || []) {
+    if (transaction?.recurring === true && isEligibleTransaction(transaction)) ids.add(String(transaction.id));
+  }
+  return ids;
+}
+
+export function applyRecurringPatternDecision(state, patternId, decision, now = new Date()) {
+  if (![RECURRING_DECISION.CONFIRMED, RECURRING_DECISION.REJECTED].includes(decision)) throw new TypeError('Recurring pattern decision must be confirmed or rejected.');
+  const pattern = deriveRecurringPatterns(state, { includeRejected: true }).find((item) => item.id === patternId);
+  if (!pattern) throw new Error('This recurring pattern is no longer available. Refresh and review the latest evidence.');
+  const next = structuredClone(state);
+  const decidedAt = validDate(now) ? now.toISOString() : new Date().toISOString();
+  const sourceIds = new Set(pattern.sourceTransactionIds.map(String));
+  for (const transaction of next.transactions || []) {
+    if (!sourceIds.has(String(transaction.id))) continue;
+    transaction.recurringPatternDecision = {
+      patternId: pattern.id,
+      evidenceFingerprint: pattern.evidenceFingerprint,
+      decision,
+      decidedAt
+    };
+    if (decision === RECURRING_DECISION.CONFIRMED) transaction.recurring = true;
+    else if (transaction.recurringPatternDecisionSource === 'pattern') transaction.recurring = false;
+    transaction.recurringPatternDecisionSource = 'pattern';
+  }
+  return next;
+}
+
+export function expectedNextOccurrence(pattern) {
+  const cadence = pattern?.cadence;
+  const lastDate = localDateKey(pattern?.lastDate || pattern?.dates?.at?.(-1));
+  if (!lastDate || !Object.values(CADENCES).includes(cadence)) return null;
+  const [year, month, day] = lastDate.split('-').map(Number);
+  let next;
+  if (cadence === CADENCES.WEEKLY) next = addDays(year, month, day, 7);
+  else if (cadence === CADENCES.FORTNIGHTLY) next = addDays(year, month, day, 14);
+  else if (cadence === CADENCES.FOUR_WEEKLY) next = addDays(year, month, day, 28);
+  else if (cadence === CADENCES.MONTHLY) next = addMonths(year, month, day, 1);
+  else if (cadence === CADENCES.QUARTERLY) next = addMonths(year, month, day, 3);
+  else next = addMonths(year, month, day, 12);
+  const tolerance = [CADENCES.WEEKLY, CADENCES.FORTNIGHTLY, CADENCES.FOUR_WEEKLY].includes(cadence) ? 1 : cadence === CADENCES.MONTHLY ? 3 : 5;
+  return {
+    date: next,
+    windowStart: shiftLocalDate(next, -tolerance),
+    windowEnd: shiftLocalDate(next, tolerance),
+    toleranceDays: tolerance
+  };
+}
+
+export function detectCadence(dates = []) {
+  const ordered = unique(dates.map(localDateKey).filter(Boolean)).sort();
+  if (ordered.length < 2) return '';
+  const intervals = ordered.slice(1).map((date, index) => dateDistance(ordered[index], date));
+  const exactInterval = (minimum, maximum) => intervals.every((days) => days >= minimum && days <= maximum);
+  if (exactInterval(6, 8)) return CADENCES.WEEKLY;
+  if (exactInterval(13, 15)) return CADENCES.FORTNIGHTLY;
+
+  const monthProgression = calendarProgression(ordered, 1, 4);
+  if (exactInterval(27, 29) && !monthProgression) return CADENCES.FOUR_WEEKLY;
+  if (monthProgression) return CADENCES.MONTHLY;
+  if (exactInterval(27, 29)) return CADENCES.FOUR_WEEKLY;
+  if (calendarProgression(ordered, 3, 6)) return CADENCES.QUARTERLY;
+  if (calendarProgression(ordered, 12, 7)) return CADENCES.ANNUAL;
+  return '';
+}
+
+export function recurringPatternExplanation(pattern = {}) {
+  const occurrenceText = `${pattern.occurrences || 0} matching occurrence${pattern.occurrences === 1 ? '' : 's'}`;
+  const amountText = pattern.amountRange?.min === pattern.amountRange?.max
+    ? `with the same amount each time`
+    : pattern.amountRange ? `with amounts normally between ${formatPlainMoney(pattern.amountRange.min)} and ${formatPlainMoney(pattern.amountRange.max)}` : 'with amount evidence unavailable';
+  if (pattern.decision === RECURRING_DECISION.CONFIRMED) return `You confirmed this pattern. OneStep also found ${occurrenceText} on a ${pattern.cadence} cadence ${amountText}.`;
+  if (pattern.decision === RECURRING_DECISION.REJECTED) return `You rejected this pattern for the current evidence. It will stay rejected unless the underlying evidence materially changes.`;
+  return `OneStep found ${occurrenceText} for the same account, direction and payee/purpose on a ${pattern.cadence} cadence ${amountText}.`;
+}
+
+function transactionIdentity(transaction) {
+  const direction = Number(transaction.incoming || 0) > 0 ? 'incoming' : Number(transaction.outgoing || 0) > 0 ? 'outgoing' : '';
+  if (!direction) return null;
+  const merchantKey = normaliseMerchant(transaction.merchantName || transaction.payee || transaction.description || transaction.userDescription);
+  if (!merchantKey) return null;
+  const purposeKey = normalise(transaction.budgetCategoryId || transaction.category || transaction.transactionPurpose || 'unclassified');
+  return { direction, accountId: String(transaction.accountId || 'unknown-account'), merchantKey, purposeKey };
+}
+
+function isEligibleTransaction(transaction = {}) {
+  if (!transaction || !transaction.id || !localDateKey(transaction.date)) return false;
+  if (transaction.financiallyActive === false) return false;
+  if (['possible', 'exact'].includes(transaction.duplicateStatus) && transaction.reviewStatus !== 'accepted') return false;
+  if (['pending', 'rejected'].includes(transaction.importReviewStatus)) return false;
+  if (['confirmed', 'possible'].includes(transaction.transferStatus)) return false;
+  const treatment = normalise(transaction.budgetTreatment);
+  if (['transfer', 'savings_transfer', 'ignored', 'debt_payment'].includes(treatment)) return false;
+  const category = normalise(transaction.category);
+  if (/^(debt|credit card|loan|finance) payment$/.test(category)) return false;
+  return Number(transaction.incoming || 0) > 0 || Number(transaction.outgoing || 0) > 0;
+}
+
+function inferConfidence(rows, dates, cadence) {
+  if (rows.some((row) => row.recurring === true)) return RECURRING_CONFIDENCE.CONFIRMED;
+  const strongCadence = cadence && dates.length >= 4;
+  if (strongCadence) return RECURRING_CONFIDENCE.CONFIRMED;
+  if (dates.length >= 3) return RECURRING_CONFIDENCE.LIKELY;
+  return RECURRING_CONFIDENCE.UNCERTAIN;
+}
+
+function matchingDecision(rows, patternId, evidenceFingerprint) {
+  const decisions = rows.map((row) => row.recurringPatternDecision).filter((decision) => decision
+    && decision.patternId === patternId
+    && decision.evidenceFingerprint === evidenceFingerprint
+    && [RECURRING_DECISION.CONFIRMED, RECURRING_DECISION.REJECTED].includes(decision.decision));
+  if (!decisions.length) return '';
+  const values = new Set(decisions.map((decision) => decision.decision));
+  return values.size === 1 ? decisions[0].decision : '';
+}
+
+function calendarProgression(dates, monthsApart, toleranceDays) {
+  return dates.slice(1).every((date, index) => {
+    const previous = parseLocalDate(dates[index]);
+    const current = parseLocalDate(date);
+    const months = (current.year - previous.year) * 12 + current.month - previous.month;
+    if (months !== monthsApart) return false;
+    if (isMonthEnd(previous) && isMonthEnd(current)) return true;
+    return Math.abs(current.day - previous.day) <= toleranceDays;
+  });
+}
+
+function moneyFingerprint(value) {
+  const amount = Number(value);
+  return Number.isFinite(amount) ? String(Math.round((amount + Number.EPSILON) * 100)) : '';
+}
+
+function transactionAmount(transaction) {
+  return Number(transaction.incoming || 0) > 0 ? Number(transaction.incoming) : Number(transaction.outgoing || 0);
+}
+
+function moneyRange(values) {
+  if (!values.length) return null;
+  const min = roundMoney(Math.min(...values));
+  const max = roundMoney(Math.max(...values));
+  const typical = roundMoney(values.reduce((sum, value) => sum + value, 0) / values.length);
+  return { min, max, typical };
+}
+
+function displayIdentity(rows, fallback) {
+  const source = rows.map((row) => row.merchantName || row.payee || row.userDescription || row.description).find(Boolean);
+  return String(source || fallback || 'Recurring activity').trim();
+}
+
+function displayPurpose(rows, fallback) {
+  const source = rows.map((row) => row.transactionPurpose || row.category).find(Boolean);
+  return String(source || fallback || 'Uncategorised').trim();
+}
+
+function comparePatterns(left, right) {
+  const confidenceRank = { confirmed: 0, likely: 1, uncertain: 2 };
+  const rejectedDifference = Number(left.confirmationState === 'rejected') - Number(right.confirmationState === 'rejected');
+  return rejectedDifference || (confidenceRank[left.confidence] - confidenceRank[right.confidence]) || left.label.localeCompare(right.label);
+}
+
+function uniqueTransactions(rows) {
+  return [...new Map(rows.map((row) => [String(row.id), row])).values()];
+}
+
+function unique(values) { return [...new Set(values)]; }
+function normalise(value) { return String(value || '').trim().toLowerCase().replace(/\s+/g, ' '); }
+function normaliseMerchant(value) {
+  return normalise(value)
+    .replace(/\b(?:card|visa|mastercard|debit|credit|contactless|faster payment|faster payments|direct debit|standing order|bacs|fps|fpi|fpo)\b/g, ' ')
+    .replace(/\b\d{4,}\b/g, ' ')
+    .replace(/\b\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?\b/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim().replace(/\s+/g, ' ');
+}
+
+function localDateKey(value) {
+  const text = String(value || '').slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) return '';
+  const parsed = parseLocalDate(text);
+  const date = new Date(Date.UTC(parsed.year, parsed.month - 1, parsed.day));
+  return date.getUTCFullYear() === parsed.year && date.getUTCMonth() === parsed.month - 1 && date.getUTCDate() === parsed.day ? text : '';
+}
+
+function parseLocalDate(value) {
+  const [year, month, day] = String(value).slice(0, 10).split('-').map(Number);
+  return { year, month, day };
+}
+
+function dateDistance(left, right) {
+  const a = parseLocalDate(left); const b = parseLocalDate(right);
+  return Math.round((Date.UTC(b.year, b.month - 1, b.day) - Date.UTC(a.year, a.month - 1, a.day)) / 86_400_000);
+}
+
+function addDays(year, month, day, days) {
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return utcDateKey(date);
+}
+
+function addMonths(year, month, day, months) {
+  const sourceLastDay = daysInMonth(year, month);
+  const sourceWasMonthEnd = day === sourceLastDay;
+  const targetBase = new Date(Date.UTC(year, month - 1 + months, 1));
+  const targetYear = targetBase.getUTCFullYear();
+  const targetMonth = targetBase.getUTCMonth() + 1;
+  const targetLastDay = daysInMonth(targetYear, targetMonth);
+  return `${targetYear}-${pad(targetMonth)}-${pad(sourceWasMonthEnd ? targetLastDay : Math.min(day, targetLastDay))}`;
+}
+
+function shiftLocalDate(value, days) {
+  const { year, month, day } = parseLocalDate(value);
+  return addDays(year, month, day, days);
+}
+
+function isMonthEnd(value) { return value.day === daysInMonth(value.year, value.month); }
+function daysInMonth(year, month) { return new Date(Date.UTC(year, month, 0)).getUTCDate(); }
+function utcDateKey(date) { return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`; }
+function pad(value) { return String(value).padStart(2, '0'); }
+function roundMoney(value) { return Math.round((Number(value) + Number.EPSILON) * 100) / 100; }
+function validDate(value) { return value instanceof Date && !Number.isNaN(value.getTime()); }
+function formatPlainMoney(value) { return `£${Number(value || 0).toFixed(2)}`; }
+
+function stableId(prefix, value) {
+  let hash = 2166136261;
+  for (const char of String(value)) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${prefix}-${(hash >>> 0).toString(16).padStart(8, '0')}`;
+}

--- a/scripts/build-pages-site.mjs
+++ b/scripts/build-pages-site.mjs
@@ -18,6 +18,8 @@ export const PAGE_FILES = Object.freeze([
   ['financial-reporting.js', 'financial-reporting.js'],
   ['next-move-priority.js', 'next-move-priority.js'],
   ['presentation-settings.js', 'presentation-settings.js'],
+  ['recurring-finance.js', 'recurring-finance.js'],
+  ['recurring-finance-ui.js', 'recurring-finance-ui.js'],
   ['review-lifecycle.js', 'review-lifecycle.js'],
   ['transaction-categorisation.js', 'transaction-categorisation.js']
 ]);

--- a/tests/recurring-finance-persistence.test.js
+++ b/tests/recurring-finance-persistence.test.js
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { FinanceDataStore } from '../data-store.js';
+import { applyRecurringPatternDecision, deriveRecurringPatterns } from '../recurring-finance.js';
+
+const seedPath = new URL('../seed-data.json', import.meta.url);
+
+test('confirmed recurring decision survives restart and encrypted backup restore', async (t) => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-recurring-'));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const store = new FinanceDataStore(directory, seedPath, null, { secureStorage: secureStorage() });
+  await store.initialise();
+
+  let current = (await store.loadState()).state;
+  current.transactions.push(
+    fictionalTransaction('recurring-1', '2026-01-31', 75),
+    fictionalTransaction('recurring-2', '2026-02-28', 79),
+    fictionalTransaction('recurring-3', '2026-03-31', 72)
+  );
+  current = await store.saveState(current);
+  const pattern = deriveRecurringPatterns(current)[0];
+  current = applyRecurringPatternDecision(current, pattern.id, 'confirmed', new Date('2026-04-01T10:00:00.000Z'));
+  current = await store.saveState(current);
+
+  const restarted = new FinanceDataStore(directory, seedPath, null, { secureStorage: secureStorage() });
+  await restarted.initialise();
+  current = (await restarted.loadState()).state;
+  assert.equal(deriveRecurringPatterns(current)[0].confirmationState, 'confirmed');
+
+  const backupPath = path.join(directory, 'fictional-recurring.osmb');
+  await restarted.createPortableBackup(backupPath, 'fictional-passphrase', current);
+  const changed = structuredClone(current);
+  for (const transaction of changed.transactions) delete transaction.recurringPatternDecision;
+  await restarted.saveState(changed);
+
+  const restored = await restarted.restorePortableBackup(backupPath, 'fictional-passphrase');
+  assert.equal(restored.status, 'restored');
+  assert.equal(deriveRecurringPatterns(restored.state)[0].confirmationState, 'confirmed');
+});
+
+function fictionalTransaction(id, date, outgoing) {
+  return {
+    id, date, budgetMonth: date.slice(0, 7), accountId: 'fictional-current-account',
+    description: 'Fictional Energy Service', category: 'Household', incoming: 0, outgoing,
+    duplicateStatus: 'none', reviewStatus: 'not_required', importReviewStatus: 'trusted', financiallyActive: true, transferStatus: 'no'
+  };
+}
+
+function secureStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(value, 'utf8'),
+    decryptString: (value) => value.toString('utf8')
+  };
+}

--- a/tests/recurring-finance.test.js
+++ b/tests/recurring-finance.test.js
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  applyRecurringPatternDecision, deriveRecurringPatterns, detectCadence, expectedNextOccurrence,
+  RECURRING_CONFIDENCE
+} from '../recurring-finance.js';
+
+const tx = (id, date, amount, overrides = {}) => ({
+  id, date, accountId: 'account-a', description: 'Fictional Utility', category: 'Household', incoming: 0, outgoing: amount,
+  duplicateStatus: 'none', reviewStatus: 'not_required', importReviewStatus: 'trusted', financiallyActive: true, transferStatus: 'no', ...overrides
+});
+const state = (transactions) => ({ meta: { revision: 0 }, transactions });
+
+test('detects fixed monthly bill conservatively', () => {
+  const patterns = deriveRecurringPatterns(state([
+    tx('m1','2026-01-15',42), tx('m2','2026-02-15',42), tx('m3','2026-03-15',42), tx('m4','2026-04-15',42)
+  ]));
+  assert.equal(patterns.length, 1);
+  assert.equal(patterns[0].cadence, 'monthly');
+  assert.equal(patterns[0].confidence, RECURRING_CONFIDENCE.CONFIRMED);
+  assert.deepEqual(patterns[0].amountRange, { min: 42, max: 42, typical: 42 });
+});
+
+test('variable monthly utility keeps cadence', () => {
+  const [pattern] = deriveRecurringPatterns(state([
+    tx('u1','2026-01-28',55), tx('u2','2026-02-28',71), tx('u3','2026-03-28',49), tx('u4','2026-04-28',65)
+  ]));
+  assert.equal(pattern.cadence, 'monthly');
+  assert.deepEqual(pattern.amountRange, { min: 49, max: 71, typical: 60 });
+});
+
+test('variable monthly salary is separate incoming activity', () => {
+  const rows = [
+    tx('s1','2026-01-31',2100,{description:'Fictional Employer A',category:'Income',incoming:2100,outgoing:0}),
+    tx('s2','2026-02-28',2185,{description:'Fictional Employer A',category:'Income',incoming:2185,outgoing:0}),
+    tx('s3','2026-03-31',2050,{description:'Fictional Employer A',category:'Income',incoming:2050,outgoing:0}),
+    tx('s4','2026-04-30',2200,{description:'Fictional Employer A',category:'Income',incoming:2200,outgoing:0})
+  ];
+  const [pattern] = deriveRecurringPatterns(state(rows));
+  assert.equal(pattern.direction, 'incoming');
+  assert.equal(pattern.cadence, 'monthly');
+});
+
+test('four-weekly income stays distinct from monthly', () => {
+  assert.equal(detectCadence(['2026-01-02','2026-01-30','2026-02-27','2026-03-27']), 'four-weekly');
+});
+
+test('detects fortnightly payment', () => {
+  assert.equal(detectCadence(['2026-01-05','2026-01-19','2026-02-02','2026-02-16']), 'fortnightly');
+});
+
+test('detects quarterly and annual patterns', () => {
+  assert.equal(detectCadence(['2025-01-31','2025-04-30','2025-07-31','2025-10-31']), 'quarterly');
+  assert.equal(detectCadence(['2024-02-29','2025-02-28','2026-02-28']), 'annual');
+});
+
+test('one-off and irregular activity remain one-off', () => {
+  assert.equal(deriveRecurringPatterns(state([tx('one','2026-01-10',30)])).length, 0);
+  assert.equal(detectCadence(['2026-01-01','2026-01-17','2026-03-04']), '');
+});
+
+test('internal transfers and debt payments are excluded', () => {
+  const rows = [
+    tx('t1','2026-01-01',100,{transferStatus:'confirmed'}), tx('t2','2026-02-01',100,{transferStatus:'confirmed'}),
+    tx('d1','2026-01-10',50,{budgetTreatment:'debt_payment'}), tx('d2','2026-02-10',50,{budgetTreatment:'debt_payment'})
+  ];
+  assert.equal(deriveRecurringPatterns(state(rows)).length, 0);
+});
+
+test('duplicate and review-inactive records are excluded', () => {
+  const rows = [
+    tx('a1','2026-01-10',20), tx('a2','2026-02-10',20),
+    tx('bad','2026-03-10',20,{duplicateStatus:'possible',reviewStatus:'pending',financiallyActive:false})
+  ];
+  const [pattern] = deriveRecurringPatterns(state(rows));
+  assert.equal(pattern.occurrences, 2);
+  assert.equal(pattern.confidence, RECURRING_CONFIDENCE.UNCERTAIN);
+});
+
+test('same merchant on different accounts remains distinct', () => {
+  const rows = [
+    tx('a1','2026-01-10',20), tx('a2','2026-02-10',20), tx('a3','2026-03-10',20),
+    tx('b1','2026-01-12',20,{accountId:'account-b'}), tx('b2','2026-02-12',20,{accountId:'account-b'}), tx('b3','2026-03-12',20,{accountId:'account-b'})
+  ];
+  assert.equal(deriveRecurringPatterns(state(rows)).length, 2);
+});
+
+test('rejected pattern stays rejected until evidence changes materially', () => {
+  const original = state([tx('r1','2026-01-10',20), tx('r2','2026-02-10',20), tx('r3','2026-03-10',20)]);
+  const [pattern] = deriveRecurringPatterns(original);
+  const rejected = applyRecurringPatternDecision(original, pattern.id, 'rejected', new Date('2026-03-11T12:00:00Z'));
+  assert.equal(deriveRecurringPatterns(rejected)[0].confirmationState, 'rejected');
+  const amountChanged = structuredClone(rejected);
+  amountChanged.transactions[2].outgoing = 25;
+  assert.notEqual(deriveRecurringPatterns(amountChanged)[0].confirmationState, 'rejected');
+  const changed = structuredClone(rejected);
+  changed.transactions.push(tx('r4','2026-04-10',21));
+  assert.notEqual(deriveRecurringPatterns(changed)[0].confirmationState, 'rejected');
+});
+
+test('confirmed pattern decision is persisted in transaction metadata and survives cloning', () => {
+  const original = state([tx('c1','2026-01-10',20), tx('c2','2026-02-10',20), tx('c3','2026-03-10',20)]);
+  const [pattern] = deriveRecurringPatterns(original);
+  const confirmed = applyRecurringPatternDecision(original, pattern.id, 'confirmed', new Date('2026-03-11T12:00:00Z'));
+  const restarted = structuredClone(confirmed);
+  const [restoredPattern] = deriveRecurringPatterns(restarted);
+  assert.equal(restoredPattern.confirmationState, 'confirmed');
+  assert.equal(restoredPattern.confidence, 'confirmed');
+  assert.ok(restarted.transactions.every((row) => row.recurringPatternDecision?.decision === 'confirmed'));
+});
+
+test('next expected occurrence handles month and year boundaries with local dates', () => {
+  assert.deepEqual(expectedNextOccurrence({cadence:'monthly',dates:['2026-01-31']}), {
+    date:'2026-02-28',windowStart:'2026-02-25',windowEnd:'2026-03-03',toleranceDays:3
+  });
+  assert.equal(expectedNextOccurrence({cadence:'annual',dates:['2024-02-29']}).date, '2025-02-28');
+});


### PR DESCRIPTION
### Purpose
Implement #73 so OneStep can conservatively recognise recurring incoming and outgoing financial activity from trusted local history, preserve user confirmation/rejection, and expose confirmed expected occurrences for later v2.2.0 reminders/payday/forecast consumers.

### Work completed
- Added deterministic recurring-pattern detection for weekly, fortnightly, four-weekly, monthly, quarterly and annual cadences.
- Added separate pattern identity by direction, account, merchant/payee and purpose so separate income streams and account-specific activity are not merged.
- Added conservative exclusions for financially inactive records, pending/rejected import review, possible/exact duplicate quarantine, transfers, ignored/savings-transfer records and debt-payment treatment.
- Added variable-amount support with observed min/max and typical amount without requiring identical values.
- Added explainable confirmed/likely/uncertain certainty classes.
- Added persistent user Confirm/Reject decisions using source-transaction metadata and evidence fingerprints.
- Rejected evidence remains rejected while unchanged, but materially changed dates/amount/source evidence is re-evaluated.
- Added local-calendar expected next occurrence/window calculation for confirmed patterns, including month/year boundaries.
- Added a Payments recurring-activity surface with cadence, confidence, purpose, amount range, expected date/window, Why? explanation and Confirm/Reject controls.
- Updated committed-vs-flexible reporting to consume confirmed recurring pattern membership while retaining existing explicit manual recurring flags.
- Preserved existing Statement Intelligence recurring observations and transaction provenance; no historical transaction is silently recategorised.
- Added the two new local modules to the browser-demo explicit public allowlist after the first CI run correctly identified the dependency closure.

### Files changed
- `recurring-finance.js`
- `recurring-finance-ui.js`
- `financial-reporting.js`
- `package.json`
- `scripts/build-pages-site.mjs`
- `tests/recurring-finance.test.js`
- `tests/recurring-finance-persistence.test.js`

### User-facing changes
- Payments now surfaces detected recurring income/commitment patterns with calm confidence labels rather than presenting uncertain patterns as guaranteed bills.
- Users can explicitly confirm or reject a pattern.
- Confirmed patterns show an expected next date/window and feed the existing committed-vs-flexible reporting view.
- Rejected identical evidence stays rejected until the underlying evidence materially changes.

### Technical changes
- Recurring patterns are derived from financially eligible local transaction history rather than rewriting historical records.
- Stable local pattern IDs use direction/account/merchant-purpose/cadence identity; a separate evidence fingerprint includes source IDs, dates, penny-rounded amounts and provider/reference evidence.
- Explicit decisions persist as `recurringPatternDecision` metadata on source transactions, which existing additive state migration/backup handling preserves.
- No stored-data schema version increase is required; existing migration code preserves unknown transaction metadata.
- Merchant/payee and purpose fields are consumed separately where current #39-compatible fields are present.
- The implementation exposes reusable pure functions for later #75/#79/#84 consumers and does not duplicate #71 execution/safety logic.
- The browser demo keeps its explicit allowlist model; only `recurring-finance.js` and `recurring-finance-ui.js` were added because `financial-reporting.js` imports them.
- No telemetry, analytics, cloud merchant service or other network dependency was introduced.

### Testing and verification
- **Passed:** focused recurrence/date test suite locally — 13/13.
- **Passed:** local syntax checks for `recurring-finance.js`, `recurring-finance-ui.js`, `financial-reporting.js`, and persistence coverage.
- **Passed:** GitHub Actions run #151 — Ubuntu `npm test`.
- **Passed:** GitHub Actions run #151 — Ubuntu `npm run check` including privacy checks.
- **Passed:** GitHub Actions run #151 — Ubuntu `npm run lint`.
- **Passed:** GitHub Actions run #151 — Windows `npm test`.
- **Passed:** GitHub Actions run #151 — Windows `npm run check` including privacy checks.
- **Passed:** GitHub Actions run #151 — Windows `npm run lint`.
- **Passed:** GitHub Actions run #151 — built Pages artifact runtime smoke test.
- **Passed:** GitHub Actions run #151 — Electron desktop startup smoke test on Windows.
- **Passed:** GitHub Actions run #151 — Windows packaging smoke test.
- **Failed then fixed:** run #150 found two Pages allowlist tests because the new local modules were not yet listed; commit `df6d0d4b77e0db6d4d8dbbba8120ee04e4959818` corrected the explicit allowlist and run #151 passed completely.
- **Unavailable:** hands-on/manual Electron interaction, Light/Night visual inspection and completed NSIS installer installation verification in this chat environment. Automated Electron startup/Windows packaging are not represented as manual testing or a completed installer test.

### Data and migration impact
No schema-version bump or destructive migration. Explicit confirmation/rejection is stored as additive metadata on existing source transactions so current migration, encrypted state persistence and backup/restore retain it. The persistence test verifies confirmation survives restart and encrypted backup/restore. Derived pattern totals/dates are recalculated from authoritative transaction history rather than persisted as financial truth. Existing statement-level `recurringObservation` provenance remains untouched.

### Known limitations
- This branch provides recurrence detection/confirmation only; it does not deliver reminders, payday calculation, forecasting or general automation rules.
- Merchant/purpose grouping consumes the current available transaction fields and can use #39 semantics where present; final release integration should confirm the completed #39 interface remains compatible.
- GitHub Project custom-field mutation is not exposed by the connected tools available in this chat, so Project Status/Branch/Start Date were not fabricated.
- Hands-on Electron visual/interaction checks are unavailable in this chat environment; CI has verified startup and packaging, not subjective UI appearance or completed installer installation.

### Excluded work
Reminder delivery, payday calculations, Safe Until Payday, automation rule editor, automated category mutation, full calendar UI, AI Companion, cloud detection, external money movement and unrelated UI redesign.

### Branch details
- Branch: `feature/recurring-finance-detection`
- Commit SHA: `df6d0d4b77e0db6d4d8dbbba8120ee04e4959818`
- Principal implementation commit: `f05ea17aaff847b0e5eb6b305844d5c84ebb57e7`
- Pull request: #113
- Target branch: `main`

### Confirmations
- No changes committed/pushed directly to `main`.
- PR not merged by this workflow.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs committed.
- Only relevant files changed.

Implements #73.