### PR TITLE
[v2.2.0][QOL] Bulk payment review and categorisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
       "main-entry.js",
       "main-process.js",
       "next-move-priority.js",
+      "payment-bulk-review.js",
+      "payment-bulk-review-ui.js",
       "payday-awareness.js",
       "payday-awareness-ui.js",
       "pdf-service.js",

--- a/payment-bulk-review-ui.js
+++ b/payment-bulk-review-ui.js
@@ -1,0 +1,297 @@
+import {
+  applyPaymentBulkCategorisation, buildPaymentBulkCategorisationPlan, paymentBulkCategoryOptions,
+  paymentBulkEligibility, retainVisiblePaymentSelection
+} from './payment-bulk-review.js';
+import { synchroniseReviewItems } from './review-lifecycle.js';
+
+const RETURN_TO_PAYMENTS_KEY = 'onestep:return-to-payments-after-bulk-review';
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') initialisePaymentBulkReviewUi();
+
+function initialisePaymentBulkReviewUi() {
+  const body = document.getElementById('transactionRows');
+  const table = document.getElementById('transactionTable');
+  const view = document.getElementById('view-transactions');
+  if (!body || !table || !view) return;
+
+  injectStyles();
+  const controls = createControls(table);
+  const selection = new Set();
+  let visibleEligibleIds = [];
+  let pending = null;
+  let syncGeneration = 0;
+
+  const observer = new MutationObserver(() => scheduleSync());
+  observer.observe(body, { childList: true });
+  ensureSelectionHeader(table);
+  scheduleSync();
+  restorePaymentsViewAfterReload();
+
+  controls.selectVisible.addEventListener('click', () => {
+    selection.clear();
+    visibleEligibleIds.forEach((id) => selection.add(id));
+    syncCheckboxes();
+    renderSelectionState();
+  });
+  controls.clearSelection.addEventListener('click', () => {
+    selection.clear();
+    syncCheckboxes();
+    renderSelectionState();
+  });
+  controls.category.addEventListener('change', renderSelectionState);
+  controls.review.addEventListener('click', reviewBulkChange);
+  controls.cancel.addEventListener('click', () => controls.dialog.close('cancelled'));
+  controls.dialog.addEventListener('cancel', (event) => {
+    event.preventDefault();
+    controls.dialog.close('cancelled');
+  });
+  controls.dialog.addEventListener('close', () => {
+    if (controls.dialog.returnValue !== 'apply') pending = null;
+  });
+  controls.apply.addEventListener('click', applyBulkChange);
+
+  function scheduleSync() {
+    const generation = ++syncGeneration;
+    queueMicrotask(() => syncVisibleRows(generation));
+  }
+
+  async function syncVisibleRows(generation) {
+    let loaded;
+    try { loaded = await window.financeAPI?.loadState(); }
+    catch { controls.toolbar.hidden = true; return; }
+    if (generation !== syncGeneration || loaded?.status !== 'normal') return;
+    const currentState = loaded.state;
+    refreshCategoryOptions(currentState);
+    ensureSelectionHeader(table);
+
+    const rows = [...body.querySelectorAll('tr')];
+    const visibleIds = [];
+    const eligibleIds = [];
+    observer.disconnect();
+    try {
+      for (const row of rows) {
+        const edit = row.querySelector('[data-edit="transaction"][data-id]');
+        if (!edit) {
+          const onlyCell = row.querySelector('td[colspan]');
+          if (onlyCell) onlyCell.colSpan = 9;
+          continue;
+        }
+        const id = String(edit.dataset.id || '');
+        visibleIds.push(id);
+        const transaction = (currentState.transactions || []).find((item) => String(item?.id) === id);
+        const eligibility = paymentBulkEligibility(transaction);
+        if (eligibility.eligible) eligibleIds.push(id);
+        ensureRowCheckbox(row, id, eligibility);
+      }
+    } finally {
+      observer.observe(body, { childList: true });
+    }
+
+    const retained = retainVisiblePaymentSelection([...selection], visibleIds, eligibleIds);
+    selection.clear(); retained.forEach((id) => selection.add(id));
+    visibleEligibleIds = eligibleIds;
+    syncCheckboxes();
+    controls.toolbar.hidden = visibleEligibleIds.length === 0;
+    controls.selectVisible.disabled = visibleEligibleIds.length === 0;
+    controls.selectVisible.textContent = visibleEligibleIds.length ? `Select visible (${visibleEligibleIds.length})` : 'Select visible';
+    renderSelectionState();
+  }
+
+  function ensureRowCheckbox(row, id, eligibility) {
+    let cell = row.querySelector('td.payment-bulk-select-cell');
+    if (!cell) {
+      cell = document.createElement('td');
+      cell.className = 'payment-bulk-select-cell';
+      row.prepend(cell);
+    }
+    let checkbox = cell.querySelector('input[data-payment-bulk-select]');
+    if (!checkbox) {
+      checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.dataset.paymentBulkSelect = 'true';
+      checkbox.setAttribute('aria-label', 'Select payment for bulk review');
+      checkbox.addEventListener('change', () => {
+        const paymentId = String(checkbox.dataset.id || '');
+        if (checkbox.checked) selection.add(paymentId); else selection.delete(paymentId);
+        renderSelectionState();
+      });
+      cell.append(checkbox);
+    }
+    checkbox.dataset.id = id;
+    checkbox.disabled = !eligibility.eligible;
+    checkbox.title = eligibility.eligible ? 'Select this visible payment' : eligibility.reason;
+  }
+
+  function syncCheckboxes() {
+    body.querySelectorAll('input[data-payment-bulk-select]').forEach((checkbox) => {
+      checkbox.checked = !checkbox.disabled && selection.has(String(checkbox.dataset.id || ''));
+    });
+  }
+
+  function refreshCategoryOptions(currentState) {
+    const previous = controls.category.value;
+    const options = paymentBulkCategoryOptions(currentState);
+    controls.category.replaceChildren(option('', 'Choose purpose / category'));
+    options.forEach((entry) => controls.category.append(option(entry.value, entry.label)));
+    controls.category.value = [...controls.category.options].some((entry) => entry.value === previous) ? previous : '';
+  }
+
+  function renderSelectionState() {
+    const count = selection.size;
+    controls.count.textContent = count ? `${count} selected` : 'No payments selected';
+    controls.actions.hidden = count === 0;
+    controls.clearSelection.disabled = count === 0;
+    controls.review.disabled = count === 0 || !controls.category.value;
+  }
+
+  async function reviewBulkChange() {
+    if (!selection.size || !controls.category.value) return;
+    let loaded;
+    try { loaded = await window.financeAPI.loadState(); }
+    catch { controls.status.textContent = 'The current financial state could not be opened. Nothing changed.'; return; }
+    if (loaded?.status !== 'normal') {
+      controls.status.textContent = 'Bulk review is unavailable while financial data is in recovery mode.';
+      return;
+    }
+    const plan = buildPaymentBulkCategorisationPlan(loaded.state, [...selection], controls.category.value);
+    if (!plan.valid) {
+      controls.status.textContent = plan.errors[0] || 'Those payments cannot safely share one bulk change.';
+      scheduleSync();
+      return;
+    }
+    pending = { state: loaded.state, plan };
+    const direction = plan.direction === 'income' ? 'incoming' : 'outgoing';
+    controls.summary.textContent = `Apply “${plan.targetLabel}” to ${plan.selectedCount} selected ${direction} payment${plan.selectedCount === 1 ? '' : 's'}?`;
+    controls.explanation.textContent = plan.targetKind === 'clear'
+      ? 'Their manual budget assignment will be cleared and the payments will remain Uncategorised until you choose a new purpose.'
+      : 'Only the selected visible payments will change. Transfer, debt-payment, refund, reversal and unresolved-import semantics remain protected.';
+    controls.dialogStatus.textContent = '';
+    controls.dialog.showModal();
+    controls.cancel.focus();
+  }
+
+  async function applyBulkChange() {
+    if (!pending) return;
+    controls.apply.disabled = true;
+    controls.cancel.disabled = true;
+    controls.dialogStatus.textContent = 'Applying reviewed change…';
+    try {
+      const result = applyPaymentBulkCategorisation(pending.state, pending.plan, { synchroniseReviewItems, now: new Date() });
+      const saved = await window.financeAPI.saveState(result.state);
+      if (saved?.status === 'blocked') throw new Error(saved.message || 'Saving is paused while recovery is required.');
+      if (saved?.status === 'conflict') {
+        controls.dialog.returnValue = 'conflict';
+        controls.dialog.close();
+        selection.clear();
+        pending = null;
+        controls.status.textContent = saved.message || 'Payments changed elsewhere. Nothing from this bulk action was saved.';
+        window.sessionStorage.setItem(RETURN_TO_PAYMENTS_KEY, '1');
+        window.setTimeout(() => window.location.reload(), 450);
+        return;
+      }
+      window.sessionStorage.setItem(RETURN_TO_PAYMENTS_KEY, '1');
+      controls.dialog.returnValue = 'apply';
+      controls.dialog.close();
+      pending = null;
+      window.location.reload();
+    } catch (error) {
+      controls.dialogStatus.textContent = error?.message || 'That bulk change could not be saved. Nothing was applied.';
+    } finally {
+      controls.apply.disabled = false;
+      controls.cancel.disabled = false;
+    }
+  }
+}
+
+function createControls(table) {
+  const toolbar = document.createElement('section');
+  toolbar.className = 'payment-bulk-toolbar';
+  toolbar.hidden = true;
+  toolbar.setAttribute('aria-label', 'Bulk payment review');
+
+  const selectionControls = document.createElement('div');
+  selectionControls.className = 'payment-bulk-selection-controls';
+  const title = document.createElement('strong'); title.textContent = 'Bulk review';
+  const selectVisible = button('secondary-button', 'Select visible');
+  const clearSelection = button('secondary-button', 'Clear selection'); clearSelection.disabled = true;
+  const count = document.createElement('span'); count.className = 'payment-bulk-count'; count.textContent = 'No payments selected'; count.setAttribute('aria-live', 'polite');
+  selectionControls.append(title, selectVisible, clearSelection, count);
+
+  const actions = document.createElement('div');
+  actions.className = 'payment-bulk-actions'; actions.hidden = true;
+  const categoryLabel = document.createElement('label'); categoryLabel.textContent = 'Purpose / budget category';
+  const category = document.createElement('select'); category.setAttribute('aria-label', 'Bulk purpose or budget category');
+  category.append(option('', 'Choose purpose / category')); categoryLabel.append(category);
+  const review = button('primary-button', 'Review changes'); review.disabled = true;
+  actions.append(categoryLabel, review);
+  const status = document.createElement('p'); status.className = 'payment-bulk-status'; status.setAttribute('role', 'status'); status.setAttribute('aria-live', 'polite');
+  toolbar.append(selectionControls, actions, status);
+  table.before(toolbar);
+
+  const dialog = document.createElement('dialog'); dialog.className = 'payment-bulk-dialog';
+  const eyebrow = document.createElement('p'); eyebrow.className = 'eyebrow'; eyebrow.textContent = 'BULK PAYMENT REVIEW';
+  const heading = document.createElement('h2'); heading.textContent = 'Review category change';
+  const summary = document.createElement('p'); summary.className = 'payment-bulk-dialog-summary';
+  const explanation = document.createElement('p'); explanation.className = 'muted';
+  const dialogStatus = document.createElement('p'); dialogStatus.className = 'payment-bulk-dialog-status'; dialogStatus.setAttribute('role', 'status'); dialogStatus.setAttribute('aria-live', 'polite');
+  const dialogActions = document.createElement('div'); dialogActions.className = 'payment-bulk-dialog-actions';
+  const cancel = button('secondary-button', 'Cancel');
+  const apply = button('primary-button', 'Apply to selected');
+  dialogActions.append(cancel, apply);
+  dialog.append(eyebrow, heading, summary, explanation, dialogStatus, dialogActions);
+  document.body.append(dialog);
+
+  return { toolbar, selectVisible, clearSelection, count, actions, category, review, status, dialog, summary, explanation, dialogStatus, cancel, apply };
+}
+
+function ensureSelectionHeader(table) {
+  const row = table.querySelector('thead tr');
+  if (!row || row.querySelector('th.payment-bulk-select-heading')) return;
+  const heading = document.createElement('th'); heading.className = 'payment-bulk-select-heading'; heading.scope = 'col';
+  const label = document.createElement('span'); label.className = 'sr-only'; label.textContent = 'Select';
+  heading.append(label); row.prepend(heading);
+}
+
+function injectStyles() {
+  if (document.getElementById('paymentBulkReviewStyles')) return;
+  const style = document.createElement('style');
+  style.id = 'paymentBulkReviewStyles';
+  style.textContent = `
+    .payment-bulk-toolbar { display: grid; gap: .75rem; margin: 1rem 0; padding: .9rem 1rem; background: var(--surface-subtle); border: 1px solid var(--line); border-radius: 16px; }
+    .payment-bulk-selection-controls, .payment-bulk-actions, .payment-bulk-dialog-actions { display: flex; align-items: center; gap: .65rem; flex-wrap: wrap; }
+    .payment-bulk-selection-controls strong { margin-right: .15rem; }
+    .payment-bulk-count { color: var(--muted); font-weight: 700; }
+    .payment-bulk-actions label { display: grid; gap: .3rem; min-width: min(100%, 260px); color: var(--muted); font-size: .82rem; font-weight: 700; }
+    .payment-bulk-actions select { min-height: 40px; padding: .45rem .65rem; color: var(--ink); background: var(--control-surface); border: 1px solid var(--line-strong); border-radius: 10px; }
+    .payment-bulk-status, .payment-bulk-dialog-status { min-height: 1.25rem; margin: 0; color: var(--warning-ink); font-size: .88rem; }
+    .payment-bulk-select-heading, .payment-bulk-select-cell { width: 2.75rem; text-align: center; }
+    .payment-bulk-select-cell input { width: 1.05rem; height: 1.05rem; accent-color: var(--teal-dark); }
+    .payment-bulk-dialog { width: min(520px, calc(100vw - 2rem)); padding: 1.35rem; color: var(--ink); background: var(--panel); border: 1px solid var(--line-strong); border-radius: 20px; box-shadow: var(--shadow-strong); }
+    .payment-bulk-dialog::backdrop { background: rgba(6, 26, 56, .48); }
+    .payment-bulk-dialog-summary { font-weight: 700; }
+    .payment-bulk-dialog-actions { justify-content: flex-end; margin-top: 1rem; }
+    @media (max-width: 720px) { .payment-bulk-actions { align-items: stretch; } .payment-bulk-actions label, .payment-bulk-actions button { width: 100%; } }
+  `;
+  document.head.append(style);
+}
+
+function restorePaymentsViewAfterReload() {
+  if (window.sessionStorage.getItem(RETURN_TO_PAYMENTS_KEY) !== '1') return;
+  window.sessionStorage.removeItem(RETURN_TO_PAYMENTS_KEY);
+  let attempts = 0;
+  const timer = window.setInterval(() => {
+    attempts += 1;
+    const shell = document.getElementById('appShell');
+    const button = document.querySelector('.nav-button[data-view="transactions"]');
+    if (shell && !shell.hidden && button) {
+      window.clearInterval(timer);
+      button.click();
+      document.getElementById('transactionTable')?.focus({ preventScroll: true });
+      return;
+    }
+    if (attempts >= 80) window.clearInterval(timer);
+  }, 50);
+}
+
+function button(className, text) { const output = document.createElement('button'); output.type = 'button'; output.className = className; output.textContent = text; return output; }
+function option(value, text) { const output = document.createElement('option'); output.value = value; output.textContent = text; return output; }

--- a/payment-bulk-review.js
+++ b/payment-bulk-review.js
@@ -1,0 +1,132 @@
+export const PAYMENT_BULK_CLEAR_VALUE = 'payment-category:uncategorised';
+export const PAYMENT_BULK_INCOME_VALUE = 'payment-category:income';
+
+const BLOCKED_TREATMENTS = new Set(['transfer', 'savings_transfer', 'debt_payment', 'refund', 'reversal', 'ignored']);
+const INCOME_LABEL = 'Income';
+const UNCATEGORISED_LABEL = 'Uncategorised';
+
+export function paymentBulkEligibility(transaction) {
+  if (!transaction || !transaction.id) return ineligible('Payment is unavailable.');
+  if (transaction.deletedAt || transaction.ignored === true || transaction.valid === false) return ineligible('This payment is inactive or invalid.');
+  if (transaction.duplicateStatus === 'exact' || transaction.reviewStatus === 'rejected' || transaction.financiallyActive === false) {
+    return ineligible('This payment is excluded from trusted financial data.');
+  }
+  if (['pending', 'rejected'].includes(normalise(transaction.importReviewStatus))) {
+    return ineligible('This payment still has an unresolved import decision.');
+  }
+  if (transaction.transferStatus && normalise(transaction.transferStatus) !== 'no') {
+    return ineligible('Transfer candidates must be reviewed individually.');
+  }
+  if (BLOCKED_TREATMENTS.has(normalise(transaction.budgetTreatment)) || transaction.refundOfTransactionId || transaction.reversalOfTransactionId) {
+    return ineligible('This payment has special financial treatment that bulk categorisation must preserve.');
+  }
+  const direction = paymentDirection(transaction);
+  if (!direction) return ineligible('This payment does not have one clear incoming or outgoing direction.');
+  return { eligible: true, direction, reason: '' };
+}
+
+export function paymentBulkCategoryOptions(state = {}) {
+  const options = [
+    { value: PAYMENT_BULK_INCOME_VALUE, label: INCOME_LABEL, kind: 'income' },
+    { value: PAYMENT_BULK_CLEAR_VALUE, label: UNCATEGORISED_LABEL, kind: 'clear' },
+    ...(Array.isArray(state.budgets) ? state.budgets : [])
+      .filter((budget) => budget?.id && normalise(budget.category) !== 'income')
+      .map((budget) => ({ value: String(budget.id), label: String(budget.category || 'Budget category'), kind: 'budget' }))
+  ];
+  return options.sort((left, right) => left.label.localeCompare(right.label, 'en-GB', { sensitivity: 'base' }) || left.value.localeCompare(right.value));
+}
+
+export function retainVisiblePaymentSelection(selectedIds, visibleIds, eligibleIds = visibleIds) {
+  const visible = new Set((visibleIds || []).map(String));
+  const eligible = new Set((eligibleIds || []).map(String));
+  return [...new Set((selectedIds || []).map(String))].filter((id) => visible.has(id) && eligible.has(id));
+}
+
+export function buildPaymentBulkCategorisationPlan(state, transactionIds, targetValue) {
+  const selectedIds = [...new Set((transactionIds || []).map(String).filter(Boolean))];
+  if (!selectedIds.length) return invalidPlan('Select at least one visible payment.');
+  const transactions = Array.isArray(state?.transactions) ? state.transactions : [];
+  const selected = [];
+  for (const id of selectedIds) {
+    const transaction = transactions.find((item) => String(item?.id) === id);
+    if (!transaction) return invalidPlan('One or more selected payments are no longer available.');
+    const eligibility = paymentBulkEligibility(transaction);
+    if (!eligibility.eligible) return invalidPlan(eligibility.reason);
+    selected.push({ transaction, direction: eligibility.direction });
+  }
+
+  const directions = new Set(selected.map((entry) => entry.direction));
+  if (directions.size !== 1) return invalidPlan('Income and outgoing spending cannot share one bulk category change.');
+  const direction = selected[0].direction;
+  const target = resolveTarget(state, targetValue);
+  if (!target.valid) return invalidPlan(target.error);
+  if (target.kind === 'income' && direction !== 'income') return invalidPlan('Income can only be assigned to incoming payments.');
+  if (target.kind !== 'income' && direction !== 'expense') return invalidPlan('Budget categories and Uncategorised can only be applied to outgoing spending.');
+
+  return {
+    valid: true,
+    errors: [],
+    transactionIds: selectedIds,
+    selectedCount: selectedIds.length,
+    direction,
+    targetValue: target.value,
+    targetKind: target.kind,
+    targetLabel: target.label,
+    budgetCategoryId: target.budgetCategoryId || '',
+    expectedRevision: Number.isInteger(state?.meta?.revision) ? state.meta.revision : null
+  };
+}
+
+export function applyPaymentBulkCategorisation(state, plan, options = {}) {
+  const checked = buildPaymentBulkCategorisationPlan(state, plan?.transactionIds, plan?.targetValue);
+  if (!checked.valid) throw bulkError(checked.errors[0] || 'The bulk category change is no longer valid.');
+  if (plan?.expectedRevision !== undefined && plan.expectedRevision !== null && checked.expectedRevision !== plan.expectedRevision) {
+    throw bulkError('The financial state changed after this bulk action was reviewed.', 'PAYMENT_BULK_STALE_REVISION');
+  }
+
+  const nextState = structuredClone(state || {});
+  const updatedIds = [];
+  for (const id of checked.transactionIds) {
+    const transaction = nextState.transactions.find((item) => String(item?.id) === id);
+    if (!transaction) throw bulkError('A selected payment is no longer available.');
+    if (checked.targetKind === 'income') {
+      transaction.budgetCategoryId = '';
+      transaction.category = INCOME_LABEL;
+    } else if (checked.targetKind === 'clear') {
+      transaction.budgetCategoryId = '';
+      transaction.category = '';
+    } else {
+      transaction.budgetCategoryId = checked.budgetCategoryId;
+      transaction.category = checked.targetLabel;
+    }
+    transaction.categorySource = 'manual';
+    if (/^\d{4}-\d{2}/.test(String(transaction.date || ''))) transaction.budgetMonth = String(transaction.date).slice(0, 7);
+    updatedIds.push(String(transaction.id));
+  }
+
+  if (typeof options.synchroniseReviewItems === 'function') options.synchroniseReviewItems(nextState, validDate(options.now));
+  return { state: nextState, updatedIds, plan: checked };
+}
+
+function resolveTarget(state, targetValue) {
+  const value = String(targetValue || '');
+  if (value === PAYMENT_BULK_CLEAR_VALUE) return { valid: true, value, kind: 'clear', label: UNCATEGORISED_LABEL, budgetCategoryId: '' };
+  if (value === PAYMENT_BULK_INCOME_VALUE) return { valid: true, value, kind: 'income', label: INCOME_LABEL, budgetCategoryId: '' };
+  const budget = (Array.isArray(state?.budgets) ? state.budgets : []).find((item) => String(item?.id) === value);
+  if (!budget) return { valid: false, error: 'Choose an available purpose or budget category.' };
+  if (normalise(budget.category) === 'income') return { valid: false, error: 'Income must use the dedicated Income category.' };
+  return { valid: true, value, kind: 'budget', label: String(budget.category || 'Budget category'), budgetCategoryId: String(budget.id) };
+}
+
+function paymentDirection(transaction) {
+  const incoming = Number(transaction?.incoming || 0) > 0;
+  const outgoing = Number(transaction?.outgoing || 0) > 0;
+  if (incoming === outgoing) return '';
+  return incoming ? 'income' : 'expense';
+}
+
+function invalidPlan(message) { return { valid: false, errors: [message], transactionIds: [], selectedCount: 0 }; }
+function ineligible(reason) { return { eligible: false, direction: '', reason }; }
+function normalise(value) { return String(value || '').trim().toLowerCase().replace(/\s+/g, '_'); }
+function validDate(value) { const date = value instanceof Date ? new Date(value) : new Date(value || Date.now()); return Number.isNaN(date.getTime()) ? new Date() : date; }
+function bulkError(message, code = 'PAYMENT_BULK_INVALID') { const error = new Error(message); error.code = code; return error; }

--- a/tests/payment-bulk-review-ui.test.js
+++ b/tests/payment-bulk-review-ui.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const ui = fs.readFileSync(new URL('../payment-bulk-review-ui.js', import.meta.url), 'utf8');
+const ledger = fs.readFileSync(new URL('../transaction-ledger.js', import.meta.url), 'utf8');
+const packageJson = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+
+test('Payments loads the bulk review UI without adding a second application entry point', () => {
+  assert.match(ledger, /import '\.\/payment-bulk-review-ui\.js';/);
+});
+
+test('bulk UI uses visible-row IDs, native checkboxes and explicit review/apply confirmation', () => {
+  assert.match(ui, /retainVisiblePaymentSelection/);
+  assert.match(ui, /Select visible/);
+  assert.match(ui, /checkbox\.type = 'checkbox'/);
+  assert.match(ui, /Review changes/);
+  assert.match(ui, /showModal\(\)/);
+  assert.match(ui, /Apply to selected/);
+  assert.match(ui, /Cancel/);
+});
+
+test('bulk UI synchronises Review Inbox from source truth before normal state save', () => {
+  assert.match(ui, /synchroniseReviewItems/);
+  assert.match(ui, /applyPaymentBulkCategorisation\(pending\.state, pending\.plan, \{ synchroniseReviewItems/);
+  assert.match(ui, /window\.financeAPI\.saveState\(result\.state\)/);
+});
+
+test('bulk UI handles state revision conflicts conservatively', () => {
+  assert.match(ui, /saved\?\.status === 'conflict'/);
+  assert.match(ui, /Nothing from this bulk action was saved/);
+});
+
+test('packaged application includes both bulk review modules', () => {
+  assert.ok(packageJson.build.files.includes('payment-bulk-review.js'));
+  assert.ok(packageJson.build.files.includes('payment-bulk-review-ui.js'));
+});
+
+test('bulk UI styles use shared theme variables for light and night compatibility', () => {
+  assert.match(ui, /var\(--surface-subtle\)/);
+  assert.match(ui, /var\(--panel\)/);
+  assert.match(ui, /var\(--ink\)/);
+  assert.match(ui, /var\(--focus-ring\)|primary-button|secondary-button/);
+});

--- a/tests/payment-bulk-review.test.js
+++ b/tests/payment-bulk-review.test.js
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  applyPaymentBulkCategorisation, buildPaymentBulkCategorisationPlan, PAYMENT_BULK_CLEAR_VALUE,
+  PAYMENT_BULK_INCOME_VALUE, paymentBulkCategoryOptions, paymentBulkEligibility, retainVisiblePaymentSelection
+} from '../payment-bulk-review.js';
+import { activeReviewItems, synchroniseReviewItems } from '../review-lifecycle.js';
+
+test('bulk categorises several compatible uncategorised expenses together', () => {
+  const state = baseState();
+  state.budgets.push({ id: 'food', category: 'Food', planned: 200 });
+  state.transactions.push(transaction({ id: 'one' }), transaction({ id: 'two' }), transaction({ id: 'three' }));
+  const plan = buildPaymentBulkCategorisationPlan(state, ['one', 'two', 'three'], 'food');
+  assert.equal(plan.valid, true);
+  const result = applyPaymentBulkCategorisation(state, plan);
+  assert.deepEqual(result.updatedIds, ['one', 'two', 'three']);
+  assert.deepEqual(result.state.transactions.map((item) => [item.budgetCategoryId, item.category, item.categorySource]), [
+    ['food', 'Food', 'manual'], ['food', 'Food', 'manual'], ['food', 'Food', 'manual']
+  ]);
+});
+
+test('duplicate selected IDs are applied exactly once', () => {
+  const state = baseState();
+  state.budgets.push({ id: 'food', category: 'Food', planned: 200 });
+  state.transactions.push(transaction({ id: 'one' }));
+  const plan = buildPaymentBulkCategorisationPlan(state, ['one', 'one', 'one'], 'food');
+  assert.equal(plan.selectedCount, 1);
+  const result = applyPaymentBulkCategorisation(state, plan);
+  assert.deepEqual(result.updatedIds, ['one']);
+});
+
+test('mixed incoming and outgoing selection is blocked', () => {
+  const state = baseState();
+  state.budgets.push({ id: 'food', category: 'Food', planned: 200 });
+  state.transactions.push(transaction({ id: 'expense' }), transaction({ id: 'income', incoming: 100, outgoing: 0 }));
+  const plan = buildPaymentBulkCategorisationPlan(state, ['expense', 'income'], 'food');
+  assert.equal(plan.valid, false);
+  assert.match(plan.errors[0], /Income and outgoing spending/i);
+});
+
+test('Income target only accepts ordinary incoming payments', () => {
+  const state = baseState();
+  state.transactions.push(transaction({ id: 'income', incoming: 100, outgoing: 0 }));
+  const incomePlan = buildPaymentBulkCategorisationPlan(state, ['income'], PAYMENT_BULK_INCOME_VALUE);
+  assert.equal(incomePlan.valid, true);
+  const result = applyPaymentBulkCategorisation(state, incomePlan);
+  assert.equal(result.state.transactions[0].category, 'Income');
+  assert.equal(result.state.transactions[0].budgetCategoryId, '');
+
+  const expenseState = baseState(); expenseState.transactions.push(transaction({ id: 'expense' }));
+  assert.equal(buildPaymentBulkCategorisationPlan(expenseState, ['expense'], PAYMENT_BULK_INCOME_VALUE).valid, false);
+});
+
+test('special transfer, debt, refund and reversal semantics are excluded from bulk changes', () => {
+  const candidates = [
+    transaction({ id: 'transfer', transferStatus: 'confirmed' }),
+    transaction({ id: 'debt', budgetTreatment: 'debt_payment' }),
+    transaction({ id: 'refund', budgetTreatment: 'refund' }),
+    transaction({ id: 'reversal', reversalOfTransactionId: 'source' })
+  ];
+  candidates.forEach((item) => assert.equal(paymentBulkEligibility(item).eligible, false));
+});
+
+test('Select visible retains only currently visible qualifying payments', () => {
+  assert.deepEqual(retainVisiblePaymentSelection(['one', 'two', 'hidden'], ['one', 'two', 'three'], ['one', 'three']), ['one']);
+});
+
+test('bulk categorisation resolves only source-linked uncategorised Review items', () => {
+  const state = baseState();
+  state.budgets.push({ id: 'food', category: 'Food', planned: 200 });
+  state.transactions.push(transaction({ id: 'one', description: 'Fictional Grocer' }), transaction({ id: 'two', description: 'Fictional Grocer' }));
+  synchroniseReviewItems(state, new Date('2026-08-11T10:00:00.000Z'));
+  assert.equal(activeReviewItems(state).filter((item) => item.type === 'uncategorised_payment').length, 2);
+
+  const plan = buildPaymentBulkCategorisationPlan(state, ['one'], 'food');
+  const result = applyPaymentBulkCategorisation(state, plan, { synchroniseReviewItems, now: new Date('2026-08-11T10:05:00.000Z') });
+  const one = result.state.reviewItems.find((item) => item.sourceId === 'one');
+  const two = result.state.reviewItems.find((item) => item.sourceId === 'two');
+  assert.equal(one.status, 'resolved');
+  assert.equal(one.resolution.decision, 'source_resolved');
+  assert.notEqual(two.status, 'resolved');
+});
+
+test('reviewing a plan does not mutate state, so cancel leaves data unchanged', () => {
+  const state = baseState();
+  state.budgets.push({ id: 'food', category: 'Food', planned: 200 });
+  state.transactions.push(transaction({ id: 'one' }));
+  const before = structuredClone(state);
+  const plan = buildPaymentBulkCategorisationPlan(state, ['one'], 'food');
+  assert.equal(plan.valid, true);
+  assert.deepEqual(state, before);
+});
+
+test('a stale revision cannot apply a reviewed bulk plan to a newer state', () => {
+  const state = baseState();
+  state.budgets.push({ id: 'food', category: 'Food', planned: 200 });
+  state.transactions.push(transaction({ id: 'one' }));
+  const plan = buildPaymentBulkCategorisationPlan(state, ['one'], 'food');
+  const newer = structuredClone(state); newer.meta.revision = state.meta.revision + 1;
+  assert.throws(() => applyPaymentBulkCategorisation(newer, plan), (error) => error.code === 'PAYMENT_BULK_STALE_REVISION');
+});
+
+test('bulk category choices stay alphabetical and exclude Income-like budgets', () => {
+  const state = baseState();
+  state.budgets.push(
+    { id: 'travel', category: 'Travel' },
+    { id: 'bills', category: 'Bills' },
+    { id: 'income-budget', category: 'Income' },
+    { id: 'food', category: 'Food' }
+  );
+  const labels = paymentBulkCategoryOptions(state).map((entry) => entry.label);
+  assert.deepEqual(labels, ['Bills', 'Food', 'Income', 'Travel', 'Uncategorised']);
+  assert.equal(paymentBulkCategoryOptions(state).some((entry) => entry.value === 'income-budget'), false);
+});
+
+test('clearing a budget category persists as an ordinary manual edit after JSON round-trip', () => {
+  const state = baseState();
+  state.budgets.push({ id: 'food', category: 'Food', planned: 200 });
+  state.transactions.push(transaction({ id: 'one', budgetCategoryId: 'food', category: 'Food' }));
+  const plan = buildPaymentBulkCategorisationPlan(state, ['one'], PAYMENT_BULK_CLEAR_VALUE);
+  const result = applyPaymentBulkCategorisation(state, plan);
+  const restored = JSON.parse(JSON.stringify(result.state));
+  assert.equal(restored.transactions[0].budgetCategoryId, '');
+  assert.equal(restored.transactions[0].category, '');
+  assert.equal(restored.transactions[0].categorySource, 'manual');
+  assert.equal(Object.hasOwn(restored, 'paymentBulkReview'), false);
+});
+
+function baseState() {
+  return {
+    schemaVersion: 8,
+    meta: { createdAt: '2026-08-11T09:00:00.000Z', updatedAt: '2026-08-11T09:00:00.000Z', revision: 7 },
+    profile: { name: '', locale: 'en-GB', currency: 'GBP', dependableIncome: 0, paydayDay: null },
+    accounts: [], transactions: [], payslips: [], taxDocuments: [], creditReports: [], debts: [], overdrafts: [], budgets: [],
+    scheduledPayments: [], documents: [], tasks: [], checkIns: [], importBatches: [], reviewItems: [],
+    settings: { selectedMonth: '2026-08', extraDebtPayment: 0, emergencyBufferTarget: 500, emergencyBufferBalance: 0, extraIncomeDebtPercent: 80, llmModel: 'qwen2.5:1.5b', reminders: { weekly: false, weeklyDay: 'monday', hour: 9 }, snoozedActions: {} }
+  };
+}
+
+function transaction(overrides = {}) {
+  return {
+    id: 'payment-1', accountId: 'account-1', date: '2026-08-11', budgetMonth: '2026-08', description: 'Fictional Payment',
+    incoming: 0, outgoing: 10, budgetCategoryId: '', category: '', categorySource: 'manual', budgetTreatment: 'auto',
+    transferStatus: 'no', duplicateStatus: 'none', reviewStatus: 'not_required', importReviewStatus: 'accepted', financiallyActive: true,
+    ...overrides
+  };
+}

--- a/transaction-ledger.js
+++ b/transaction-ledger.js
@@ -1,4 +1,5 @@
 import { ALL_TIME_PERIOD, isIncomePayment } from './finance-core.js';
+import './payment-bulk-review-ui.js';
 
 export const DEFAULT_TRANSACTION_PAGE_SIZE = 100;
 export const INCOME_PAYMENT_CATEGORY_VALUE = 'payment-category:income';


### PR DESCRIPTION
### Purpose
Implement #74 as the v2.2.0 QOL workstream for explicit, safe bulk review and categorisation of visible Payments without introducing silent automation or a second review lifecycle.

### Work completed
- Added visible-row multi-select controls with `Select visible`, clear selection, selected count, and a bulk action area that appears only when useful.
- Added an explicit review dialog before any bulk category change is saved.
- Added bulk assignment to an existing purpose/Budget category, the dedicated Income category, or Uncategorised/cleared assignment.
- Added compatibility guards that block mixed income/outgoing operations and exclude inactive, rejected, unresolved-import, transfer, debt-payment, refund and reversal semantics from unsafe bulk edits.
- Preserved manual categorisation authority by writing ordinary `budgetCategoryId`, `category` and `categorySource = manual` transaction fields only.
- Reused `synchroniseReviewItems` so source-linked uncategorised Review Inbox work resolves from source truth rather than deleting or independently mutating review entries.
- Preserved state revision protection: reviewed plans retain the source revision and IPC save conflicts are treated conservatively with no bulk overwrite.
- Added focused safety and UI integration coverage using fictional data only.

### Files changed
- `payment-bulk-review.js` — pure bulk eligibility, compatibility, planning and application logic.
- `payment-bulk-review-ui.js` — Payments selection UI, confirmation flow, state save/revision handling and theme-aware styling.
- `transaction-ledger.js` — loads the bulk-review UI alongside the existing Payments ledger.
- `package.json` — includes the two new runtime modules in packaged builds.
- `tests/payment-bulk-review.test.js` — focused behaviour, safety, Review Inbox and persistence tests.
- `tests/payment-bulk-review-ui.test.js` — UI wiring, confirmation, packaging, conflict and theme integration assertions.

### User-facing changes
- Payments gain a checkbox selection column for qualifying visible rows.
- Users can select the currently visible qualifying payments, clear the selection, see the selected count, choose one purpose/category, review a clear summary, then Apply or Cancel.
- Hidden/non-visible records are not silently included by `Select visible`.
- Unsafe combinations are blocked rather than guessed or split silently.
- Successful saves reload the authoritative state and return the user to Payments.

### Technical changes
- No new persisted schema or bulk-operation history model was added.
- Bulk plans deduplicate selected IDs and validate direction, eligibility, target category and state revision before applying.
- Special financial semantics remain unchanged; bulk categorisation does not rewrite transfer/debt/refund/reversal treatment.
- Review Inbox resolution remains source-driven via the existing lifecycle synchroniser.
- Runtime UI integration is side-effect loaded from `transaction-ledger.js`; the module is guarded so Node tests do not require a DOM.
- Styling uses existing shared theme variables and existing button/focus behaviour.

### Testing and verification
- **Passed** — changed-file JavaScript syntax checks with Node before push.
- **Passed** — focused local safety harness, 5/5 tests: apply/clear, duplicate-ID dedupe, mixed-direction blocking, special-semantic exclusion, Income-only direction, visible-only selection, alphabetical options, non-mutating review and stale-revision rejection.
- **Passed** — targeted privacy scan across all six changed files using the repository privacy-check forbidden patterns.
- **Passed** — new runtime packaging dependency sanity check; both new modules are present in `build.files` and their new local runtime dependencies are represented.
- **Passed** — GitHub Actions Ubuntu `test` job: `npm test`, `npm run check`, and `npm run lint`.
- **Passed** — GitHub Actions Windows `test-windows` job: `npm test`, `npm run check`, `npm run lint`, built Pages artifact runtime smoke test, automated Electron desktop startup smoke/capture, and Windows NSIS packaging smoke (`npm run dist:win -- --publish never`).
- **Skipped by workflow as expected** — `release-windows`; release publishing runs only for version tags, not draft PRs.
- **Unavailable** — manual Electron feature walkthrough, manual keyboard/accessibility walkthrough, and manual Light/Night visual inspection in this execution environment. Automated Electron startup and theme-variable integration coverage passed, but are not presented as manual testing.

### Data and migration impact
- No schema migration.
- Existing transaction fields only; edits remain compatible with normal state save, backup/restore and restart behaviour.
- No financial values, merchant descriptions or selected-payment details are logged.
- No telemetry, analytics, cloud financial storage or new network service was added.

### Known limitations
- This brief deliberately does not add bulk deletion, free-form spreadsheet editing, background auto-bulk categorisation, external finance actions, cloud categorisation or AI Companion behaviour.
- Existing automation-rule application from #72 is not added to the bulk toolbar in this focused implementation; the brief marks that action as optional.
- Manual keyboard and Light/Night interaction review remains outstanding for human review; automated CI and static theme integration checks are green.

### Excluded work
- Bulk delete.
- Background/silent bulk automation.
- External payments or finance actions.
- Spreadsheet-style editor.
- Cloud categorisation or telemetry.
- AI Companion work.
- Changes to #39 contextual categorisation or #72 rule semantics beyond preserving their existing source-of-truth behaviour.

### Branch details
- Branch: `feature/payment-bulk-review`
- Commit SHA: `c217c7143d04a0b6386ed58922ccea449d3ae8ff`
- Pull request: #117
- Target branch: `main`

### Confirmations
- No changes committed/pushed directly to `main`.
- PR not merged by this workflow.
- No personal financial data, imported documents, credentials, secrets, or sensitive logs committed.
- Only relevant files changed.