### PR TITLE
[v2.2.0][Feature] Automatic statement reconciliation

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
       "review-lifecycle.js",
       "credit-report-intelligence.js",
       "statement-intelligence.js",
+      "statement-reconciliation.js",
       "transaction-categorisation.js",
       "transaction-ledger.js",
       "seed-data.json",

--- a/statement-intelligence.js
+++ b/statement-intelligence.js
@@ -3,17 +3,30 @@ import {
   isTransactionFinanciallyActive, matchStatementAccount, syncStatementAccount
 } from './finance-core.js';
 import { synchroniseReviewItems } from './review-lifecycle.js';
+import {
+  applyStatementReconciliationMatches,
+  buildStatementReconciliationPlan,
+  STATEMENT_RECONCILIATION_CLASS
+} from './statement-reconciliation.js';
 
 export function buildStatementImportPlan(state, preview, documentId = '') {
   if (preview?.kind !== 'statement') throw new Error('Statement Intelligence only accepts bank-statement previews.');
   const accounts = state.accounts || [];
   const accountMatch = matchStatementAccount(accounts, preview);
   const duplicates = findDuplicateCandidates(state.transactions || [], preview.records || []);
-  const exactIds = new Set(duplicates.exact.map((item) => item.incoming.id));
-  const possibleIds = new Set(duplicates.possible.map((item) => item.incoming.id));
-  const newRecords = (preview.records || []).filter((record) => !exactIds.has(record.id));
+  const reconciliation = buildStatementReconciliationPlan(state, preview, { documentId, duplicates });
+  const classificationById = new Map(reconciliation.items.map((item) => [String(item.incoming?.id || ''), item]));
+  const reviewItems = reconciliation.items.filter((item) => item.safetyClass === 'review_required');
+  const reviewIds = new Set(reviewItems.map((item) => String(item.incoming?.id || '')));
+  const automaticMatches = reconciliation.items.filter((item) => [
+    STATEMENT_RECONCILIATION_CLASS.EXACT_MATCH,
+    STATEMENT_RECONCILIATION_CLASS.COMPATIBLE_UPDATE,
+    STATEMENT_RECONCILIATION_CLASS.NO_CHANGE
+  ].includes(item.classification));
+  const automaticMatchIds = new Set(automaticMatches.map((item) => String(item.incoming?.id || '')));
+  const newRecords = (preview.records || []).filter((record) => !automaticMatchIds.has(String(record.id || '')));
   const trustedHistory = (state.transactions || []).filter(isTransactionFinanciallyActive);
-  const trustedNewRecords = preview.reconciled ? newRecords.filter((record) => !possibleIds.has(record.id)) : [];
+  const trustedNewRecords = preview.reconciled ? newRecords.filter((record) => !reviewIds.has(String(record.id || ''))) : [];
   const recurring = detectRecurringTransactions(trustedHistory, trustedNewRecords);
   const transferMatches = matchInternalTransfers([...trustedHistory, ...trustedNewRecords], accounts)
     .filter((match) => trustedNewRecords.some((record) => record.id === match.debitId || record.id === match.creditId));
@@ -21,13 +34,19 @@ export function buildStatementImportPlan(state, preview, documentId = '') {
   const configuredCurrency = String(state.profile?.currency || 'GBP').toUpperCase();
   const statementCurrency = String(preview.accountIdentity?.currency || preview.summary?.currency || '').toUpperCase();
   const currencyConflict = Boolean(statementCurrency && statementCurrency !== configuredCurrency);
-  const warnings = statementWarnings(preview, accountMatch, balance, currencyConflict, statementCurrency, configuredCurrency, possibleIds.size);
-  const recordPlans = (preview.records || []).map((record) => ({
-    record,
-    action: exactIds.has(record.id) ? 'already-known' : possibleIds.has(record.id) ? 'needs-review' : 'add',
-    recurring: recurring.find((item) => item.transactionId === record.id) || null,
-    transfer: transferMatches.find((item) => item.debitId === record.id || item.creditId === record.id) || null
-  }));
+  const warnings = statementWarnings(preview, accountMatch, balance, currencyConflict, statementCurrency, configuredCurrency, reconciliation.counts.needsReview);
+  const recordPlans = (preview.records || []).map((record) => {
+    const reconciliationItem = classificationById.get(String(record.id || ''));
+    return {
+      record,
+      action: reconciliationItem?.safetyClass === 'review_required'
+        ? 'needs-review'
+        : automaticMatchIds.has(String(record.id || '')) ? 'already-known' : 'add',
+      reconciliation: reconciliationItem || null,
+      recurring: recurring.find((item) => item.transactionId === record.id) || null,
+      transfer: transferMatches.find((item) => item.debitId === record.id || item.creditId === record.id) || null
+    };
+  });
   const canApply = accountMatch.status === 'matched' && !currencyConflict && preview.records?.length > 0;
 
   return {
@@ -37,97 +56,155 @@ export function buildStatementImportPlan(state, preview, documentId = '') {
     balance,
     recordPlans,
     duplicates,
+    reconciliation,
     newRecords,
     recurring,
     transferMatches,
     warnings,
     currencyConflict,
     canApply,
+    expectedRevision: reconciliation.expectedRevision,
     counts: {
       total: preview.records?.length || 0,
-      new: newRecords.length,
-      add: recordPlans.filter((item) => item.action === 'add').length,
-      alreadyKnown: recordPlans.filter((item) => item.action === 'already-known').length,
-      needsReview: recordPlans.filter((item) => item.action === 'needs-review').length,
+      new: reconciliation.counts.newTransactions,
+      add: reconciliation.counts.newTransactions,
+      alreadyKnown: reconciliation.counts.matchedAutomatically + reconciliation.counts.noChange,
+      needsReview: reconciliation.counts.needsReview,
       recurring: recurring.length,
-      transfers: transferMatches.length
+      transfers: transferMatches.length,
+      matchedAutomatically: reconciliation.counts.matchedAutomatically,
+      automaticUpdates: reconciliation.counts.automaticUpdates,
+      duplicatesIgnoredOrQuarantined: reconciliation.counts.duplicatesIgnoredOrQuarantined,
+      noChange: reconciliation.counts.noChange
     },
     basisToken: statementStateToken(state, preview, documentId)
   };
 }
 
-export function applyStatementImportPlan(state, preview, reviewedPlan, documentId = '', importedAt = new Date().toISOString()) {
+export function applyStatementImportPlan(state, preview, reviewedPlan, documentId = '', importedAt = new Date().toISOString(), options = {}) {
   const currentPlan = buildStatementImportPlan(state, preview, documentId);
+  if (currentPlan.expectedRevision !== reviewedPlan?.expectedRevision) {
+    throw stalePlanError();
+  }
   if (currentPlan.basisToken !== reviewedPlan?.basisToken) {
-    throw new Error('Financial information changed after this preview was prepared. Review the refreshed statement plan before importing.');
+    throw stalePlanError();
   }
   if (!currentPlan.canApply) throw new Error(currentPlan.warnings[0] || 'This statement needs review before it can be imported.');
   if ((state.importBatches || []).some((batch) => batch.documentId === documentId)) {
-    throw new Error('This statement already has a completed import batch.');
+    const error = new Error('This statement already has a completed import batch. No duplicate changes were made.');
+    error.code = 'STATEMENT_IMPORT_ALREADY_APPLIED';
+    throw error;
   }
 
   const next = structuredClone(state);
   next.transactions ||= [];
   next.importBatches ||= [];
   next.overdrafts ||= [];
+  const batchId = createId('import');
+  const reconciliationResult = applyStatementReconciliationMatches(next, currentPlan.reconciliation, {
+    documentId,
+    importBatchId: batchId,
+    importedAt
+  });
+  injectFault(options, 'after-existing-match-reconciliation');
+
   const recurringById = new Map(currentPlan.recurring.map((item) => [item.transactionId, item]));
-  const possibleIds = new Set(currentPlan.duplicates.possible.map((item) => item.incoming.id));
-  const possibleMatches = new Map(currentPlan.duplicates.possible.map((item) => [item.incoming.id, item.existing.id]));
+  const reviewById = new Map(currentPlan.reconciliation.items
+    .filter((item) => item.safetyClass === 'review_required')
+    .map((item) => [String(item.incoming?.id || ''), item]));
   const addedIds = new Set();
-  for (const duplicate of currentPlan.duplicates.exact) {
-    const existing = next.transactions.find((item) => item.id === duplicate.existing.id);
-    if (!existing || !documentId) continue;
-    existing.sourceDocumentIds = [...new Set([...(existing.sourceDocumentIds || []), existing.sourceDocumentId, documentId].filter(Boolean))];
-  }
   for (const record of currentPlan.newRecords) {
     const observation = recurringById.get(record.id);
+    const review = reviewById.get(String(record.id || ''));
     next.transactions.push({
       ...record,
       sourceDocumentId: documentId || record.sourceDocumentId || '',
       sourceDocumentIds: [...new Set([...(record.sourceDocumentIds || []), documentId || record.sourceDocumentId].filter(Boolean))],
-      duplicateStatus: possibleIds.has(record.id) ? 'possible' : 'none',
-      reviewStatus: possibleIds.has(record.id) ? 'pending' : 'not_required',
+      reconciliationProvenance: [...(Array.isArray(record.reconciliationProvenance) ? record.reconciliationProvenance : []), {
+        documentId,
+        importBatchId: batchId,
+        reconciledAt: importedAt,
+        evidence: review?.evidence || 'new-statement-record',
+        classification: review?.classification || STATEMENT_RECONCILIATION_CLASS.NEW_RECORD
+      }],
+      duplicateStatus: review ? 'possible' : 'none',
+      reviewStatus: review ? 'pending' : 'not_required',
       importReviewStatus: preview.reconciled ? 'trusted' : 'pending',
-      financiallyActive: Boolean(preview.reconciled) && !possibleIds.has(record.id),
-      duplicateCandidateId: possibleMatches.get(record.id) || '',
-      recurring: record.recurring || observation?.confidence === 'confirmed',
-      recurringObservation: observation || null
+      financiallyActive: Boolean(preview.reconciled) && !review,
+      duplicateCandidateId: review?.existingTransactionId || '',
+      duplicateCandidateIds: review?.candidateTransactionIds || [],
+      reconciliationStatus: review ? 'review_required' : 'reconciled',
+      reconciliationEvidence: review?.evidence || 'new-statement-record',
+      recurring: record.recurring || (!review && observation?.confidence === 'confirmed'),
+      recurringObservation: review ? null : observation || null
     });
     addedIds.add(record.id);
   }
+  injectFault(options, 'after-new-records');
 
   applyTransferEvidence(next.transactions, currentPlan.transferMatches, addedIds);
   const account = next.accounts.find((item) => item.id === currentPlan.accountMatch.account.id);
   const balanceAction = syncStatementAccount(next, account, preview, documentId);
   const stateDocument = (next.documents || []).find((document) => document.id === documentId);
   if (stateDocument) stateDocument.parseStatus = 'imported';
+  const needsReview = currentPlan.counts.needsReview > 0 || !preview.reconciled;
   next.importBatches.push({
-    id: createId('import'),
+    id: batchId,
     documentId,
     kind: 'statement',
     importedAt,
     recordCount: currentPlan.newRecords.length,
     parsedRecordCount: preview.records.length,
-    exactDuplicateCount: currentPlan.counts.alreadyKnown,
-    possibleDuplicateCount: currentPlan.counts.needsReview,
+    exactDuplicateCount: currentPlan.reconciliation.counts.exactMatches,
+    possibleDuplicateCount: currentPlan.reconciliation.counts.possibleDuplicates,
     reconciled: Boolean(preview.reconciled),
-    reconciliationState: preview.reconciled ? 'reconciled' : 'review-required',
+    reconciliationState: needsReview ? 'review-required' : 'reconciled',
+    reconciliationSummary: {
+      matchedAutomatically: currentPlan.counts.matchedAutomatically,
+      automaticUpdates: currentPlan.counts.automaticUpdates,
+      newTransactions: currentPlan.counts.new,
+      needsReview: currentPlan.counts.needsReview,
+      duplicatesIgnoredOrQuarantined: currentPlan.counts.duplicatesIgnoredOrQuarantined,
+      noChange: currentPlan.counts.noChange
+    },
+    reviewCount: currentPlan.counts.needsReview,
+    noChangeCount: currentPlan.counts.noChange,
     statementStartDate: preview.summary?.statementStartDate || '',
     statementEndDate: preview.summary?.statementEndDate || '',
     accountId: account.id
   });
+  injectFault(options, 'before-review-synchronisation');
+  const synchronised = synchroniseReviewItems(next, new Date(importedAt));
+  injectFault(options, 'before-return');
   return {
-    state: synchroniseReviewItems(next, new Date(importedAt)),
+    state: synchronised,
     result: {
       added: currentPlan.newRecords.length,
+      newTransactions: currentPlan.counts.new,
       alreadyKnown: currentPlan.counts.alreadyKnown,
+      matchedAutomatically: reconciliationResult.matchedAutomatically,
+      automaticUpdates: reconciliationResult.automaticUpdates,
       needsReview: currentPlan.counts.needsReview,
+      duplicatesIgnoredOrQuarantined: currentPlan.counts.duplicatesIgnoredOrQuarantined,
+      noChange: reconciliationResult.noChange,
       balanceAction,
       recurring: currentPlan.counts.recurring,
       transfers: currentPlan.counts.transfers,
-      awaitingImportReview: !preview.reconciled
+      awaitingImportReview: !preview.reconciled,
+      reviewRequired: currentPlan.counts.needsReview > 0
     }
   };
+}
+
+function stalePlanError() {
+  const error = new Error('Financial information changed after this preview was prepared. Review the refreshed statement plan before importing.');
+  error.code = 'STATEMENT_RECONCILIATION_STALE_REVISION';
+  return error;
+}
+
+function injectFault(options, point) {
+  if (typeof options?.faultInjector !== 'function') return;
+  options.faultInjector(point);
 }
 
 function balanceChangePlan(account, preview) {
@@ -144,14 +221,14 @@ function balanceChangePlan(account, preview) {
   return { action: 'update', reason: 'newer-reconciled-balance', statementDate, closingBalance, currentBalance: account.currentBalance };
 }
 
-function statementWarnings(preview, accountMatch, balance, currencyConflict, statementCurrency, configuredCurrency, possibleCount) {
+function statementWarnings(preview, accountMatch, balance, currencyConflict, statementCurrency, configuredCurrency, reviewCount) {
   const warnings = [...(preview.warnings || [])];
   if (accountMatch.status === 'conflict') warnings.push('Account needs confirmation. The selected account conflicts with identifiers read from this statement, so OneStep will not apply it.');
   if (accountMatch.status === 'ambiguous') warnings.push(`Account needs confirmation. This statement could match ${accountMatch.candidates.length} accounts.`);
   if (accountMatch.status === 'unmatched') warnings.push('Account needs confirmation. OneStep could not safely match this statement to an account.');
   if (balance.action === 'historical-only') warnings.push('Statement transactions can be imported, but this statement is older than the balance OneStep already has. The current account balance will be preserved.');
   if (currencyConflict) warnings.push(`Currency needs review. This statement uses ${statementCurrency}, but this OneStep profile uses ${configuredCurrency}. No financial changes will be applied.`);
-  if (possibleCount) warnings.push(`${possibleCount} transaction${possibleCount === 1 ? '' : 's'} look similar to existing payments but cannot be proven to be duplicates. They are marked for review and will remain visible.`);
+  if (reviewCount) warnings.push(`${reviewCount} transaction${reviewCount === 1 ? '' : 's'} cannot be reconciled automatically. They will stay outside trusted totals until reviewed.`);
   return [...new Set(warnings)];
 }
 
@@ -175,6 +252,7 @@ function applyTransferEvidence(transactions, matches, addedIds) {
 function statementStateToken(state, preview, documentId) {
   return JSON.stringify({
     documentId,
+    revision: Number.isInteger(state.meta?.revision) ? state.meta.revision : 0,
     accountHint: preview.accountHint || '',
     preview: {
       reconciled: Boolean(preview.reconciled),
@@ -183,7 +261,11 @@ function statementStateToken(state, preview, documentId) {
       records: (preview.records || []).map((item) => [item.id, item.accountId, item.date, item.incoming, item.outgoing, item.description, item.reference, item.runningBalance, item.providerTransactionId])
     },
     accounts: (state.accounts || []).map((item) => [item.id, item.institution, item.accountReference, item.type, item.currentBalance, item.statementDate]),
-    transactions: (state.transactions || []).map((item) => [item.id, item.accountId, item.date, item.incoming, item.outgoing, item.description, item.reference, item.runningBalance, item.providerTransactionId]),
+    transactions: (state.transactions || []).map((item) => [
+      item.id, item.accountId, item.date, item.incoming, item.outgoing, item.description, item.reference, item.runningBalance,
+      item.providerTransactionId, item.category, item.categorySource, item.budgetCategoryId, item.budgetCategorySource,
+      item.merchantName, item.merchantSource, item.descriptionSource, item.sourceDocumentId, item.sourceDocumentIds
+    ]),
     overdrafts: (state.overdrafts || []).map((item) => [item.id, item.accountId, item.currentBalance, item.limit, item.status]),
     importBatches: (state.importBatches || []).map((item) => [item.id, item.documentId, item.importedAt])
   });

--- a/statement-reconciliation.js
+++ b/statement-reconciliation.js
@@ -1,0 +1,368 @@
+const AUTOMATION_SAFETY = Object.freeze({
+  SAFE_AUTOMATIC: 'safe_automatic',
+  REVIEW_REQUIRED: 'review_required'
+});
+
+const AUTOMATION_CERTAINTY = Object.freeze({
+  CERTAIN: 'certain',
+  AMBIGUOUS: 'ambiguous',
+  CONFLICTING: 'conflicting',
+  INSUFFICIENT: 'insufficient'
+});
+
+export const STATEMENT_RECONCILIATION_CLASS = Object.freeze({
+  EXACT_MATCH: 'exact_authoritative_match',
+  COMPATIBLE_UPDATE: 'high_confidence_compatible_update',
+  NEW_RECORD: 'new_record',
+  POSSIBLE_DUPLICATE: 'possible_duplicate_conflict',
+  REVIEW_REQUIRED: 'insufficient_evidence_review_required',
+  NO_CHANGE: 'no_change'
+});
+
+const SAFE_FILL_FIELDS = Object.freeze([
+  'providerTransactionId',
+  'reference',
+  'description',
+  'runningBalance',
+  'merchantName'
+]);
+
+export function buildStatementReconciliationPlan(state, preview, options = {}) {
+  const documentId = String(options.documentId || '');
+  const existing = Array.isArray(state?.transactions) ? state.transactions : [];
+  const incoming = Array.isArray(preview?.records) ? preview.records : [];
+  const exactPairs = new Map((options.duplicates?.exact || []).map((pair) => [String(pair.incoming?.id || ''), pair]));
+  const indexes = buildExistingIndexes(existing);
+  const items = incoming.map((record) => classifyRecord(record, indexes, exactPairs.get(String(record?.id || '')), documentId));
+  return {
+    kind: 'statement-reconciliation-plan',
+    documentId,
+    expectedRevision: normaliseRevision(state?.meta?.revision),
+    items,
+    counts: summarise(items)
+  };
+}
+
+export function applyStatementReconciliationMatches(state, plan, options = {}) {
+  if (!state || typeof state !== 'object') throw new TypeError('A financial state is required for statement reconciliation.');
+  const expectedRevision = normaliseRevision(plan?.expectedRevision);
+  const actualRevision = normaliseRevision(state?.meta?.revision);
+  if (expectedRevision !== actualRevision) {
+    const error = new Error('Financial information changed after this reconciliation preview was prepared. Review the refreshed statement plan before importing.');
+    error.code = 'STATEMENT_RECONCILIATION_STALE_REVISION';
+    throw error;
+  }
+
+  const documentId = String(options.documentId || plan?.documentId || '');
+  const importBatchId = String(options.importBatchId || '');
+  const importedAt = validIso(options.importedAt) || new Date().toISOString();
+  const transactions = Array.isArray(state.transactions) ? state.transactions : [];
+  let matchedAutomatically = 0;
+  let automaticUpdates = 0;
+  let noChange = 0;
+
+  for (const item of plan?.items || []) {
+    if (![STATEMENT_RECONCILIATION_CLASS.EXACT_MATCH, STATEMENT_RECONCILIATION_CLASS.COMPATIBLE_UPDATE, STATEMENT_RECONCILIATION_CLASS.NO_CHANGE].includes(item.classification)) continue;
+    const existing = transactions.find((transaction) => String(transaction?.id || '') === String(item.existingTransactionId || ''));
+    if (!existing) {
+      const error = new Error('A transaction selected for reconciliation is no longer available.');
+      error.code = 'STATEMENT_RECONCILIATION_TARGET_MISSING';
+      throw error;
+    }
+    if (manualConflictFields(existing, item.incoming).length) {
+      const error = new Error('A manual transaction value changed before statement reconciliation could be applied.');
+      error.code = 'STATEMENT_RECONCILIATION_MANUAL_CONFLICT';
+      throw error;
+    }
+
+    const changedFields = applySafePatch(existing, item.patch || {});
+    const provenanceChanged = attachProvenance(existing, {
+      documentId,
+      importBatchId,
+      importedAt,
+      evidence: item.evidence,
+      classification: item.classification
+    });
+    if (changedFields.length || provenanceChanged) matchedAutomatically += 1;
+    if (changedFields.length) automaticUpdates += 1;
+    if (!changedFields.length && !provenanceChanged) noChange += 1;
+  }
+
+  return { matchedAutomatically, automaticUpdates, noChange };
+}
+
+function classifyRecord(record, indexes, exactPair, documentId) {
+  if (!hasMinimumEvidence(record)) {
+    return reviewItem(record, [], 'minimum-evidence-missing', AUTOMATION_CERTAINTY.INSUFFICIENT);
+  }
+
+  const providerMatches = providerCandidates(indexes, record);
+  if (providerMatches.length > 1) {
+    return reviewItem(record, providerMatches, 'multiple-provider-id-matches', AUTOMATION_CERTAINTY.AMBIGUOUS);
+  }
+  if (providerMatches.length === 1) {
+    const providerMatch = providerMatches[0];
+    if (manualConflictFields(providerMatch, record).length) {
+      return reviewItem(record, [providerMatch], 'manual-value-conflict', AUTOMATION_CERTAINTY.CONFLICTING);
+    }
+    const patch = safeMissingFieldPatch(providerMatch, record);
+    const alreadyLinked = documentId && sourceDocumentIds(providerMatch).includes(documentId);
+    if (!Object.keys(patch).length && alreadyLinked) {
+      return automaticItem(record, providerMatch, STATEMENT_RECONCILIATION_CLASS.NO_CHANGE, 'source-already-linked', {}, false);
+    }
+    return automaticItem(
+      record, providerMatch, Object.keys(patch).length ? STATEMENT_RECONCILIATION_CLASS.COMPATIBLE_UPDATE : STATEMENT_RECONCILIATION_CLASS.EXACT_MATCH,
+      'provider-id', patch, true
+    );
+  }
+
+  const coreCandidates = indexes.core.get(coreIdentityKey(record)) || [];
+  const manualConflicts = coreCandidates.filter((candidate) => manualConflictFields(candidate, record).length);
+  if (manualConflicts.length) {
+    return reviewItem(record, coreCandidates, 'manual-value-conflict', AUTOMATION_CERTAINTY.CONFLICTING);
+  }
+  if (coreCandidates.length > 1) {
+    return reviewItem(record, coreCandidates, 'multiple-plausible-matches', AUTOMATION_CERTAINTY.AMBIGUOUS);
+  }
+
+  const exact = exactPair?.existing || exactAuthoritativeCandidate(coreCandidates, record);
+  if (exact) {
+    const patch = safeMissingFieldPatch(exact, record);
+    const alreadyLinked = documentId && sourceDocumentIds(exact).includes(documentId);
+    if (!Object.keys(patch).length && alreadyLinked) {
+      return automaticItem(record, exact, STATEMENT_RECONCILIATION_CLASS.NO_CHANGE, 'source-already-linked', {}, false);
+    }
+    const classification = Object.keys(patch).length
+      ? STATEMENT_RECONCILIATION_CLASS.COMPATIBLE_UPDATE
+      : STATEMENT_RECONCILIATION_CLASS.EXACT_MATCH;
+    const evidence = exactPair?.evidence || providerEvidence(exact, record) || 'transaction-identity';
+    return automaticItem(record, exact, classification, evidence, patch, true);
+  }
+
+  if (coreCandidates.length === 1) {
+    const candidate = coreCandidates[0];
+    const evidence = compatibleEvidence(candidate, record);
+    if (evidence) {
+      const patch = safeMissingFieldPatch(candidate, record);
+      if (Object.keys(patch).length) {
+        return automaticItem(record, candidate, STATEMENT_RECONCILIATION_CLASS.COMPATIBLE_UPDATE, evidence, patch, true);
+      }
+    }
+    return reviewItem(record, [candidate], 'compatible-core-without-deterministic-identity', AUTOMATION_CERTAINTY.AMBIGUOUS);
+  }
+
+  return {
+    incoming: record,
+    classification: STATEMENT_RECONCILIATION_CLASS.NEW_RECORD,
+    existingTransactionId: '',
+    candidateTransactionIds: [],
+    patch: {},
+    evidence: 'no-existing-core-match',
+    safetyClass: AUTOMATION_SAFETY.SAFE_AUTOMATIC,
+    certainty: AUTOMATION_CERTAINTY.CERTAIN,
+    automatic: true
+  };
+}
+
+function automaticItem(record, existing, classification, evidence, patch, automatic) {
+  return {
+    incoming: record,
+    classification,
+    existingTransactionId: String(existing?.id || ''),
+    candidateTransactionIds: [String(existing?.id || '')].filter(Boolean),
+    patch,
+    evidence,
+    safetyClass: AUTOMATION_SAFETY.SAFE_AUTOMATIC,
+    certainty: AUTOMATION_CERTAINTY.CERTAIN,
+    automatic
+  };
+}
+
+function reviewItem(record, candidates, evidence, certainty) {
+  return {
+    incoming: record,
+    classification: certainty === AUTOMATION_CERTAINTY.INSUFFICIENT
+      ? STATEMENT_RECONCILIATION_CLASS.REVIEW_REQUIRED
+      : STATEMENT_RECONCILIATION_CLASS.POSSIBLE_DUPLICATE,
+    existingTransactionId: candidates.length === 1 ? String(candidates[0]?.id || '') : '',
+    candidateTransactionIds: candidates.map((candidate) => String(candidate?.id || '')).filter(Boolean),
+    patch: {},
+    evidence,
+    safetyClass: AUTOMATION_SAFETY.REVIEW_REQUIRED,
+    certainty,
+    automatic: false
+  };
+}
+
+function summarise(items) {
+  const count = (classification) => items.filter((item) => item.classification === classification).length;
+  const exactMatches = count(STATEMENT_RECONCILIATION_CLASS.EXACT_MATCH);
+  const automaticUpdates = count(STATEMENT_RECONCILIATION_CLASS.COMPATIBLE_UPDATE);
+  const newTransactions = count(STATEMENT_RECONCILIATION_CLASS.NEW_RECORD);
+  const possibleDuplicates = count(STATEMENT_RECONCILIATION_CLASS.POSSIBLE_DUPLICATE);
+  const insufficientEvidence = count(STATEMENT_RECONCILIATION_CLASS.REVIEW_REQUIRED);
+  const noChange = count(STATEMENT_RECONCILIATION_CLASS.NO_CHANGE);
+  return {
+    total: items.length,
+    matchedAutomatically: exactMatches + automaticUpdates,
+    exactMatches,
+    automaticUpdates,
+    newTransactions,
+    needsReview: possibleDuplicates + insufficientEvidence,
+    possibleDuplicates,
+    insufficientEvidence,
+    duplicatesIgnoredOrQuarantined: exactMatches + possibleDuplicates + noChange,
+    noChange
+  };
+}
+
+function hasMinimumEvidence(record) {
+  if (!record || !String(record.accountId || '').trim() || !/^\d{4}-\d{2}-\d{2}$/.test(String(record.date || ''))) return false;
+  const incoming = moneyPennies(record.incoming);
+  const outgoing = moneyPennies(record.outgoing);
+  return (incoming > 0 && outgoing === 0) || (outgoing > 0 && incoming === 0);
+}
+
+function coreIdentityKey(item) {
+  return [String(item?.accountId || ''), String(item?.date || ''), moneyPennies(item?.incoming), moneyPennies(item?.outgoing)].join('|');
+}
+
+function exactAuthoritativeCandidate(candidates, incoming) {
+  if (candidates.length !== 1) return null;
+  const candidate = candidates[0];
+  if (providerEvidence(candidate, incoming)) return candidate;
+  const sameDescription = normalise(candidate.description) === normalise(incoming.description);
+  const sameReference = normalise(candidate.reference) === normalise(incoming.reference);
+  return sameDescription && sameReference ? candidate : null;
+}
+
+function compatibleEvidence(existing, incoming) {
+  if (providerEvidence(existing, incoming)) return 'provider-id';
+  const reference = nonEmptyEqual(existing.reference, incoming.reference);
+  const description = nonEmptyEqualNormalised(existing.description, incoming.description);
+  if (reference && description) return 'reference-and-description';
+  if (reference && isMissing(existing.description) && !isMissing(incoming.description)) return 'reference-with-missing-description';
+  if (description && isMissing(existing.reference) && !isMissing(incoming.reference)) return 'description-with-missing-reference';
+  return '';
+}
+
+function buildExistingIndexes(existing) {
+  const core = new Map();
+  const provider = new Map();
+  for (const candidate of existing || []) {
+    addToIndex(core, coreIdentityKey(candidate), candidate);
+    const providerId = String(candidate?.providerTransactionId || '').trim();
+    if (providerId) addToIndex(provider, `${String(candidate?.accountId || '')}|${providerId}`, candidate);
+  }
+  return { core, provider };
+}
+
+function addToIndex(index, key, value) {
+  const rows = index.get(key) || [];
+  rows.push(value);
+  index.set(key, rows);
+}
+
+function providerCandidates(indexes, incoming) {
+  const providerId = String(incoming?.providerTransactionId || '').trim();
+  if (!providerId) return [];
+  return indexes.provider.get(`${String(incoming?.accountId || '')}|${providerId}`) || [];
+}
+
+function providerEvidence(existing, incoming) {
+  const left = String(existing?.providerTransactionId || '').trim();
+  const right = String(incoming?.providerTransactionId || '').trim();
+  return left && right && left === right ? 'provider-id' : '';
+}
+
+function safeMissingFieldPatch(existing, incoming) {
+  const patch = {};
+  for (const field of SAFE_FILL_FIELDS) {
+    if (!isMissing(existing?.[field]) || isMissing(incoming?.[field])) continue;
+    patch[field] = incoming[field];
+  }
+  return patch;
+}
+
+function applySafePatch(existing, patch) {
+  const changed = [];
+  for (const [field, value] of Object.entries(patch || {})) {
+    if (!SAFE_FILL_FIELDS.includes(field) || !isMissing(existing[field]) || isMissing(value)) continue;
+    existing[field] = value;
+    changed.push(field);
+  }
+  return changed;
+}
+
+function manualConflictFields(existing, incoming) {
+  const conflicts = [];
+  const manualPairs = [
+    ['categorySource', 'category'],
+    ['budgetCategorySource', 'budgetCategoryId'],
+    ['merchantSource', 'merchantName'],
+    ['descriptionSource', 'description']
+  ];
+  for (const [sourceField, valueField] of manualPairs) {
+    if (String(existing?.[sourceField] || '').toLowerCase() !== 'manual') continue;
+    if (isMissing(incoming?.[valueField]) || isMissing(existing?.[valueField])) continue;
+    if (normalise(existing[valueField]) !== normalise(incoming[valueField])) conflicts.push(valueField);
+  }
+  return conflicts;
+}
+
+function attachProvenance(transaction, entry) {
+  const beforeDocumentIds = sourceDocumentIds(transaction);
+  const afterDocumentIds = [...new Set([...beforeDocumentIds, entry.documentId].filter(Boolean))];
+  transaction.sourceDocumentIds = afterDocumentIds;
+  if (!transaction.sourceDocumentId && entry.documentId) transaction.sourceDocumentId = entry.documentId;
+
+  const history = Array.isArray(transaction.reconciliationProvenance) ? transaction.reconciliationProvenance : [];
+  const provenanceKey = [entry.documentId, entry.importBatchId, entry.evidence, entry.classification].join('|');
+  const alreadyRecorded = history.some((item) => [item?.documentId || '', item?.importBatchId || '', item?.evidence || '', item?.classification || ''].join('|') === provenanceKey);
+  if (!alreadyRecorded && (entry.documentId || entry.importBatchId)) {
+    transaction.reconciliationProvenance = [...history, {
+      documentId: entry.documentId,
+      importBatchId: entry.importBatchId,
+      reconciledAt: entry.importedAt,
+      evidence: entry.evidence,
+      classification: entry.classification
+    }];
+  }
+  return afterDocumentIds.length !== beforeDocumentIds.length || !alreadyRecorded;
+}
+
+function sourceDocumentIds(transaction) {
+  return [...new Set([...(Array.isArray(transaction?.sourceDocumentIds) ? transaction.sourceDocumentIds : []), transaction?.sourceDocumentId].filter(Boolean).map(String))];
+}
+
+function moneyPennies(value) {
+  const amount = Number(value || 0);
+  return Number.isFinite(amount) ? Math.round((amount + Number.EPSILON) * 100) : Number.NaN;
+}
+
+function nonEmptyEqual(left, right) {
+  return !isMissing(left) && !isMissing(right) && String(left).trim() === String(right).trim();
+}
+
+function nonEmptyEqualNormalised(left, right) {
+  return !isMissing(left) && !isMissing(right) && normalise(left) === normalise(right);
+}
+
+function isMissing(value) {
+  return value === undefined || value === null || String(value).trim() === '';
+}
+
+function normalise(value) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim().replace(/\s+/g, ' ');
+}
+
+function normaliseRevision(value) {
+  const revision = Number(value);
+  return Number.isInteger(revision) && revision >= 0 ? revision : 0;
+}
+
+function validIso(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+}

--- a/tests/statement-reconciliation-integration.test.js
+++ b/tests/statement-reconciliation-integration.test.js
@@ -1,0 +1,225 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { FinanceDataStore } from '../data-store.js';
+import { isTransactionFinanciallyActive } from '../finance-core.js';
+import { activeReviewItems } from '../review-lifecycle.js';
+import { applyStatementImportPlan, buildStatementImportPlan } from '../statement-intelligence.js';
+import { buildStatementReconciliationPlan, STATEMENT_RECONCILIATION_CLASS } from '../statement-reconciliation.js';
+
+const seedPath = new URL('../seed-data.json', import.meta.url);
+const passphrase = 'fictional-reconciliation-backup';
+
+const transaction = (overrides = {}) => ({
+  id: overrides.id || `transaction-${Math.random()}`,
+  accountId: 'account-1',
+  date: '2026-08-01',
+  description: 'Fictional merchant',
+  reference: 'REF-1',
+  providerTransactionId: '',
+  incoming: 0,
+  outgoing: 10,
+  runningBalance: 90,
+  transferStatus: 'no',
+  ...overrides
+});
+
+const baseState = () => ({
+  meta: { revision: 12 },
+  profile: { currency: 'GBP' },
+  accounts: [{ id: 'account-1', name: 'Main account', institution: 'Fictional Bank', accountReference: '••••1234', type: 'Current account', currentBalance: 100, statementDate: '2026-07-31' }],
+  transactions: [],
+  overdrafts: [],
+  documents: [{ id: 'document-1', kind: 'statement', parseStatus: 'ready' }],
+  importBatches: [],
+  reviewItems: [],
+  budgets: [],
+  debts: [],
+  tasks: []
+});
+
+const statementPreview = (records, overrides = {}) => ({
+  kind: 'statement',
+  accountHint: 'account-1',
+  records,
+  rejected: [],
+  warnings: [],
+  reconciled: true,
+  accountIdentity: { institution: 'Fictional Bank', accountReference: '••••1234', accountType: 'Current account', currency: 'GBP' },
+  summary: { openingBalance: 100, closingBalance: 90, statementStartDate: '2026-08-01', statementEndDate: '2026-08-01', currency: 'GBP' },
+  ...overrides
+});
+
+test('exact statement match adds provenance without adding a duplicate transaction', () => {
+  const state = baseState();
+  state.transactions.push(transaction({ id: 'existing', sourceDocumentId: 'document-old' }));
+  const preview = statementPreview([transaction({ id: 'incoming' })]);
+  const plan = buildStatementImportPlan(state, preview, 'document-1');
+  const applied = applyStatementImportPlan(state, preview, plan, 'document-1', '2026-08-11T10:00:00.000Z');
+
+  assert.equal(applied.state.transactions.length, 1);
+  assert.deepEqual(applied.state.transactions[0].sourceDocumentIds.sort(), ['document-1', 'document-old']);
+  assert.equal(applied.state.transactions[0].reconciliationProvenance[0].documentId, 'document-1');
+  assert.equal(applied.result.matchedAutomatically, 1);
+  assert.equal(applied.result.newTransactions, 0);
+});
+
+test('clear new statement transaction is added once and becomes financially active', () => {
+  const state = baseState();
+  const preview = statementPreview([transaction({ id: 'new-payment' })]);
+  const plan = buildStatementImportPlan(state, preview, 'document-1');
+  const applied = applyStatementImportPlan(state, preview, plan, 'document-1');
+
+  assert.equal(applied.state.transactions.length, 1);
+  assert.equal(applied.state.transactions[0].id, 'new-payment');
+  assert.equal(applied.result.newTransactions, 1);
+  assert.equal(isTransactionFinanciallyActive(applied.state.transactions[0]), true);
+});
+
+test('two plausible matches are quarantined and routed to Review Inbox', () => {
+  const state = baseState();
+  state.transactions.push(
+    transaction({ id: 'candidate-one', description: 'Fictional Merchant A', reference: '' }),
+    transaction({ id: 'candidate-two', description: 'Fictional Merchant B', reference: '' })
+  );
+  const preview = statementPreview([transaction({ id: 'ambiguous', description: 'Fictional Merchant C', reference: '' })]);
+  const plan = buildStatementImportPlan(state, preview, 'document-1');
+  const applied = applyStatementImportPlan(state, preview, plan, 'document-1');
+  const ambiguous = applied.state.transactions.find((item) => item.id === 'ambiguous');
+
+  assert.equal(plan.reconciliation.items[0].classification, STATEMENT_RECONCILIATION_CLASS.POSSIBLE_DUPLICATE);
+  assert.deepEqual(plan.reconciliation.items[0].candidateTransactionIds.sort(), ['candidate-one', 'candidate-two']);
+  assert.equal(ambiguous.duplicateStatus, 'possible');
+  assert.equal(ambiguous.reviewStatus, 'pending');
+  assert.equal(isTransactionFinanciallyActive(ambiguous), false);
+  assert.ok(activeReviewItems(applied.state).some((item) => item.sourceId === 'ambiguous'));
+});
+
+test('manual transaction interpretation remains authoritative during reconciliation', () => {
+  const state = baseState();
+  state.transactions.push(transaction({ id: 'existing', category: 'Groceries', categorySource: 'manual' }));
+  const preview = statementPreview([transaction({ id: 'incoming', category: 'Fuel' })]);
+  const plan = buildStatementImportPlan(state, preview, 'document-1');
+  const applied = applyStatementImportPlan(state, preview, plan, 'document-1');
+
+  const existing = applied.state.transactions.find((item) => item.id === 'existing');
+  const incoming = applied.state.transactions.find((item) => item.id === 'incoming');
+  assert.equal(existing.category, 'Groceries');
+  assert.equal(existing.categorySource, 'manual');
+  assert.equal(incoming.financiallyActive, false);
+  assert.equal(plan.reconciliation.items[0].evidence, 'manual-value-conflict');
+});
+
+test('re-applying a completed statement document is idempotently rejected without changes', () => {
+  const state = baseState();
+  const preview = statementPreview([transaction({ id: 'new-payment' })]);
+  const firstPlan = buildStatementImportPlan(state, preview, 'document-1');
+  const first = applyStatementImportPlan(state, preview, firstPlan, 'document-1');
+  const before = structuredClone(first.state);
+  const secondPlan = buildStatementImportPlan(first.state, preview, 'document-1');
+
+  assert.throws(
+    () => applyStatementImportPlan(first.state, preview, secondPlan, 'document-1'),
+    (error) => error.code === 'STATEMENT_IMPORT_ALREADY_APPLIED'
+  );
+  assert.deepEqual(first.state, before);
+  assert.equal(first.state.transactions.length, 1);
+  assert.equal(first.state.importBatches.length, 1);
+});
+
+test('partial reconciliation failure leaves the original state untouched', () => {
+  const state = baseState();
+  const preview = statementPreview([transaction({ id: 'new-payment' })]);
+  const plan = buildStatementImportPlan(state, preview, 'document-1');
+  const before = structuredClone(state);
+
+  assert.throws(() => applyStatementImportPlan(state, preview, plan, 'document-1', '2026-08-11T10:00:00.000Z', {
+    faultInjector(point) {
+      if (point === 'after-new-records') throw new Error('fictional reconciliation failure');
+    }
+  }), /fictional reconciliation failure/);
+  assert.deepEqual(state, before);
+});
+
+test('state revision change blocks a stale reconciliation plan', () => {
+  const state = baseState();
+  const preview = statementPreview([transaction({ id: 'new-payment' })]);
+  const plan = buildStatementImportPlan(state, preview, 'document-1');
+  state.meta.revision += 1;
+
+  assert.throws(
+    () => applyStatementImportPlan(state, preview, plan, 'document-1'),
+    (error) => error.code === 'STATEMENT_RECONCILIATION_STALE_REVISION'
+  );
+  assert.equal(state.transactions.length, 0);
+  assert.equal(state.importBatches.length, 0);
+});
+
+test('restart and portable backup/restore preserve reconciliation provenance', async (t) => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-reconciliation-'));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const store = new FinanceDataStore(directory, seedPath, null, { secureStorage: secureStorage(), appVersion: '2.1.26' });
+  await store.initialise();
+  let state = (await store.loadState()).state;
+  state.transactions.push({
+    ...transaction({ id: 'reconciled', sourceDocumentId: 'document-fictional', sourceDocumentIds: ['document-fictional'] }),
+    duplicateStatus: 'none', reviewStatus: 'not_required', importReviewStatus: 'trusted', financiallyActive: true,
+    reconciliationProvenance: [{
+      documentId: 'document-fictional', importBatchId: 'batch-fictional', reconciledAt: '2026-08-11T10:00:00.000Z',
+      evidence: 'transaction-identity', classification: 'exact_authoritative_match'
+    }]
+  });
+  state = await store.saveState(state);
+
+  const restarted = new FinanceDataStore(directory, seedPath, null, { secureStorage: secureStorage(), appVersion: '2.1.26' });
+  await restarted.initialise();
+  const reloaded = (await restarted.loadState()).state;
+  assert.equal(reloaded.transactions[0].reconciliationProvenance[0].documentId, 'document-fictional');
+
+  const backup = path.join(directory, 'reconciliation.osmb');
+  await restarted.createPortableBackup(backup, passphrase, reloaded);
+  const changed = structuredClone(reloaded);
+  changed.transactions = [];
+  await restarted.saveState(changed);
+  const restored = await restarted.restorePortableBackup(backup, passphrase);
+  assert.equal(restored.status, 'restored');
+  assert.equal(restored.state.transactions[0].reconciliationProvenance[0].importBatchId, 'batch-fictional');
+});
+
+test('large fictional multi-month reconciliation remains bounded', () => {
+  const existing = [];
+  const incoming = [];
+  for (let index = 0; index < 20_000; index += 1) {
+    existing.push(transaction({
+      id: `existing-${index}`,
+      date: `2025-${String((index % 12) + 1).padStart(2, '0')}-${String((index % 27) + 1).padStart(2, '0')}`,
+      outgoing: (index % 997) + 0.01,
+      description: `Fictional merchant ${index}`,
+      reference: `REF-${index}`
+    }));
+  }
+  for (let index = 0; index < 2_000; index += 1) {
+    incoming.push(transaction({
+      id: `incoming-${index}`,
+      date: `2026-${String((index % 8) + 1).padStart(2, '0')}-${String((index % 27) + 1).padStart(2, '0')}`,
+      outgoing: 5_000 + index + 0.01,
+      description: `New fictional merchant ${index}`,
+      reference: `NEW-${index}`
+    }));
+  }
+  const started = performance.now();
+  const plan = buildStatementReconciliationPlan({ meta: { revision: 1 }, transactions: existing }, { records: incoming }, { documentId: 'fictional-performance-document' });
+  const elapsed = performance.now() - started;
+  assert.equal(plan.counts.newTransactions, 2_000);
+  assert.ok(elapsed < 2_500, `reconciliation took ${elapsed.toFixed(1)}ms`);
+});
+
+function secureStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(value, 'utf8'),
+    decryptString: (value) => value.toString('utf8')
+  };
+}

--- a/tests/statement-reconciliation-integration.test.js
+++ b/tests/statement-reconciliation-integration.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { performance } from 'node:perf_hooks';
 import { FinanceDataStore } from '../data-store.js';
 import { isTransactionFinanciallyActive } from '../finance-core.js';
 import { activeReviewItems } from '../review-lifecycle.js';

--- a/tests/statement-reconciliation.test.js
+++ b/tests/statement-reconciliation.test.js
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyStatementReconciliationMatches,
+  buildStatementReconciliationPlan,
+  STATEMENT_RECONCILIATION_CLASS
+} from '../statement-reconciliation.js';
+
+const transaction = (overrides = {}) => ({
+  id: overrides.id || 'tx-1',
+  accountId: 'account-1',
+  date: '2026-08-01',
+  description: 'Example merchant',
+  reference: 'REF-1',
+  providerTransactionId: '',
+  incoming: 0,
+  outgoing: 10,
+  runningBalance: 90,
+  duplicateStatus: 'none',
+  reviewStatus: 'not_required',
+  importReviewStatus: 'trusted',
+  financiallyActive: true,
+  ...overrides
+});
+
+const preview = (records) => ({ kind: 'statement', records });
+const state = (transactions = []) => ({ meta: { revision: 7 }, transactions });
+
+test('exact transaction match adds provenance without creating a duplicate', () => {
+  const existing = transaction({ id: 'existing', sourceDocumentId: 'document-old' });
+  const incoming = transaction({ id: 'incoming' });
+  const plan = buildStatementReconciliationPlan(state([existing]), preview([incoming]), {
+    documentId: 'document-new',
+    duplicates: { exact: [{ incoming, existing, evidence: 'transaction-identity' }], possible: [] }
+  });
+  const working = structuredClone(state([existing]));
+  const result = applyStatementReconciliationMatches(working, plan, {
+    documentId: 'document-new', importBatchId: 'batch-1', importedAt: '2026-08-11T09:00:00.000Z'
+  });
+
+  assert.equal(plan.items[0].classification, STATEMENT_RECONCILIATION_CLASS.EXACT_MATCH);
+  assert.equal(working.transactions.length, 1);
+  assert.deepEqual(working.transactions[0].sourceDocumentIds.sort(), ['document-new', 'document-old']);
+  assert.equal(working.transactions[0].reconciliationProvenance[0].importBatchId, 'batch-1');
+  assert.equal(result.matchedAutomatically, 1);
+});
+
+test('clear new statement transaction is classified for one safe add', () => {
+  const plan = buildStatementReconciliationPlan(state([]), preview([transaction({ id: 'new' })]), { documentId: 'document-1' });
+  assert.equal(plan.items[0].classification, STATEMENT_RECONCILIATION_CLASS.NEW_RECORD);
+  assert.equal(plan.counts.newTransactions, 1);
+  assert.equal(plan.counts.needsReview, 0);
+});
+
+test('two plausible candidates are ambiguous and never automatic', () => {
+  const incoming = transaction({ id: 'incoming', description: 'Different display text', reference: '' });
+  const existing = [
+    transaction({ id: 'one', description: 'First', reference: '' }),
+    transaction({ id: 'two', description: 'Second', reference: '' })
+  ];
+  const plan = buildStatementReconciliationPlan(state(existing), preview([incoming]));
+  assert.equal(plan.items[0].classification, STATEMENT_RECONCILIATION_CLASS.POSSIBLE_DUPLICATE);
+  assert.equal(plan.items[0].certainty, 'ambiguous');
+  assert.equal(plan.items[0].automatic, false);
+  assert.deepEqual(plan.items[0].candidateTransactionIds.sort(), ['one', 'two']);
+});
+
+test('manual category conflict is routed to review and never overwritten', () => {
+  const existing = transaction({ id: 'existing', category: 'Food', categorySource: 'manual' });
+  const incoming = transaction({ id: 'incoming', category: 'Fuel' });
+  const plan = buildStatementReconciliationPlan(state([existing]), preview([incoming]), {
+    duplicates: { exact: [{ incoming, existing, evidence: 'transaction-identity' }], possible: [] }
+  });
+  assert.equal(plan.items[0].classification, STATEMENT_RECONCILIATION_CLASS.POSSIBLE_DUPLICATE);
+  assert.equal(plan.items[0].certainty, 'conflicting');
+  assert.equal(plan.items[0].evidence, 'manual-value-conflict');
+});
+
+test('trusted statement evidence only fills missing compatible fields', () => {
+  const existing = transaction({ id: 'existing', description: '', reference: 'REF-1', providerTransactionId: '' });
+  const incoming = transaction({ id: 'incoming', description: 'Example merchant', reference: 'REF-1', providerTransactionId: 'BANK-123' });
+  const plan = buildStatementReconciliationPlan(state([existing]), preview([incoming]));
+  assert.equal(plan.items[0].classification, STATEMENT_RECONCILIATION_CLASS.COMPATIBLE_UPDATE);
+  assert.deepEqual(plan.items[0].patch, { providerTransactionId: 'BANK-123', description: 'Example merchant' });
+
+  const working = structuredClone(state([existing]));
+  applyStatementReconciliationMatches(working, plan, { documentId: 'document-1', importBatchId: 'batch-1' });
+  assert.equal(working.transactions[0].description, 'Example merchant');
+  assert.equal(working.transactions[0].providerTransactionId, 'BANK-123');
+  assert.equal(working.transactions[0].reference, 'REF-1');
+});
+
+test('same evidence already linked becomes a no-change item', () => {
+  const existing = transaction({ id: 'existing', sourceDocumentId: 'document-1', sourceDocumentIds: ['document-1'] });
+  const incoming = transaction({ id: 'incoming' });
+  const plan = buildStatementReconciliationPlan(state([existing]), preview([incoming]), {
+    documentId: 'document-1',
+    duplicates: { exact: [{ incoming, existing, evidence: 'transaction-identity' }], possible: [] }
+  });
+  assert.equal(plan.items[0].classification, STATEMENT_RECONCILIATION_CLASS.NO_CHANGE);
+  assert.equal(plan.counts.noChange, 1);
+});
+
+test('stale state revision blocks reconciliation before mutation', () => {
+  const existing = transaction({ id: 'existing', sourceDocumentId: '' });
+  const incoming = transaction({ id: 'incoming' });
+  const plan = buildStatementReconciliationPlan(state([existing]), preview([incoming]), {
+    documentId: 'document-1',
+    duplicates: { exact: [{ incoming, existing, evidence: 'transaction-identity' }], possible: [] }
+  });
+  const working = structuredClone(state([existing]));
+  working.meta.revision += 1;
+  assert.throws(
+    () => applyStatementReconciliationMatches(working, plan, { documentId: 'document-1' }),
+    (error) => error.code === 'STATEMENT_RECONCILIATION_STALE_REVISION'
+  );
+  assert.equal(working.transactions[0].sourceDocumentId, '');
+});
+
+test('insufficient evidence is review-required and not automatic', () => {
+  const incoming = transaction({ id: 'incoming', date: '', outgoing: 0, incoming: 0 });
+  const plan = buildStatementReconciliationPlan(state([]), preview([incoming]));
+  assert.equal(plan.items[0].classification, STATEMENT_RECONCILIATION_CLASS.REVIEW_REQUIRED);
+  assert.equal(plan.items[0].certainty, 'insufficient');
+  assert.equal(plan.counts.needsReview, 1);
+});
+
+test('reconciliation summary exposes import UI categories without financial content', () => {
+  const exactExisting = transaction({ id: 'exact-existing' });
+  const exactIncoming = transaction({ id: 'exact-incoming' });
+  const newIncoming = transaction({ id: 'new', date: '2026-08-02', outgoing: 20 });
+  const ambiguousIncoming = transaction({ id: 'ambiguous', date: '2026-08-03', outgoing: 30, description: 'Unknown', reference: '' });
+  const candidates = [
+    exactExisting,
+    transaction({ id: 'candidate-a', date: '2026-08-03', outgoing: 30, description: 'A', reference: '' }),
+    transaction({ id: 'candidate-b', date: '2026-08-03', outgoing: 30, description: 'B', reference: '' })
+  ];
+  const plan = buildStatementReconciliationPlan(state(candidates), preview([exactIncoming, newIncoming, ambiguousIncoming]), {
+    documentId: 'document-2',
+    duplicates: { exact: [{ incoming: exactIncoming, existing: exactExisting, evidence: 'transaction-identity' }], possible: [] }
+  });
+  assert.deepEqual(plan.counts, {
+    total: 3,
+    matchedAutomatically: 1,
+    exactMatches: 1,
+    automaticUpdates: 0,
+    newTransactions: 1,
+    needsReview: 1,
+    possibleDuplicates: 1,
+    insufficientEvidence: 0,
+    duplicatesIgnoredOrQuarantined: 2,
+    noChange: 0
+  });
+});
+
+test('module has no network, telemetry, logging, or statement-content diagnostics', async () => {
+  const source = await import('node:fs/promises').then((fs) => fs.readFile(new URL('../statement-reconciliation.js', import.meta.url), 'utf8'));
+  assert.doesNotMatch(source, /fetch\s*\(|XMLHttpRequest|https?:\/\//i);
+  assert.doesNotMatch(source, /console\.|telemetry|analytics/i);
+});


### PR DESCRIPTION
Closes #83

### Purpose
Implement local confidence-based statement reconciliation for v2.2.0 so trusted statement evidence can be matched safely without creating duplicate financial records, while ambiguity remains quarantined for explicit review.

### Work completed
- Added a deterministic local reconciliation engine with exact/authoritative, compatible-update, new-record, possible-duplicate/conflict, insufficient-evidence, and no-change classifications.
- Added high-confidence automatic provenance attachment and missing-field enrichment only; manual values remain authoritative and are never silently overwritten.
- Routed ambiguous/conflicting statement records into the existing possible-duplicate Review Inbox lifecycle and kept them financially inactive until resolved.
- Added revision-stale protection, clone-before-apply atomicity, fault-injection rollback coverage, and idempotent completed-document rejection.
- Added reconciliation summaries for matched automatically, new transactions, needs review, duplicates ignored/quarantined, automatic updates, and no-change outcomes.
- Added focused regression, integration, persistence/backup, privacy, and large-history performance coverage using fictional data only.

### Files changed
- `statement-reconciliation.js` — new local confidence-based reconciliation engine.
- `statement-intelligence.js` — integrates reconciliation into statement planning/apply, quarantine, provenance, atomicity and summaries.
- `tests/statement-reconciliation.test.js` — focused reconciliation safety tests.
- `tests/statement-reconciliation-integration.test.js` — statement-import, Review Inbox, rollback, persistence/backup and performance tests.
- `package.json` — includes the reconciliation engine in packaged builds.

### User-facing changes
- Re-imported/overlapping statements can match trusted existing transactions instead of duplicating them.
- Safe missing trusted fields and source provenance can be added automatically.
- Ambiguous/conflicting matches remain outside trusted totals and appear in Review Inbox rather than being guessed.
- Existing concise statement preview continues to show New / Already known / Needs review; richer reconciliation outcome counts are also retained in the import plan/batch.

### Technical changes
- Matching uses account identity, date, penny-exact direction/amount, provider/reference identifiers, normalised description evidence, existing source relationships and import provenance.
- Candidate indexing keeps reconciliation bounded for larger histories and detects multiple plausible matches instead of selecting the first candidate.
- Automatic writes are restricted to missing non-interpretive fields plus provenance; category/budget/manual interpretation fields are protected.
- State revision and basis-token checks reject stale plans before mutation.
- All apply work occurs on a cloned state; injected failures never partially mutate the caller's financial state.
- No network, telemetry, analytics, cloud storage or remote enrichment is introduced.

### Testing and verification
- Passed: focused local reconciliation suite — 10/10 tests.
- Passed: focused JavaScript syntax checks for the reconciliation engine, statement integration and integration tests.
- Passed: full Linux GitHub CI — `npm test`, `npm run check` including privacy check, and `npm run lint`.
- Passed: full suite contains 344 tests with 0 failures; the final-head Linux run also completed the full test step successfully.
- Passed: Windows GitHub CI — `npm test`, `npm run check`, `npm run lint`.
- Passed: Windows built-Pages artifact runtime smoke test.
- Passed: Windows Electron desktop startup smoke test.
- Passed: Windows packaging smoke test. This is automated packaging verification, not a claim of manual installer testing.
- Passed: fictional 20,000-existing / 2,000-incoming reconciliation performance check; CI completed the large-history test successfully.
- Unavailable: interactive/manual Electron statement-import and Review Inbox verification in the connector-only environment. The automated Electron startup smoke passed, but is not presented as manual feature testing.
- Unavailable: manual Windows installer verification. The automated Windows packaging smoke passed.
- Skipped: release-windows publication job on the draft PR, as expected for a pull-request workflow.

### Data and migration impact
- Additive only: transaction reconciliation provenance/status metadata and import-batch reconciliation summaries.
- Existing migration preserves additional transaction fields; no destructive migration or schema rewrite is required.
- Backup/restore coverage verifies reconciliation provenance survives portable backup round trips.
- Core access, backup/restore and export remain independent of payment and network access.

### Known limitations
- The existing concise statement preview is reused rather than broadly redesigned; New / Already known / Needs review remain the visible summary tiles, while the more detailed matched/automatic-update/quarantined/no-change counts are retained in reconciliation metadata for onward UI/Why? use.
- GitHub connector write restrictions forced three focused commits (implementation, safety/regression coverage, and one lint-only import fix) instead of the preferred single implementation commit. No history was rewritten or force-pushed.
- GitHub Project field mutation was unavailable through the connected tooling, so Project Status/Branch/Start Date could not be updated by this workflow; the Issue itself was promoted in place and retains `brief: ready`.

### Excluded work
- New bank/parser support.
- Open Banking or cloud reconciliation/enrichment.
- Broad import UI redesign.
- AI Companion behaviour.
- Any unrelated v2.2.0 feature work.

### Branch details
- Branch: `feature/statement-reconciliation-automation`
- Commit SHA: `4426ff2d49b2fefb862021344317ea7d57b69fb8`
- Pull request: #114
- Target branch: `main`

### Confirmations
- No changes committed/pushed directly to `main`.
- PR not merged by this workflow.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs committed.
- Only relevant files changed.