### PR TITLE
[v2.2.0][Feature] Simple local automation rules and rule management

### DIFF
--- a/automation-rule-model.js
+++ b/automation-rule-model.js
@@ -1,0 +1,253 @@
+const SAFE_ID = /^[a-z0-9][a-z0-9._-]{0,119}$/;
+const MAX_RULES = 200;
+const MAX_CONDITIONS = 8;
+const MAX_TEXT = 160;
+
+export const AUTOMATION_RULE_TRIGGER = Object.freeze({
+  TRANSACTION_CHANGE: 'transaction_change',
+  DATE_BOUNDARY: 'date_boundary'
+});
+
+export const AUTOMATION_RULE_CONDITION = Object.freeze({
+  MERCHANT: 'merchant',
+  PURPOSE: 'purpose',
+  ACCOUNT: 'account',
+  DIRECTION: 'direction',
+  AMOUNT: 'amount',
+  RECURRING_CADENCE: 'recurring_cadence',
+  REVIEW_STATE: 'review_state',
+  DAYS_UNTIL_DUE: 'days_until_due'
+});
+
+export const AUTOMATION_RULE_ACTION = Object.freeze({
+  ASSIGN_BUDGET: 'assign_budget',
+  ADD_TAG: 'add_tag',
+  CREATE_REMINDER: 'create_reminder'
+});
+
+const TRIGGERS = new Set(Object.values(AUTOMATION_RULE_TRIGGER));
+const CONDITIONS = new Set(Object.values(AUTOMATION_RULE_CONDITION));
+const ACTIONS = new Set(Object.values(AUTOMATION_RULE_ACTION));
+const TEXT_OPERATORS = new Set(['equals', 'contains']);
+const RANGE_OPERATORS = new Set(['equals', 'at_least', 'at_most', 'between']);
+
+export function normaliseAutomationRuleCollection(value) {
+  if (!Array.isArray(value)) return [];
+  const output = [];
+  const ids = new Set();
+  for (const candidate of value) {
+    const checked = validateAutomationRule(candidate);
+    if (!checked.valid || ids.has(checked.rule.id)) continue;
+    ids.add(checked.rule.id);
+    output.push(checked.rule);
+    if (output.length >= MAX_RULES) break;
+  }
+  return output.sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id));
+}
+
+export function validateAutomationRule(input) {
+  const errors = [];
+  const rule = isPlainObject(input) ? input : {};
+  const id = safeId(rule.id);
+  if (!id) errors.push('Rule ID is invalid.');
+  const name = safeText(rule.name, MAX_TEXT);
+  if (!name) errors.push('Give the rule a name.');
+  const trigger = TRIGGERS.has(rule.trigger) ? rule.trigger : '';
+  if (!trigger) errors.push('Choose a supported When trigger.');
+
+  const conditions = Array.isArray(rule.conditions)
+    ? rule.conditions.slice(0, MAX_CONDITIONS).map((condition, index) => normaliseCondition(condition, index, errors)).filter(Boolean)
+    : [];
+  if (!conditions.length) errors.push('Add at least one If condition.');
+  if (trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY && !conditions.some((condition) => condition.field === AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE)) {
+    errors.push('Date-relative rules need a days-until-due condition.');
+  }
+
+  const action = normaliseAction(rule.action, trigger, errors);
+  const explanation = safeText(rule.explanation, 240) || explainRule({ trigger, conditions, action });
+  const createdAt = validIso(rule.createdAt) ? rule.createdAt : null;
+  const updatedAt = validIso(rule.updatedAt) ? rule.updatedAt : createdAt;
+  const enabled = rule.enabled !== false;
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    rule: {
+      id: id || '',
+      name,
+      enabled,
+      trigger,
+      conditions,
+      action,
+      explanation,
+      createdAt,
+      updatedAt
+    }
+  };
+}
+
+export function upsertAutomationRule(state, input, now = new Date()) {
+  const checked = validateAutomationRule(input);
+  if (!checked.valid) {
+    const error = new Error(checked.errors.join(' '));
+    error.code = 'AUTOMATION_RULE_INVALID';
+    error.validationErrors = checked.errors;
+    throw error;
+  }
+  const next = structuredClone(state || {});
+  next.automation = normaliseAutomationRuleState(next.automation);
+  const timestamp = validDate(now).toISOString();
+  const existingIndex = next.automation.rules.findIndex((rule) => rule.id === checked.rule.id);
+  const existing = existingIndex >= 0 ? next.automation.rules[existingIndex] : null;
+  const saved = {
+    ...checked.rule,
+    createdAt: existing?.createdAt || checked.rule.createdAt || timestamp,
+    updatedAt: timestamp
+  };
+  if (existingIndex >= 0) next.automation.rules.splice(existingIndex, 1, saved);
+  else {
+    if (next.automation.rules.length >= MAX_RULES) throw new Error(`OneStep supports up to ${MAX_RULES} local rules.`);
+    next.automation.rules.push(saved);
+  }
+  next.automation.rules = normaliseAutomationRuleCollection(next.automation.rules);
+  return next;
+}
+
+export function removeAutomationRule(state, ruleId) {
+  const next = structuredClone(state || {});
+  next.automation = normaliseAutomationRuleState(next.automation);
+  next.automation.rules = next.automation.rules.filter((rule) => rule.id !== safeId(ruleId));
+  return next;
+}
+
+export function setAutomationRuleEnabled(state, ruleId, enabled, now = new Date()) {
+  const next = structuredClone(state || {});
+  next.automation = normaliseAutomationRuleState(next.automation);
+  const rule = next.automation.rules.find((item) => item.id === safeId(ruleId));
+  if (!rule) throw new Error('That automation rule is no longer available.');
+  rule.enabled = Boolean(enabled);
+  rule.updatedAt = validDate(now).toISOString();
+  return next;
+}
+
+export function duplicateAutomationRule(state, ruleId, newId, now = new Date()) {
+  const source = normaliseAutomationRuleState(state?.automation).rules.find((rule) => rule.id === safeId(ruleId));
+  if (!source) throw new Error('That automation rule is no longer available.');
+  return upsertAutomationRule(state, {
+    ...structuredClone(source),
+    id: safeId(newId),
+    name: `${source.name} copy`.slice(0, MAX_TEXT),
+    enabled: false,
+    createdAt: null,
+    updatedAt: null
+  }, now);
+}
+
+export function explainRule(rule) {
+  const trigger = rule?.trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY
+    ? 'When a confirmed recurring date is reached'
+    : 'When a payment is added or changed';
+  const conditions = (rule?.conditions || []).map(conditionLabel).filter(Boolean).join(' and ');
+  const action = actionLabel(rule?.action);
+  return [trigger, conditions ? `if ${conditions}` : '', action ? `then ${action}` : ''].filter(Boolean).join(', ').slice(0, 240);
+}
+
+export function conditionLabel(condition) {
+  const field = condition?.field;
+  const operator = condition?.operator;
+  if (field === AUTOMATION_RULE_CONDITION.MERCHANT) return `merchant ${operator === 'contains' ? 'contains' : 'is'} “${condition.value}”`;
+  if (field === AUTOMATION_RULE_CONDITION.PURPOSE) return `purpose ${operator === 'contains' ? 'contains' : 'is'} “${condition.value}”`;
+  if (field === AUTOMATION_RULE_CONDITION.ACCOUNT) return `account is “${condition.value}”`;
+  if (field === AUTOMATION_RULE_CONDITION.DIRECTION) return `money is ${condition.value}`;
+  if (field === AUTOMATION_RULE_CONDITION.RECURRING_CADENCE) return `recurring cadence is ${condition.value}`;
+  if (field === AUTOMATION_RULE_CONDITION.REVIEW_STATE) return `review state is ${condition.value}`;
+  if (field === AUTOMATION_RULE_CONDITION.AMOUNT) return rangeLabel('amount', condition);
+  if (field === AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE) return rangeLabel('days until due', condition);
+  return '';
+}
+
+export function actionLabel(action) {
+  if (action?.type === AUTOMATION_RULE_ACTION.ASSIGN_BUDGET) return `assign budget/category “${action.value}”`;
+  if (action?.type === AUTOMATION_RULE_ACTION.ADD_TAG) return `add local tag “${action.value}”`;
+  if (action?.type === AUTOMATION_RULE_ACTION.CREATE_REMINDER) return `create local reminder “${action.value}”`;
+  return '';
+}
+
+export function normaliseAutomationRuleState(value) {
+  const automation = isPlainObject(value) ? structuredClone(value) : {};
+  automation.enabled = automation.enabled !== false;
+  automation.rules = normaliseAutomationRuleCollection(automation.rules);
+  automation.executions = isPlainObject(automation.executions) ? automation.executions : {};
+  automation.manualOverrides = isPlainObject(automation.manualOverrides) ? automation.manualOverrides : {};
+  automation.version = Number.isInteger(automation.version) ? automation.version : 1;
+  return automation;
+}
+
+function normaliseCondition(input, index, errors) {
+  if (!isPlainObject(input) || !CONDITIONS.has(input.field)) {
+    errors.push(`Condition ${index + 1} is not supported.`);
+    return null;
+  }
+  const field = input.field;
+  const id = safeId(input.id) || `condition_${index + 1}`;
+  if ([AUTOMATION_RULE_CONDITION.MERCHANT, AUTOMATION_RULE_CONDITION.PURPOSE].includes(field)) {
+    const operator = TEXT_OPERATORS.has(input.operator) ? input.operator : 'equals';
+    const value = safeText(input.value, MAX_TEXT);
+    if (!value) errors.push(`Condition ${index + 1} needs a value.`);
+    return { id, field, operator, value };
+  }
+  if ([AUTOMATION_RULE_CONDITION.AMOUNT, AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE].includes(field)) {
+    const operator = RANGE_OPERATORS.has(input.operator) ? input.operator : 'equals';
+    const value = finiteOrNull(input.value);
+    const value2 = finiteOrNull(input.value2);
+    if (value === null) errors.push(`Condition ${index + 1} needs a number.`);
+    if (operator === 'between' && value2 === null) errors.push(`Condition ${index + 1} needs both ends of the range.`);
+    if (operator === 'between' && value !== null && value2 !== null && value > value2) errors.push(`Condition ${index + 1} range is backwards.`);
+    return { id, field, operator, value, value2: operator === 'between' ? value2 : null };
+  }
+  const allowed = field === AUTOMATION_RULE_CONDITION.DIRECTION ? new Set(['incoming', 'outgoing'])
+    : field === AUTOMATION_RULE_CONDITION.RECURRING_CADENCE ? new Set(['weekly', 'fortnightly', 'four-weekly', 'monthly', 'quarterly', 'annual'])
+      : field === AUTOMATION_RULE_CONDITION.REVIEW_STATE ? new Set(['none', 'pending', 'accepted', 'rejected', 'in_progress', 'snoozed'])
+        : null;
+  const value = safeText(input.value, MAX_TEXT);
+  if (!value || (allowed && !allowed.has(value))) errors.push(`Condition ${index + 1} has an invalid value.`);
+  return { id, field, operator: 'equals', value };
+}
+
+function normaliseAction(input, trigger, errors) {
+  if (!isPlainObject(input) || !ACTIONS.has(input.type)) {
+    errors.push('Choose a supported Then action.');
+    return { type: '', value: '' };
+  }
+  const type = input.type;
+  const value = safeText(input.value, MAX_TEXT);
+  if (!value) errors.push('The Then action needs a value.');
+  if (trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY && type !== AUTOMATION_RULE_ACTION.CREATE_REMINDER) {
+    errors.push('Date-relative rules can only create a local reminder in this release.');
+  }
+  return { type, value };
+}
+
+function rangeLabel(label, condition) {
+  if (condition.operator === 'between') return `${label} is between ${condition.value} and ${condition.value2}`;
+  if (condition.operator === 'at_least') return `${label} is at least ${condition.value}`;
+  if (condition.operator === 'at_most') return `${label} is at most ${condition.value}`;
+  return `${label} is ${condition.value}`;
+}
+
+function safeId(value) {
+  const id = String(value || '').trim().toLowerCase();
+  return SAFE_ID.test(id) ? id : '';
+}
+function safeText(value, limit) { return String(value ?? '').replace(/[\r\n]+/g, ' ').trim().slice(0, limit); }
+function finiteOrNull(value) {
+  if (value === '' || value === null || value === undefined) return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+function validIso(value) { return typeof value === 'string' && Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value; }
+function validDate(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+function isPlainObject(value) { return Boolean(value) && typeof value === 'object' && !Array.isArray(value); }

--- a/automation-rules-ui.js
+++ b/automation-rules-ui.js
@@ -1,0 +1,257 @@
+import {
+  AUTOMATION_RULE_ACTION, AUTOMATION_RULE_CONDITION, AUTOMATION_RULE_TRIGGER,
+  actionLabel, conditionLabel, duplicateAutomationRule, normaliseAutomationRuleState,
+  removeAutomationRule, setAutomationRuleEnabled, upsertAutomationRule
+} from './automation-rule-model.js';
+
+let state = null;
+let editId = '';
+let draft = null;
+let lastCycleSignature = '';
+let cycleRunning = false;
+let runSummary = null;
+
+export function renderAutomationRulesPanel(nextState) {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  state = nextState;
+  render();
+  scheduleCycle();
+}
+
+function render() {
+  const grid = document.querySelector('#view-settings .settings-grid');
+  if (!grid || !state) return;
+  let panel = document.getElementById('automationRulesSettings');
+  if (!panel) {
+    panel = document.createElement('article');
+    panel.id = 'automationRulesSettings';
+    panel.className = 'panel';
+    grid.append(panel);
+    panel.addEventListener('click', onClick);
+    panel.addEventListener('change', onChange);
+    panel.addEventListener('submit', onSubmit);
+  }
+  panel.replaceChildren();
+
+  const automation = normaliseAutomationRuleState(state.automation);
+  panel.append(heading(automation), statusLine(automation), buttonRow(button('Create rule', 'primary-button', { automationCreate: 'true' })));
+
+  const list = el('div', 'compact-card-list');
+  if (!automation.rules.length) list.append(el('p', 'muted', 'No rules yet. Start with one clear trigger, one or more conditions, and one approved local action.'));
+  for (const rule of automation.rules) list.append(ruleCard(rule));
+  panel.append(list);
+  if (draft) panel.append(ruleForm());
+}
+
+function heading(automation) {
+  const wrapper = el('div', 'panel-heading');
+  const copy = el('div');
+  copy.append(el('p', 'eyebrow', 'LOCAL AUTOMATION'), el('h2', '', 'Simple rules'),
+    el('p', 'muted', 'Build small “When… If… Then…” rules. They stay local, use OneStep’s shared safety engine, and never move money or contact an external service.'));
+  const label = el('label', 'confirmation-check');
+  const toggle = document.createElement('input'); toggle.type = 'checkbox'; toggle.checked = automation.enabled; toggle.dataset.automationGlobal = 'true';
+  label.append(toggle, document.createTextNode(automation.enabled ? 'Automations enabled' : 'Automations paused'));
+  wrapper.append(copy, label);
+  return wrapper;
+}
+
+function statusLine(automation) {
+  const output = el('p', 'muted'); output.id = 'automationRulesStatus'; output.setAttribute('role', 'status'); output.setAttribute('aria-live', 'polite');
+  if (!automation.enabled) output.textContent = 'Paused. Rules can still be edited and previewed, but automatic changes are blocked.';
+  else if (runSummary?.conflicts) output.textContent = `${runSummary.conflicts} conflicting rule decision${runSummary.conflicts === 1 ? '' : 's'} need review. No conflicting category was applied.`;
+  else if (runSummary?.applied) output.textContent = `${runSummary.applied} safe local automation change${runSummary.applied === 1 ? '' : 's'} applied.`;
+  return output;
+}
+
+function ruleCard(rule) {
+  const card = el('article', 'review-card');
+  const head = el('div', 'review-card-heading');
+  const copy = el('div'); copy.append(el('strong', '', rule.name), el('span', 'muted', rule.explanation));
+  head.append(copy, el('span', 'badge', rule.enabled ? 'Enabled' : 'Paused')); card.append(head);
+  card.append(el('p', 'muted', `${triggerLabel(rule.trigger)} · ${rule.conditions.map(conditionLabel).join(' · ')} · ${actionLabel(rule.action)}`));
+  card.append(buttonRow(
+    button('Edit', 'secondary-button', { automationEdit: rule.id }),
+    button('Preview', 'secondary-button', { automationPreview: rule.id }),
+    button(rule.enabled ? 'Pause rule' : 'Enable rule', 'secondary-button', { automationToggle: rule.id }),
+    button('Duplicate', 'secondary-button', { automationDuplicate: rule.id }),
+    button('Delete', 'danger-button', { automationDelete: rule.id })
+  ));
+  return card;
+}
+
+function ruleForm() {
+  const form = el('form', 'form-grid'); form.id = 'automationRuleForm';
+  form.append(el('h3', 'wide-field', editId ? 'Edit rule' : 'Create rule'));
+  form.append(field('Rule name', input('ruleName', draft.name, 'text', true)));
+  form.append(field('When…', select('ruleTrigger', [
+    ['transaction_change', 'A payment is added or changed'],
+    ['date_boundary', 'A confirmed recurring item reaches a relative date']
+  ], draft.trigger)));
+
+  const conditions = el('div', 'wide-field'); conditions.append(el('strong', '', 'If…'));
+  draft.conditions.forEach((condition, index) => conditions.append(conditionRow(condition, index)));
+  conditions.append(button('Add condition', 'secondary-button', { conditionAdd: 'true' })); form.append(conditions);
+
+  form.append(field('Then…', select('ruleAction', actionOptions(draft.trigger), draft.action.type)));
+  form.append(field('Action value', actionValueInput(draft.action)));
+  const why = field('Why this rule exists', input('ruleExplanation', draft.explanation || '', 'text', false)); why.classList.add('wide-field'); form.append(why);
+  const actions = buttonRow(button(editId ? 'Save rule' : 'Create rule', 'primary-button', {}, 'submit'), button('Cancel', 'secondary-button', { automationCancel: 'true' }));
+  actions.classList.add('wide-field'); form.append(actions);
+  return form;
+}
+
+function conditionRow(condition, index) {
+  const row = el('div', 'review-card'); row.dataset.conditionIndex = String(index);
+  row.append(field('Condition', select(`conditionField${index}`, conditionOptions(), condition.field)));
+  row.append(field('Match', select(`conditionOperator${index}`, operatorOptions(condition.field), condition.operator)));
+  row.append(field('Value', conditionValueInput(condition, index, 'value')));
+  if (condition.operator === 'between' && numericCondition(condition.field)) row.append(field('To', conditionValueInput(condition, index, 'value2')));
+  if (draft.conditions.length > 1) row.append(button('Remove condition', 'secondary-button', { conditionRemove: String(index) }));
+  return row;
+}
+
+async function onClick(event) {
+  const target = event.target;
+  if (target.closest('[data-automation-create]')) { editId = ''; draft = blankRule(); render(); return; }
+  if (target.closest('[data-automation-cancel]')) { editId = ''; draft = null; render(); return; }
+  const edit = target.closest('[data-automation-edit]');
+  if (edit) { const rule = rules().find((item) => item.id === edit.dataset.automationEdit); if (rule) { editId = rule.id; draft = structuredClone(rule); render(); } return; }
+  const add = target.closest('[data-condition-add]');
+  if (add) { captureDraft(); if (draft.conditions.length < 8) draft.conditions.push(defaultCondition(draft.trigger)); render(); return; }
+  const removeCondition = target.closest('[data-condition-remove]');
+  if (removeCondition) { captureDraft(); draft.conditions.splice(Number(removeCondition.dataset.conditionRemove), 1); render(); return; }
+  const toggle = target.closest('[data-automation-toggle]');
+  if (toggle) { const rule = rules().find((item) => item.id === toggle.dataset.automationToggle); await persist(setAutomationRuleEnabled(state, rule.id, !rule.enabled), rule.enabled ? 'Rule paused.' : 'Rule enabled.'); return; }
+  const duplicate = target.closest('[data-automation-duplicate]');
+  if (duplicate) { await persist(duplicateAutomationRule(state, duplicate.dataset.automationDuplicate, createRuleId()), 'Rule duplicated in a paused state.'); return; }
+  const remove = target.closest('[data-automation-delete]');
+  if (remove) { const rule = rules().find((item) => item.id === remove.dataset.automationDelete); if (rule && window.confirm(`Delete “${rule.name}”? Existing financial history will not be reversed.`)) await persist(removeAutomationRule(state, rule.id), 'Rule deleted. Existing history was left unchanged.'); return; }
+  const preview = target.closest('[data-automation-preview]');
+  if (preview) await previewRule(preview.dataset.automationPreview);
+}
+
+async function onChange(event) {
+  if (event.target.matches('[data-automation-global]')) {
+    const next = structuredClone(state); next.automation = normaliseAutomationRuleState(next.automation); next.automation.enabled = event.target.checked;
+    await persist(next, event.target.checked ? 'Automations enabled.' : 'All automations paused.'); return;
+  }
+  if (!draft) return;
+  if (event.target.id === 'ruleTrigger') {
+    captureDraft(); draft.trigger = event.target.value;
+    if (draft.trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY) {
+      draft.action = { type: AUTOMATION_RULE_ACTION.CREATE_REMINDER, value: draft.action.type === AUTOMATION_RULE_ACTION.CREATE_REMINDER ? draft.action.value : '' };
+      if (!draft.conditions.some((item) => item.field === AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE)) draft.conditions.push(defaultCondition(draft.trigger));
+    }
+    render(); return;
+  }
+  if (event.target.id === 'ruleAction') {
+    captureDraft();
+    draft.action = { type: event.target.value, value: '' };
+    render(); return;
+  }
+  if (/^condition(Field|Operator)/.test(event.target.id)) {
+    captureDraft();
+    const row = event.target.closest('[data-condition-index]'); const index = Number(row?.dataset.conditionIndex);
+    if (event.target.id.startsWith('conditionField')) draft.conditions[index] = defaultConditionForField(event.target.value, draft.conditions[index]?.id);
+    render();
+  }
+}
+
+async function onSubmit(event) {
+  if (event.target.id !== 'automationRuleForm') return;
+  event.preventDefault(); captureDraft();
+  const existing = rules().find((item) => item.id === editId);
+  try {
+    const next = upsertAutomationRule(state, { ...(existing || {}), ...draft, id: existing?.id || createRuleId(), enabled: existing?.enabled ?? true });
+    editId = ''; draft = null; await persist(next, existing ? 'Rule saved.' : 'Rule created.');
+  } catch (error) { setStatus(error?.message || 'That rule could not be saved.'); }
+}
+
+function captureDraft() {
+  const form = document.getElementById('automationRuleForm'); if (!form || !draft) return;
+  draft.name = document.getElementById('ruleName')?.value || '';
+  draft.trigger = document.getElementById('ruleTrigger')?.value || draft.trigger;
+  draft.action = { type: document.getElementById('ruleAction')?.value || draft.action.type, value: document.getElementById('ruleActionValue')?.value || '' };
+  draft.explanation = document.getElementById('ruleExplanation')?.value || '';
+  draft.conditions = [...document.querySelectorAll('[data-condition-index]')].map((row, index) => {
+    const fieldName = document.getElementById(`conditionField${index}`)?.value || draft.conditions[index]?.field;
+    const operator = document.getElementById(`conditionOperator${index}`)?.value || 'equals';
+    const value = document.getElementById(`conditionValue${index}`)?.value ?? '';
+    const value2 = document.getElementById(`conditionValue2${index}`)?.value ?? null;
+    return { id: draft.conditions[index]?.id || createConditionId(), field: fieldName, operator, value, value2 };
+  });
+}
+
+async function previewRule(ruleId) {
+  if (!window.financeAPI?.previewAutomationRules) { setStatus('Rule preview is available in the desktop app. No data was sent anywhere.'); return; }
+  setStatus('Checking this rule locally…');
+  try {
+    const result = await window.financeAPI.previewAutomationRules(state, { ruleId, now: new Date().toISOString() });
+    setStatus(`${result.matchCount} matching local action${result.matchCount === 1 ? '' : 's'} found${result.conflicts?.length ? `, with ${result.conflicts.length} conflict${result.conflicts.length === 1 ? '' : 's'}` : ''}. Preview changed nothing.`);
+  } catch (error) { setStatus(error?.message || 'The local preview could not be completed.'); }
+}
+
+async function persist(next, message) {
+  try {
+    const saved = await window.financeAPI.saveState(next);
+    if (saved?.status === 'blocked' || saved?.status === 'conflict') throw new Error(saved.message || 'The rule could not be saved safely.');
+    state = saved; runSummary = null; render(); setStatus(message); scheduleCycle();
+  } catch (error) { setStatus(error?.message || 'The rule could not be saved.'); }
+}
+
+function scheduleCycle() {
+  if (!state || !window.financeAPI?.runAutomationRules || !window.financeAPI?.saveState || cycleRunning) return;
+  const automation = normaliseAutomationRuleState(state.automation);
+  if (!automation.enabled || !automation.rules.some((rule) => rule.enabled)) return;
+  const signature = `${state.meta?.revision ?? 0}:${automation.rules.map((rule) => `${rule.id}:${rule.enabled}:${rule.updatedAt || ''}`).join('|')}`;
+  if (signature === lastCycleSignature) return;
+  lastCycleSignature = signature; cycleRunning = true; queueMicrotask(runCycle);
+}
+
+async function runCycle() {
+  try {
+    const result = await window.financeAPI.runAutomationRules(state, { now: new Date().toISOString() });
+    runSummary = { applied: (result.results || []).filter((row) => row.status === 'applied').length, conflicts: result.conflicts?.length || 0 };
+    if (result.changed) {
+      const saved = await window.financeAPI.saveState(result.state);
+      if (saved?.status === 'blocked' || saved?.status === 'conflict') throw new Error(saved.message || 'Automation could not save safely.');
+      state = saved; window.location.reload(); return;
+    }
+    render();
+  } catch (error) { setStatus(error?.message || 'Automatic rules were not applied. Existing financial data was left unchanged.'); }
+  finally { cycleRunning = false; }
+}
+
+function blankRule() { return { name: '', enabled: true, trigger: AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE, conditions: [defaultCondition(AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE)], action: { type: AUTOMATION_RULE_ACTION.ASSIGN_BUDGET, value: '' }, explanation: '' }; }
+function defaultCondition(trigger) { return trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY ? { id: createConditionId(), field: AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE, operator: 'between', value: 0, value2: 3 } : { id: createConditionId(), field: AUTOMATION_RULE_CONDITION.MERCHANT, operator: 'equals', value: '' }; }
+function defaultConditionForField(field, id = createConditionId()) {
+  if (field === AUTOMATION_RULE_CONDITION.AMOUNT) return { id, field, operator: 'at_least', value: 0, value2: null };
+  if (field === AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE) return { id, field, operator: 'between', value: 0, value2: 3 };
+  const defaults = { direction: 'outgoing', recurring_cadence: 'monthly', review_state: 'pending' };
+  return { id, field, operator: 'equals', value: defaults[field] || '' };
+}
+function conditionOptions() { return [['merchant','Merchant / payee'],['purpose','Resolved purpose / budget'],['account','Account'],['direction','Direction'],['amount','Amount'],['recurring_cadence','Recurring cadence'],['review_state','Review state'],['days_until_due','Days until expected recurring date']]; }
+function operatorOptions(field) { return numericCondition(field) ? [['equals','Equals'],['at_least','At least'],['at_most','At most'],['between','Between']] : ['merchant','purpose'].includes(field) ? [['equals','Equals'],['contains','Contains']] : [['equals','Equals']]; }
+function actionOptions(trigger) { return trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY ? [['create_reminder','Create a local reminder']] : [['assign_budget','Assign a budget/category'],['add_tag','Add a local tag'],['create_reminder','Create a local reminder']]; }
+function actionValueInput(action) { return action.type === AUTOMATION_RULE_ACTION.ASSIGN_BUDGET ? select('ruleActionValue', (state.budgets || []).map((item) => [String(item.id), item.category]), action.value) : input('ruleActionValue', action.value || '', 'text', true); }
+function conditionValueInput(condition, index, part) {
+  const id = part === 'value2' ? `conditionValue2${index}` : `conditionValue${index}`; const value = condition[part] ?? '';
+  if (condition.field === 'account') return select(id, (state.accounts || []).map((item) => [String(item.id), item.name]), value);
+  if (condition.field === 'purpose') return select(id, (state.budgets || []).map((item) => [String(item.id), item.category]), value);
+  if (condition.field === 'direction') return select(id, [['incoming','Incoming'],['outgoing','Outgoing']], value);
+  if (condition.field === 'recurring_cadence') return select(id, [['weekly','Weekly'],['fortnightly','Fortnightly'],['four-weekly','Four-weekly'],['monthly','Monthly'],['quarterly','Quarterly'],['annual','Annual']], value);
+  if (condition.field === 'review_state') return select(id, [['none','No review state'],['pending','Pending'],['accepted','Accepted'],['rejected','Rejected'],['in_progress','In progress'],['snoozed','Snoozed']], value);
+  return input(id, value, numericCondition(condition.field) ? 'number' : 'text', true);
+}
+function numericCondition(field) { return [AUTOMATION_RULE_CONDITION.AMOUNT, AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE].includes(field); }
+function rules() { return normaliseAutomationRuleState(state.automation).rules; }
+function triggerLabel(trigger) { return trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY ? 'When: recurring date' : 'When: payment changes'; }
+function createRuleId() { const value = globalThis.crypto?.randomUUID?.() || `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`; return `rule_${String(value).toLowerCase().replace(/[^a-z0-9_-]/g, '_')}`.slice(0, 120); }
+function createConditionId() { return `condition_${Math.random().toString(36).slice(2, 10)}`; }
+function setStatus(message) { const line = document.getElementById('automationRulesStatus'); if (line) line.textContent = message; }
+function buttonRow(...buttons) { const row = el('div', 'inline-actions'); row.append(...buttons); return row; }
+function button(text, className, data = {}, type = 'button') { const output = el('button', className, text); output.type = type; for (const [key, value] of Object.entries(data)) output.dataset[key] = value; return output; }
+function field(text, control) { const label = el('label'); label.append(document.createTextNode(text), control); return label; }
+function input(id, value, type, required) { const output = document.createElement('input'); output.id = id; output.type = type; output.value = value ?? ''; output.required = Boolean(required); if (type === 'number') output.step = '0.01'; return output; }
+function select(id, options, value) { const output = document.createElement('select'); output.id = id; for (const [key, text] of options) { const option = document.createElement('option'); option.value = key; option.textContent = text; output.append(option); } output.value = value ?? ''; return output; }
+function el(tag, className = '', text = '') { const output = document.createElement(tag); if (className) output.className = className; if (text) output.textContent = text; return output; }

--- a/automation-rules.js
+++ b/automation-rules.js
@@ -1,0 +1,369 @@
+import {
+  AUTOMATION_CERTAINTY, AUTOMATION_EXECUTION_STATUS, AUTOMATION_REASON, AUTOMATION_SAFETY_CLASS,
+  AUTOMATION_TRIGGER, createAutomationTrigger, evaluateAutomationRules, executeAutomationProposal
+} from './automation-engine.js';
+import {
+  AUTOMATION_RULE_ACTION, AUTOMATION_RULE_CONDITION, AUTOMATION_RULE_TRIGGER,
+  normaliseAutomationRuleCollection, normaliseAutomationRuleState, validateAutomationRule
+} from './automation-rule-model.js';
+import { deriveRecurringPatterns, RECURRING_CONFIDENCE } from './recurring-finance.js';
+import { resolveTransactionBudgetAssignment } from './transaction-categorisation.js';
+
+const EXECUTION_TRIGGERS = new Set([AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE, AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY]);
+
+export function previewStoredAutomationRules(state, options = {}) {
+  const safeState = withNormalisedRules(state);
+  const selectedRuleId = String(options.ruleId || '');
+  const rules = safeState.automation.rules.filter((rule) => !selectedRuleId || rule.id === selectedRuleId);
+  const contexts = evaluationContexts(safeState, options.now, true);
+  const proposals = evaluateContexts(safeState, rules, contexts, true, options.now);
+  const resolution = resolveRuleProposalConflicts(proposals);
+  return {
+    proposals: resolution.executable,
+    conflicts: resolution.conflicts,
+    duplicates: resolution.duplicates,
+    matchCount: resolution.executable.length + resolution.conflicts.length + resolution.duplicates.length
+  };
+}
+
+export async function runStoredAutomationRules(state, options = {}) {
+  let current = withNormalisedRules(state);
+  if (current.automation.enabled === false || !current.automation.rules.some((rule) => rule.enabled)) {
+    return { state: current, changed: false, results: [], conflicts: [] };
+  }
+  const contexts = evaluationContexts(current, options.now);
+  const proposals = evaluateContexts(current, current.automation.rules, contexts, false, options.now);
+  const resolution = resolveRuleProposalConflicts(proposals);
+  const results = [
+    ...resolution.duplicates.map((entry) => ({
+      status: AUTOMATION_EXECUTION_STATUS.SKIPPED,
+      reasonCode: 'compatible_duplicate_rule_action',
+      ruleId: entry.ruleId,
+      sourceType: entry.source.type,
+      sourceId: entry.source.id
+    })),
+    ...resolution.conflicts.map((entry) => ({
+      status: AUTOMATION_EXECUTION_STATUS.REVIEW_REQUIRED,
+      reasonCode: 'rule_conflict',
+      ruleId: entry.ruleIds.join(','),
+      sourceType: entry.source.type,
+      sourceId: entry.source.id
+    }))
+  ];
+
+  let changed = false;
+  const handlers = ruleActionHandlers();
+  for (const proposal of resolution.executable) {
+    const executed = await executeAutomationProposal(current, proposal, handlers, {
+      recoveryMode: options.recoveryMode || 'normal',
+      now: options.now
+    });
+    current = executed.state;
+    changed ||= executed.result.status === AUTOMATION_EXECUTION_STATUS.APPLIED;
+    results.push({
+      ...executed.result,
+      ruleId: proposal.ruleId,
+      sourceType: proposal.source.type,
+      sourceId: proposal.source.id
+    });
+  }
+  return { state: current, changed, results, conflicts: resolution.conflicts };
+}
+
+export function ruleActionHandlers() {
+  return {
+    assign_transaction_budget: ({ state, proposal }) => {
+      const transaction = transactionById(state, proposal.source.id);
+      const budget = (state.budgets || []).find((item) => String(item.id) === String(proposal.action.payload?.budgetId || ''));
+      if (!transaction || !budget) return { state };
+      if (transaction.categorySource === 'manual') return { state };
+      transaction.budgetCategoryId = budget.id;
+      transaction.category = budget.category;
+      transaction.categorySource = 'automation';
+      transaction.automationRuleId = proposal.ruleId;
+      return { state };
+    },
+    add_local_tag: ({ state, proposal }) => {
+      const transaction = transactionById(state, proposal.source.id);
+      if (!transaction) return { state };
+      const value = String(proposal.action.payload?.tag || '').trim().slice(0, 80);
+      if (!value) return { state };
+      transaction.automationTags = [...new Set([...(Array.isArray(transaction.automationTags) ? transaction.automationTags : []), value])].slice(-20);
+      return { state };
+    },
+    create_local_reminder: ({ state, proposal }) => {
+      const title = String(proposal.action.payload?.title || '').trim().slice(0, 160);
+      if (!title) return { state };
+      state.tasks = Array.isArray(state.tasks) ? state.tasks : [];
+      const id = `automation_${proposal.executionId.slice(0, 32)}`;
+      const existing = state.tasks.find((task) => String(task.id) === id);
+      const timestamp = new Date().toISOString();
+      const task = {
+        id,
+        title,
+        detail: String(proposal.action.payload?.detail || 'Created by a local automation rule.').slice(0, 240),
+        priority: 'normal',
+        actionView: 'today',
+        source: 'automation_rule',
+        automationRuleId: proposal.ruleId,
+        automationExecutionId: proposal.executionId,
+        createdAt: existing?.createdAt || timestamp,
+        updatedAt: timestamp,
+        completedAt: existing?.completedAt || null
+      };
+      if (existing) Object.assign(existing, task);
+      else state.tasks.push(task);
+      return { state };
+    }
+  };
+}
+
+export function resolveRuleProposalConflicts(proposals = []) {
+  const ordered = [...proposals].sort((left, right) => left.executionId.localeCompare(right.executionId));
+  const executable = [];
+  const duplicates = [];
+  const conflicts = [];
+  const categoryGroups = new Map();
+
+  for (const proposal of ordered) {
+    if (proposal.action.type !== 'assign_transaction_budget') {
+      executable.push(proposal);
+      continue;
+    }
+    const key = `${proposal.source.type}:${proposal.source.id}:budget-category`;
+    if (!categoryGroups.has(key)) categoryGroups.set(key, []);
+    categoryGroups.get(key).push(proposal);
+  }
+
+  for (const rows of categoryGroups.values()) {
+    const byValue = new Map();
+    for (const row of rows) {
+      const value = String(row.action.payload?.budgetId || '');
+      if (!byValue.has(value)) byValue.set(value, []);
+      byValue.get(value).push(row);
+    }
+    if (byValue.size > 1) {
+      conflicts.push({
+        source: rows[0].source,
+        ruleIds: rows.map((row) => row.ruleId).sort(),
+        actionType: 'assign_transaction_budget',
+        values: [...byValue.keys()].sort()
+      });
+      continue;
+    }
+    const compatible = [...rows].sort((left, right) => left.ruleId.localeCompare(right.ruleId));
+    executable.push(compatible[0]);
+    duplicates.push(...compatible.slice(1));
+  }
+
+  executable.sort((left, right) => left.executionId.localeCompare(right.executionId));
+  return { executable, duplicates, conflicts };
+}
+
+function evaluateContexts(state, rules, contexts, includeDisabled, now) {
+  const proposals = [];
+  const runtimeRules = rules
+    .filter((rule) => includeDisabled || rule.enabled)
+    .map((rule) => compileStoredRule(rule, now))
+    .filter(Boolean);
+  for (const context of contexts) {
+    const trigger = createAutomationTrigger(context.triggerType, {
+      sourceType: context.sourceType,
+      sourceId: context.sourceId,
+      occurredAt: validDate(now).toISOString()
+    });
+    proposals.push(...evaluateAutomationRules(state, trigger, runtimeRules));
+  }
+  return proposals;
+}
+
+function compileStoredRule(rule, now) {
+  const checked = validateAutomationRule(rule);
+  if (!checked.valid || !EXECUTION_TRIGGERS.has(checked.rule.trigger)) return null;
+  const stored = checked.rule;
+  return {
+    id: stored.id,
+    triggers: [stored.trigger, AUTOMATION_TRIGGER.EXPLICIT_TEST],
+    conditions: stored.conditions.map((condition) => ({
+      id: condition.id,
+      test: ({ state, trigger }) => conditionMatches(condition, state, trigger, now)
+    })),
+    propose: ({ state, trigger }) => proposalForRule(stored, state, trigger, now)
+  };
+}
+
+function proposalForRule(rule, state, trigger, now) {
+  const source = { type: trigger.sourceType, id: trigger.sourceId };
+  const manualCategory = rule.action.type === AUTOMATION_RULE_ACTION.ASSIGN_BUDGET
+    && transactionById(state, trigger.sourceId)?.categorySource === 'manual';
+  const base = {
+    source,
+    sourceStatus: 'ready',
+    safetyClass: manualCategory ? AUTOMATION_SAFETY_CLASS.BLOCKED : AUTOMATION_SAFETY_CLASS.SAFE_AUTOMATIC,
+    certainty: AUTOMATION_CERTAINTY.CERTAIN,
+    reasonCode: manualCategory ? AUTOMATION_REASON.MANUAL_OVERRIDE : 'user_defined_local_rule',
+    explanation: rule.explanation
+  };
+
+  if (rule.action.type === AUTOMATION_RULE_ACTION.ASSIGN_BUDGET) {
+    const transaction = transactionById(state, trigger.sourceId);
+    const budget = (state.budgets || []).find((item) => String(item.id) === String(rule.action.value));
+    if (!transaction || !budget) return { ...base, sourceStatus: 'missing' };
+    return {
+      ...base,
+      action: {
+        type: 'assign_transaction_budget',
+        key: 'budget-category',
+        risk: 'housekeeping',
+        identityContext: { budgetId: budget.id, ruleUpdatedAt: rule.updatedAt },
+        payload: { budgetId: budget.id }
+      }
+    };
+  }
+
+  if (rule.action.type === AUTOMATION_RULE_ACTION.ADD_TAG) {
+    if (!transactionById(state, trigger.sourceId)) return { ...base, sourceStatus: 'missing' };
+    return {
+      ...base,
+      action: {
+        type: 'add_local_tag',
+        key: `tag:${normalise(rule.action.value)}`,
+        risk: 'housekeeping',
+        identityContext: { tag: normalise(rule.action.value), ruleUpdatedAt: rule.updatedAt },
+        payload: { tag: rule.action.value }
+      }
+    };
+  }
+
+  const pattern = recurringPatternForTrigger(state, trigger);
+  const dueDate = pattern?.nextExpected?.date || '';
+  return {
+    ...base,
+    action: {
+      type: 'create_local_reminder',
+      key: 'local-reminder',
+      risk: 'housekeeping',
+      identityContext: { title: rule.action.value, dueDate, ruleUpdatedAt: rule.updatedAt },
+      payload: {
+        title: rule.action.value,
+        detail: pattern ? `${pattern.label} · expected ${dueDate}` : rule.explanation
+      }
+    }
+  };
+}
+
+function conditionMatches(condition, state, trigger, now) {
+  const transaction = transactionById(state, trigger.sourceId);
+  const pattern = recurringPatternForTrigger(state, trigger);
+
+  if (condition.field === AUTOMATION_RULE_CONDITION.MERCHANT) {
+    if (!transaction) return false;
+    const merchant = normalise(transaction.merchantName || transaction.payee || transaction.description || transaction.userDescription);
+    return textMatches(merchant, condition);
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.PURPOSE) {
+    if (!transaction) return false;
+    const assignment = resolveTransactionBudgetAssignment(transaction, { budgets: state.budgets || [], transactions: state.transactions || [] });
+    const values = [
+      assignment.budget?.id,
+      assignment.budget?.category,
+      transaction.transactionPurpose,
+      transaction.category,
+      transaction.budgetCategoryId
+    ].map(normalise).filter(Boolean);
+    return values.some((value) => textMatches(value, condition));
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.ACCOUNT) return Boolean(transaction) && String(transaction.accountId || '') === String(condition.value);
+  if (condition.field === AUTOMATION_RULE_CONDITION.DIRECTION) {
+    if (!transaction) return false;
+    const direction = Number(transaction.incoming || 0) > 0 ? 'incoming' : Number(transaction.outgoing || 0) > 0 ? 'outgoing' : '';
+    return direction === condition.value;
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.AMOUNT) {
+    if (!transaction) return false;
+    const amount = Number(transaction.incoming || 0) > 0 ? Number(transaction.incoming) : Number(transaction.outgoing || 0);
+    return rangeMatches(amount, condition);
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.RECURRING_CADENCE) return pattern?.cadence === condition.value;
+  if (condition.field === AUTOMATION_RULE_CONDITION.REVIEW_STATE) {
+    if (!transaction) return false;
+    const stateValue = transaction.reviewStatus || transaction.importReviewStatus || 'none';
+    return stateValue === condition.value;
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE) {
+    if (!pattern?.nextExpected?.date) return false;
+    return rangeMatches(daysBetween(localDateKey(validDate(now)), pattern.nextExpected.date), condition);
+  }
+  return false;
+}
+
+function evaluationContexts(state, now, includeDisabled = false) {
+  const contexts = [];
+  const hasTransactionRules = state.automation.rules.some((rule) => (includeDisabled || rule.enabled) && rule.trigger === AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE);
+  if (hasTransactionRules) {
+    for (const transaction of state.transactions || []) {
+      if (!transaction?.id || transaction.deletedAt) continue;
+      contexts.push({ triggerType: AUTOMATION_TRIGGER.TRANSACTION_CHANGE, sourceType: 'transaction', sourceId: String(transaction.id) });
+    }
+  }
+  const hasDateRules = state.automation.rules.some((rule) => (includeDisabled || rule.enabled) && rule.trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY);
+  if (hasDateRules) {
+    for (const pattern of deriveRecurringPatterns(state, { includeRejected: false })) {
+      if (pattern.confidence !== RECURRING_CONFIDENCE.CONFIRMED || !pattern.nextExpected?.date) continue;
+      contexts.push({ triggerType: AUTOMATION_TRIGGER.DATE_BOUNDARY, sourceType: 'recurring_pattern', sourceId: pattern.id });
+    }
+  }
+  return contexts;
+}
+
+function recurringPatternForTrigger(state, trigger) {
+  const patterns = deriveRecurringPatterns(state, { includeRejected: false });
+  if (trigger.sourceType === 'recurring_pattern') return patterns.find((pattern) => pattern.id === trigger.sourceId) || null;
+  if (trigger.sourceType === 'transaction') return patterns.find((pattern) => pattern.sourceTransactionIds.includes(String(trigger.sourceId))) || null;
+  return null;
+}
+
+function withNormalisedRules(state) {
+  const next = structuredClone(state || {});
+  next.automation = normaliseAutomationRuleState(next.automation);
+  next.automation.rules = normaliseAutomationRuleCollection(next.automation.rules);
+  return next;
+}
+
+function transactionById(state, id) {
+  return (state.transactions || []).find((transaction) => String(transaction.id) === String(id)) || null;
+}
+
+function textMatches(value, condition) {
+  const expected = normalise(condition.value);
+  if (!expected) return false;
+  return condition.operator === 'contains' ? value.includes(expected) : value === expected;
+}
+
+function rangeMatches(value, condition) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return false;
+  const first = Number(condition.value);
+  if (!Number.isFinite(first)) return false;
+  if (condition.operator === 'at_least') return number >= first;
+  if (condition.operator === 'at_most') return number <= first;
+  if (condition.operator === 'between') {
+    const second = Number(condition.value2);
+    return Number.isFinite(second) && number >= first && number <= second;
+  }
+  return number === first;
+}
+
+function daysBetween(left, right) {
+  const [ly, lm, ld] = String(left).split('-').map(Number);
+  const [ry, rm, rd] = String(right).split('-').map(Number);
+  return Math.round((Date.UTC(ry, rm - 1, rd) - Date.UTC(ly, lm - 1, ld)) / 86_400_000);
+}
+function localDateKey(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+function normalise(value) { return String(value || '').trim().toLowerCase().replace(/\s+/g, ' '); }
+function validDate(value) {
+  const candidate = value === undefined ? new Date() : value instanceof Date ? value : new Date(value);
+  return Number.isNaN(candidate.getTime()) ? new Date() : candidate;
+}

--- a/automation-state.js
+++ b/automation-state.js
@@ -1,3 +1,5 @@
+import { normaliseAutomationRuleCollection } from './automation-rule-model.js';
+
 const EXECUTION_ID_PATTERN = /^[0-9a-f]{64}$/;
 const SAFE_CODE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,119}$/;
 const MAX_EXECUTIONS = 5000;
@@ -10,6 +12,7 @@ export function normaliseAutomationState(value) {
   return {
     version: AUTOMATION_STATE_VERSION,
     enabled: automation.enabled !== false,
+    rules: normaliseAutomationRuleCollection(automation.rules),
     executions: normaliseExecutions(automation.executions),
     manualOverrides: normaliseManualOverrides(automation.manualOverrides)
   };

--- a/main-entry.js
+++ b/main-entry.js
@@ -1,0 +1,33 @@
+import { ipcMain } from 'electron';
+import { previewStoredAutomationRules, runStoredAutomationRules } from './automation-rules.js';
+import './main-process.js';
+
+const MAX_AUTOMATION_STATE_BYTES = 25_000_000;
+
+ipcMain.handle('automation:preview', (_event, state, options = {}) => {
+  validateStatePayload(state);
+  return previewStoredAutomationRules(state, {
+    ruleId: String(options?.ruleId || ''),
+    now: safeNow(options?.now)
+  });
+});
+
+ipcMain.handle('automation:run', async (_event, state, options = {}) => {
+  validateStatePayload(state);
+  return runStoredAutomationRules(state, {
+    now: safeNow(options?.now),
+    recoveryMode: 'normal'
+  });
+});
+
+function validateStatePayload(state) {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) throw new TypeError('Automation state is invalid.');
+  if (JSON.stringify(state).length > MAX_AUTOMATION_STATE_BYTES) throw new TypeError('Automation state is too large.');
+}
+
+function safeNow(value) {
+  if (value === undefined || value === null || value === '') return new Date();
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) throw new TypeError('Automation date is invalid.');
+  return date;
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A local-first, ADHD-friendly UK finance and debt companion built around one clear move at a time.",
   "private": true,
   "type": "module",
-  "main": "main-process.js",
+  "main": "main-entry.js",
   "author": "OneStep Money contributors",
   "license": "MIT",
   "repository": {
@@ -46,6 +46,9 @@
     "asar": true,
     "files": [
       "automation-engine.js",
+      "automation-rule-model.js",
+      "automation-rules.js",
+      "automation-rules-ui.js",
       "automation-state.js",
       "data-store.js",
       "date-utils.js",
@@ -58,6 +61,7 @@
       "financial-reporting.js",
       "index.html",
       "local-llm-service.js",
+      "main-entry.js",
       "main-process.js",
       "next-move-priority.js",
       "payday-awareness.js",

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -4,6 +4,8 @@ contextBridge.exposeInMainWorld('financeAPI', Object.freeze({
   getAppVersion: () => ipcRenderer.invoke('app:version'),
   loadState: () => ipcRenderer.invoke('state:load'),
   saveState: (state) => ipcRenderer.invoke('state:save', state),
+  previewAutomationRules: (state, options) => ipcRenderer.invoke('automation:preview', state, options),
+  runAutomationRules: (state, options) => ipcRenderer.invoke('automation:run', state, options),
   retryRecovery: () => ipcRenderer.invoke('recovery:retry'),
   restoreRecoveryBackup: (backupId) => ipcRenderer.invoke('recovery:restore-backup', backupId),
   selectRecoveryPortableBackup: (passphrase) => ipcRenderer.invoke('recovery:select-portable-backup', passphrase),

--- a/recurring-finance-ui.js
+++ b/recurring-finance-ui.js
@@ -2,6 +2,7 @@ import {
   applyRecurringPatternDecision, deriveRecurringPatterns, RECURRING_DECISION
 } from './recurring-finance.js';
 import { renderPaydayAwareness } from './payday-awareness-ui.js';
+import { renderAutomationRulesPanel } from './automation-rules-ui.js';
 
 let latestState = null;
 let renderScheduled = false;
@@ -10,6 +11,7 @@ export function renderRecurringActivityPanel(state) {
   if (typeof document === 'undefined' || typeof window === 'undefined') return;
   latestState = state;
   renderPaydayAwareness(state);
+  renderAutomationRulesPanel(state);
   if (renderScheduled) return;
   renderScheduled = true;
   queueMicrotask(() => { renderScheduled = false; renderPanel(); });
@@ -52,7 +54,7 @@ function decisionButton(label, patternId, decision, className) { const button = 
 async function handleDecision(event) {
   const button = event.target.closest('[data-recurring-decision]'); if (!button || !latestState || !window.financeAPI?.saveState) return;
   const status = document.getElementById('recurringActivityStatus'); button.disabled = true; if (status) status.textContent = button.dataset.recurringDecision === RECURRING_DECISION.CONFIRMED ? 'Confirming this pattern…' : 'Rejecting this pattern…';
-  try { const next = applyRecurringPatternDecision(latestState, button.dataset.recurringPatternId, button.dataset.recurringDecision, new Date()); latestState = await window.financeAPI.saveState(next); if (status) status.textContent = button.dataset.recurringDecision === RECURRING_DECISION.CONFIRMED ? 'Pattern confirmed. Its expected window can now be used by financial automation.' : 'Pattern rejected. Identical evidence will stay rejected unless the underlying history materially changes.'; renderPaydayAwareness(latestState); renderPanel(); window.setTimeout(() => window.location.reload(), 150); }
+  try { const next = applyRecurringPatternDecision(latestState, button.dataset.recurringPatternId, button.dataset.recurringDecision, new Date()); latestState = await window.financeAPI.saveState(next); if (status) status.textContent = button.dataset.recurringDecision === RECURRING_DECISION.CONFIRMED ? 'Pattern confirmed. Its expected window can now be used by financial automation.' : 'Pattern rejected. Identical evidence will stay rejected unless the underlying history materially changes.'; renderPaydayAwareness(latestState); renderAutomationRulesPanel(latestState); renderPanel(); window.setTimeout(() => window.location.reload(), 150); }
   catch (error) { button.disabled = false; if (status) status.textContent = error?.message || 'The recurring-pattern decision could not be saved.'; }
 }
 function amountSummary(pattern) { const range = pattern.amountRange; if (!range) return `${pattern.occurrences} occurrence${pattern.occurrences === 1 ? '' : 's'}`; const amount = range.min === range.max ? formatMoney(range.min) : `${formatMoney(range.min)}–${formatMoney(range.max)}`; return `${pattern.occurrences} occurrence${pattern.occurrences === 1 ? '' : 's'} · typical ${formatMoney(range.typical)} · observed ${amount}`; }

--- a/scripts/build-pages-site.mjs
+++ b/scripts/build-pages-site.mjs
@@ -13,6 +13,8 @@ export const PAGE_FILES = Object.freeze([
   ['demo/demo-data.js', 'demo/demo-data.js'],
   ['demo/demo-state.js', 'demo/demo-state.js'],
   ['assets/onestep-money-icon.png', 'assets/onestep-money-icon.png'],
+  ['automation-rule-model.js', 'automation-rule-model.js'],
+  ['automation-rules-ui.js', 'automation-rules-ui.js'],
   ['date-utils.js', 'date-utils.js'],
   ['finance-core.js', 'finance-core.js'],
   ['financial-reporting.js', 'financial-reporting.js'],

--- a/tests/automation-persistence.test.js
+++ b/tests/automation-persistence.test.js
@@ -19,7 +19,7 @@ test('legacy state migrates automation metadata safely and backup/restore preser
 
   let current = (await store.loadState()).state;
   assert.equal(current.schemaVersion, 10);
-  assert.deepEqual(current.automation, { version: 1, enabled: true, executions: {}, manualOverrides: {} });
+  assert.deepEqual(current.automation, { version: 1, enabled: true, rules: [], executions: {}, manualOverrides: {} });
 
   current.transactions.push(fictionalTransaction());
   current = await store.saveState(current);

--- a/tests/automation-rules.test.js
+++ b/tests/automation-rules.test.js
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import test from 'node:test';
+import {
+  AUTOMATION_RULE_ACTION, AUTOMATION_RULE_CONDITION, AUTOMATION_RULE_TRIGGER,
+  duplicateAutomationRule, normaliseAutomationRuleCollection, removeAutomationRule,
+  setAutomationRuleEnabled, upsertAutomationRule, validateAutomationRule
+} from '../automation-rule-model.js';
+import { normaliseAutomationState } from '../automation-state.js';
+import { previewStoredAutomationRules, runStoredAutomationRules } from '../automation-rules.js';
+
+function baseState() {
+  return {
+    meta: { revision: 7 },
+    automation: normaliseAutomationState(),
+    accounts: [{ id: 'account-main', name: 'Main account', active: true }],
+    budgets: [
+      { id: 'budget-food', category: 'Food', planned: 300 },
+      { id: 'budget-fuel', category: 'Fuel', planned: 180 }
+    ],
+    transactions: [{
+      id: 'tx-tesco-fuel',
+      accountId: 'account-main',
+      date: '2026-04-20',
+      description: 'CARD PURCHASE 123456',
+      merchantName: 'Tesco Fuel',
+      outgoing: 45,
+      incoming: 0,
+      category: '',
+      budgetCategoryId: '',
+      categorySource: 'imported',
+      reviewStatus: 'pending',
+      financiallyActive: true
+    }],
+    tasks: []
+  };
+}
+
+function merchantBudgetRule(overrides = {}) {
+  return {
+    id: 'rule_tesco_fuel',
+    name: 'Tesco fuel to Fuel',
+    enabled: true,
+    trigger: AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE,
+    conditions: [{
+      id: 'merchant',
+      field: AUTOMATION_RULE_CONDITION.MERCHANT,
+      operator: 'equals',
+      value: 'Tesco Fuel'
+    }],
+    action: { type: AUTOMATION_RULE_ACTION.ASSIGN_BUDGET, value: 'budget-fuel' },
+    explanation: 'When the merchant is Tesco Fuel, use the Fuel budget.',
+    ...overrides
+  };
+}
+
+test('rule CRUD stays bounded, validated and restart-safe', () => {
+  let state = upsertAutomationRule(baseState(), merchantBudgetRule(), new Date('2026-08-11T11:00:00.000Z'));
+  assert.equal(state.automation.rules.length, 1);
+  assert.equal(state.automation.rules[0].id, 'rule_tesco_fuel');
+
+  state = duplicateAutomationRule(state, 'rule_tesco_fuel', 'rule_tesco_fuel_copy', new Date('2026-08-11T11:05:00.000Z'));
+  assert.equal(state.automation.rules.length, 2);
+  assert.equal(state.automation.rules.find((rule) => rule.id === 'rule_tesco_fuel_copy').enabled, false);
+
+  state = setAutomationRuleEnabled(state, 'rule_tesco_fuel_copy', true, new Date('2026-08-11T11:10:00.000Z'));
+  assert.equal(state.automation.rules.find((rule) => rule.id === 'rule_tesco_fuel_copy').enabled, true);
+
+  state = removeAutomationRule(state, 'rule_tesco_fuel_copy');
+  assert.deepEqual(state.automation.rules.map((rule) => rule.id), ['rule_tesco_fuel']);
+
+  const restarted = normaliseAutomationState(JSON.parse(JSON.stringify(state.automation)));
+  assert.deepEqual(restarted.rules, state.automation.rules);
+});
+
+test('invalid or unsupported actions cannot persist', () => {
+  const checked = validateAutomationRule({
+    ...merchantBudgetRule(),
+    action: { type: 'transfer_money', value: 'fictional destination' }
+  });
+  assert.equal(checked.valid, false);
+  assert.match(checked.errors.join(' '), /supported Then action/i);
+
+  const collection = normaliseAutomationRuleCollection([merchantBudgetRule(), {
+    ...merchantBudgetRule(),
+    id: 'rule_forbidden',
+    action: { type: 'external_payment', value: 'nowhere' }
+  }]);
+  assert.deepEqual(collection.map((rule) => rule.id), ['rule_tesco_fuel']);
+});
+
+test('merchant identity can drive a deterministic budget assignment through the shared engine', async () => {
+  const configured = upsertAutomationRule(baseState(), merchantBudgetRule(), new Date('2026-08-11T11:00:00.000Z'));
+  const result = await runStoredAutomationRules(configured, { now: new Date('2026-08-11T12:00:00.000Z'), recoveryMode: 'normal' });
+  assert.equal(result.changed, true);
+  assert.equal(result.state.transactions[0].budgetCategoryId, 'budget-fuel');
+  assert.equal(result.state.transactions[0].category, 'Fuel');
+  assert.equal(result.state.transactions[0].categorySource, 'automation');
+  assert.equal(result.results.filter((row) => row.status === 'applied').length, 1);
+});
+
+test('manual transaction purpose always wins over automation', async () => {
+  const state = baseState();
+  state.transactions[0].budgetCategoryId = 'budget-food';
+  state.transactions[0].category = 'Food';
+  state.transactions[0].categorySource = 'manual';
+  const configured = upsertAutomationRule(state, merchantBudgetRule(), new Date('2026-08-11T11:00:00.000Z'));
+  const result = await runStoredAutomationRules(configured, { now: new Date('2026-08-11T12:00:00.000Z'), recoveryMode: 'normal' });
+  assert.equal(result.changed, false);
+  assert.equal(result.state.transactions[0].budgetCategoryId, 'budget-food');
+  assert.equal(result.state.transactions[0].category, 'Food');
+  assert.ok(result.results.some((row) => row.reasonCode === 'manual_override'));
+});
+
+test('disabled rule and global pause never mutate financial state', async () => {
+  const disabled = upsertAutomationRule(baseState(), { ...merchantBudgetRule(), enabled: false }, new Date('2026-08-11T11:00:00.000Z'));
+  let result = await runStoredAutomationRules(disabled, { now: new Date('2026-08-11T12:00:00.000Z'), recoveryMode: 'normal' });
+  assert.equal(result.changed, false);
+  assert.equal(result.state.transactions[0].budgetCategoryId, '');
+
+  const pausedState = baseState();
+  pausedState.automation.enabled = false;
+  const paused = upsertAutomationRule(pausedState, merchantBudgetRule(), new Date('2026-08-11T11:00:00.000Z'));
+  result = await runStoredAutomationRules(paused, { now: new Date('2026-08-11T12:00:00.000Z'), recoveryMode: 'normal' });
+  assert.equal(result.changed, false);
+  assert.equal(result.state.transactions[0].budgetCategoryId, '');
+});
+
+test('recovery mode blocks otherwise safe rule execution', async () => {
+  const configured = upsertAutomationRule(baseState(), merchantBudgetRule(), new Date('2026-08-11T11:00:00.000Z'));
+  const result = await runStoredAutomationRules(configured, { now: new Date('2026-08-11T12:00:00.000Z'), recoveryMode: 'recovery_required' });
+  assert.equal(result.changed, false);
+  assert.equal(result.state.transactions[0].budgetCategoryId, '');
+  assert.ok(result.results.some((row) => row.reasonCode === 'recovery_mode_active'));
+});
+
+test('the same rule action is idempotent across repeated cycles', async () => {
+  const configured = upsertAutomationRule(baseState(), merchantBudgetRule(), new Date('2026-08-11T11:00:00.000Z'));
+  const first = await runStoredAutomationRules(configured, { now: new Date('2026-08-11T12:00:00.000Z'), recoveryMode: 'normal' });
+  const second = await runStoredAutomationRules(first.state, { now: new Date('2026-08-11T12:05:00.000Z'), recoveryMode: 'normal' });
+  assert.equal(first.changed, true);
+  assert.equal(second.changed, false);
+  assert.ok(second.results.some((row) => row.status === 'already_applied'));
+  assert.equal(second.state.transactions[0].budgetCategoryId, 'budget-fuel');
+});
+
+test('compatible duplicate actions deduplicate and conflicting categories fail safe', async () => {
+  let compatible = upsertAutomationRule(baseState(), merchantBudgetRule(), new Date('2026-08-11T11:00:00.000Z'));
+  compatible = upsertAutomationRule(compatible, {
+    ...merchantBudgetRule(),
+    id: 'rule_tesco_fuel_second',
+    name: 'Same safe Fuel assignment'
+  }, new Date('2026-08-11T11:01:00.000Z'));
+  let result = await runStoredAutomationRules(compatible, { now: new Date('2026-08-11T12:00:00.000Z'), recoveryMode: 'normal' });
+  assert.equal(result.changed, true);
+  assert.equal(result.state.transactions[0].budgetCategoryId, 'budget-fuel');
+  assert.ok(result.results.some((row) => row.reasonCode === 'compatible_duplicate_rule_action'));
+
+  let conflicting = upsertAutomationRule(baseState(), merchantBudgetRule(), new Date('2026-08-11T11:00:00.000Z'));
+  conflicting = upsertAutomationRule(conflicting, {
+    ...merchantBudgetRule(),
+    id: 'rule_tesco_food',
+    name: 'Conflicting Food assignment',
+    action: { type: AUTOMATION_RULE_ACTION.ASSIGN_BUDGET, value: 'budget-food' }
+  }, new Date('2026-08-11T11:01:00.000Z'));
+  result = await runStoredAutomationRules(conflicting, { now: new Date('2026-08-11T12:00:00.000Z'), recoveryMode: 'normal' });
+  assert.equal(result.changed, false);
+  assert.equal(result.state.transactions[0].budgetCategoryId, '');
+  assert.equal(result.conflicts.length, 1);
+  assert.ok(result.results.some((row) => row.reasonCode === 'rule_conflict'));
+});
+
+test('preview includes a paused rule but never mutates state', () => {
+  const state = upsertAutomationRule(baseState(), { ...merchantBudgetRule(), enabled: false }, new Date('2026-08-11T11:00:00.000Z'));
+  const preview = previewStoredAutomationRules(state, { ruleId: 'rule_tesco_fuel', now: new Date('2026-08-11T12:00:00.000Z') });
+  assert.equal(preview.matchCount, 1);
+  assert.equal(state.transactions[0].budgetCategoryId, '');
+});
+
+test('date-relative recurring rule creates one local reminder for a confirmed pattern', async () => {
+  const state = baseState();
+  state.transactions = ['2026-01-01', '2026-02-01', '2026-03-01', '2026-04-01'].map((date, index) => ({
+    id: `tx-rent-${index + 1}`,
+    accountId: 'account-main',
+    date,
+    merchantName: 'Fictional Homes',
+    description: 'Fictional Homes',
+    outgoing: 700,
+    incoming: 0,
+    category: 'Rent',
+    budgetCategoryId: 'budget-food',
+    categorySource: 'imported',
+    financiallyActive: true
+  }));
+  const rule = {
+    id: 'rule_rent_due',
+    name: 'Rent reminder',
+    enabled: true,
+    trigger: AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY,
+    conditions: [
+      { id: 'cadence', field: AUTOMATION_RULE_CONDITION.RECURRING_CADENCE, operator: 'equals', value: 'monthly' },
+      { id: 'due', field: AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE, operator: 'between', value: 0, value2: 3 }
+    ],
+    action: { type: AUTOMATION_RULE_ACTION.CREATE_REMINDER, value: 'Check upcoming rent' },
+    explanation: 'Remind me shortly before the expected monthly rent date.'
+  };
+  const configured = upsertAutomationRule(state, rule, new Date('2026-04-28T12:00:00.000Z'));
+  const result = await runStoredAutomationRules(configured, { now: new Date('2026-04-29T12:00:00.000Z'), recoveryMode: 'normal' });
+  assert.equal(result.changed, true);
+  assert.equal(result.state.tasks.length, 1);
+  assert.equal(result.state.tasks[0].title, 'Check upcoming rent');
+  const repeated = await runStoredAutomationRules(result.state, { now: new Date('2026-04-30T12:00:00.000Z'), recoveryMode: 'normal' });
+  assert.equal(repeated.changed, false);
+  assert.equal(repeated.state.tasks.length, 1);
+});
+
+test('rules implementation has no network, telemetry or analytics dependency', async () => {
+  for (const file of ['automation-rule-model.js', 'automation-rules.js']) {
+    const source = await fs.readFile(new URL(`../${file}`, import.meta.url), 'utf8');
+    assert.doesNotMatch(source, /from ['"]node:(?:http|https|net|tls|dns)['"]/);
+    assert.doesNotMatch(source, /\bfetch\s*\(/);
+    assert.doesNotMatch(source, /telemetry|analytics/i);
+  }
+});


### PR DESCRIPTION
Closes #72

### Purpose
Implement the v2.2.0 branch-level Design Brief for simple, understandable local automation rules without creating a second automation engine or permitting unsafe/external actions.

### Work completed
- Added a bounded persisted rule model with stable IDs, names, enable/disable state, deterministic conditions, one approved action, explanations, and timestamps.
- Added a guided **When / If / Then** rule manager in Settings with create, edit, pause/enable, duplicate, delete confirmation, and local preview.
- Compiled stored rules into the existing #71 automation engine so execution keeps its idempotency, stale-state, recovery, manual-override, and forbidden-action protections.
- Added deterministic transaction rules for merchant/payee, purpose/budget, account, direction, amount, recurring cadence, and review state.
- Added date-relative reminder rules using confirmed recurring-pattern dates from the existing recurring-finance model.
- Added approved local actions for budget/category assignment, local tags, and local reminders only.
- Added conflict handling: identical compatible category actions deduplicate; incompatible category targets are blocked for review instead of using race/last-write-wins behaviour.
- Preserved manual category/budget choices as authoritative.
- Added IPC/preload boundaries so the Node-based shared automation engine stays in the main process rather than being reimplemented in the browser renderer.
- Updated the existing automation persistence regression expectation for the additive `rules: []` state field after the first CI run identified the stale assertion.

### Files changed
- `automation-rule-model.js`
- `automation-rules.js`
- `automation-rules-ui.js`
- `automation-state.js`
- `main-entry.js`
- `package.json`
- `preload-bridge.cjs`
- `recurring-finance-ui.js`
- `scripts/build-pages-site.mjs`
- `tests/automation-rules.test.js`
- `tests/automation-persistence.test.js`

### User-facing changes
- New **Simple rules** section in Settings.
- Global automation pause remains available and is surfaced beside rule management.
- Users can build understandable rules such as “When a payment changes, if merchant is Tesco Fuel, then assign Fuel”.
- Users can preview a rule without applying changes.
- Users can pause, enable, duplicate, edit, or delete rules; deletion explicitly warns that existing financial history is not reversed.
- Conflicting category decisions are left unapplied and surfaced as requiring review.

### Technical changes
- Rule definitions persist under the existing `state.automation.rules` object and normalise legacy/malformed rule data to safe bounded defaults.
- Runtime proposals execute through `automation-engine.js` from #71.
- Category/purpose matching uses the existing transaction-categorisation model from #39.
- Recurring/date conditions use the existing recurring-finance model.
- Rule execution remains local-only; no network service, telemetry, analytics, or remote financial storage is introduced.
- Existing state-save revision/recovery protection remains the final persistence guard.

### Testing and verification
- **Passed — local source syntax:** `node --check` over all authored JS/CJS/MJS and the new test file.
- **Passed — local package JSON:** parsed successfully with `python -m json.tool`.
- **Passed — local isolated model smoke check:** rule upsert/duplicate/normalisation exercised with fictional data.
- **Passed — Linux GitHub CI:** `npm test` — 383/383 tests passed on the final head.
- **Passed — Linux GitHub CI:** `npm run check` including project and privacy checks.
- **Passed — Linux GitHub CI:** `npm run lint`.
- **Passed — Windows GitHub CI:** `npm test`.
- **Passed — Windows GitHub CI:** `npm run check` including project/privacy checks.
- **Passed — Windows GitHub CI:** `npm run lint`.
- **Passed — Windows GitHub CI:** built Pages artifact runtime smoke test.
- **Passed — Windows GitHub CI:** Electron desktop startup smoke test.
- **Passed — Windows GitHub CI:** Windows packaging smoke test.
- **Skipped as designed — release-windows job:** release publishing is not run for this draft PR; the packaging smoke above is the verification used here.
- **Unavailable locally — manual Electron UI verification:** this environment does not have an interactive repository/Electron desktop session; CI startup smoke is not represented as manual testing.
- **Unavailable locally — Light/Night manual visual verification:** requires an interactive Electron session.

### Data and migration impact
- Additive only: automation rules are stored inside the existing automation state object.
- Existing states without `automation.rules` migrate to an empty rules collection.
- Existing execution/manual-override metadata is preserved and bounded by the existing automation-state normaliser.
- Backup/restore carries rules as part of the existing financial-state payload; no separate file or cloud data store is introduced.
- Malformed/unsupported stored rules are dropped conservatively rather than executed.

### Known limitations
- v2.2.0 #72 deliberately remains a constrained rule builder, not a scripting language.
- Date-relative automation in this brief creates local reminders only; it does not move money or make external changes.
- Conflicting category rules are blocked and surfaced rather than automatically resolved.
- GitHub Project custom-field updates (Status/Branch/Start Date) are unavailable through the connected GitHub tooling in this workflow, so those fields were not fabricated.
- Manual Light/Night UI verification remains outstanding until an interactive Electron environment is available.
- The branch contains the principal implementation commit plus one narrow CI correction commit for the pre-existing persistence assertion; history was not rewritten or force-pushed.

### Excluded work
- Money movement, borrowing, external payments, account changes, document deletion, external communications, network services, telemetry, analytics, and cloud storage.
- Arbitrary scripting/expression execution.
- Reimplementation of #71 automation safety or #39 merchant/purpose categorisation.
- Future AI-authored or advanced automation features outside #72.

### Branch details
- Branch: `feature/automation-rules`
- Commit SHA: `5ae337e0269f14180729b4a480aeb602d21b1fd2`
- Pull request: #116
- Target branch: `main`

### Confirmations
- No changes committed/pushed directly to `main`.
- PR not merged by this workflow.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs committed.
- Only relevant files changed.