### PR TITLE
[v2.2.0][Feature] Local financial reminders and due-date automation

### DIFF
--- a/automation-state.js
+++ b/automation-state.js
@@ -6,7 +6,7 @@ const SAFE_CODE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,119}$/;
 const MAX_EXECUTIONS = 5000;
 const MAX_MANUAL_OVERRIDES = 1000;
 
-export const AUTOMATION_STATE_VERSION = 2;
+export const AUTOMATION_STATE_VERSION = 1;
 
 export function normaliseAutomationState(value) {
   const automation = isPlainObject(value) ? value : {};

--- a/automation-state.js
+++ b/automation-state.js
@@ -1,11 +1,12 @@
 import { normaliseAutomationRuleCollection } from './automation-rule-model.js';
+import { normaliseFinancialReminderCollection } from './financial-reminders.js';
 
 const EXECUTION_ID_PATTERN = /^[0-9a-f]{64}$/;
 const SAFE_CODE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,119}$/;
 const MAX_EXECUTIONS = 5000;
 const MAX_MANUAL_OVERRIDES = 1000;
 
-export const AUTOMATION_STATE_VERSION = 1;
+export const AUTOMATION_STATE_VERSION = 2;
 
 export function normaliseAutomationState(value) {
   const automation = isPlainObject(value) ? value : {};
@@ -13,6 +14,7 @@ export function normaliseAutomationState(value) {
     version: AUTOMATION_STATE_VERSION,
     enabled: automation.enabled !== false,
     rules: normaliseAutomationRuleCollection(automation.rules),
+    reminders: normaliseFinancialReminderCollection(automation.reminders),
     executions: normaliseExecutions(automation.executions),
     manualOverrides: normaliseManualOverrides(automation.manualOverrides)
   };

--- a/financial-reminders-ui.js
+++ b/financial-reminders-ui.js
@@ -1,0 +1,143 @@
+import {
+  createUserFinancialReminder, dismissFinancialReminderForToday,
+  listFinancialReminderSources, removeUserFinancialReminder, setFinancialReminderConfiguration
+} from './financial-reminders.js';
+
+let state = null;
+
+export function renderFinancialRemindersPanel(nextState) {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  state = nextState;
+  const grid = document.querySelector('#view-settings .settings-grid');
+  if (!grid || !state) return;
+  let panel = document.getElementById('financialRemindersSettings');
+  if (!panel) {
+    panel = document.createElement('article');
+    panel.id = 'financialRemindersSettings';
+    panel.className = 'panel';
+    grid.append(panel);
+    panel.addEventListener('click', onClick);
+    panel.addEventListener('change', onChange);
+    panel.addEventListener('submit', onSubmit);
+  }
+  render(panel);
+}
+
+function render(panel) {
+  const sources = listFinancialReminderSources(state, new Date());
+  panel.replaceChildren();
+  const heading = el('div', 'panel-heading');
+  const copy = el('div');
+  copy.append(el('p', 'eyebrow', 'FINANCIAL REMINDERS'), el('h2', '', 'Due dates and reminders'),
+    el('p', 'muted', 'OneStep uses confirmed or explicit dates only. Reminders stay on this device and flow through Today and Review Inbox.'));
+  heading.append(copy, el('span', 'badge', state.automation?.enabled === false ? 'Paused' : `${sources.filter((item) => item.enabled).length} enabled`));
+  panel.append(heading);
+
+  const status = el('p', 'muted'); status.id = 'financialRemindersStatus'; status.setAttribute('role', 'status'); status.setAttribute('aria-live', 'polite');
+  status.textContent = state.automation?.enabled === false
+    ? 'Automations are globally paused. Reminder settings are preserved, but automatic reminder delivery is paused.'
+    : 'Reminder timing uses local calendar dates, including month, year and daylight-saving boundaries.';
+  panel.append(status, createForm());
+
+  const list = el('div', 'compact-card-list');
+  if (!sources.length) list.append(el('p', 'muted', 'No confirmed or explicitly dated financial reminders are available yet. You can add one below.'));
+  for (const source of sources.slice(0, 30)) list.append(reminderCard(source));
+  panel.append(list);
+}
+
+function createForm() {
+  const form = el('form', 'form-grid'); form.id = 'financialReminderForm';
+  form.append(el('h3', 'wide-field', 'Add a financial reminder'));
+  const title = input('reminderTitle', 'text'); title.maxLength = 160; title.required = true; title.placeholder = 'e.g. Review annual insurance renewal';
+  const due = input('reminderDueDate', 'date'); due.required = true;
+  const days = input('reminderDaysBefore', 'number'); days.min = '0'; days.max = '31'; days.step = '1'; days.value = '3'; days.required = true;
+  form.append(field('What is due?', title), field('Due date', due), field('Remind me days before', days));
+  const actions = el('div', 'inline-actions wide-field'); const add = el('button', 'primary-button', 'Add reminder'); add.type = 'submit'; actions.append(add); form.append(actions);
+  return form;
+}
+
+function reminderCard(source) {
+  const card = el('article', 'review-card'); card.dataset.reminderSourceType = source.sourceType; card.dataset.reminderSourceId = source.sourceId;
+  const head = el('div', 'review-card-heading'); const copy = el('div'); copy.append(el('strong', '', source.title), el('span', 'muted', sourceLabel(source)));
+  head.append(copy, el('span', `badge ${source.status === 'overdue' ? 'red' : ''}`.trim(), statusLabel(source))); card.append(head);
+  card.append(el('p', 'muted', `${formatDate(source.dueDate)} · reminder ${timingLabel(source.daysBefore)}.`));
+
+  const controls = el('div', 'form-grid');
+  const enabledLabel = el('label', 'confirmation-check'); const enabled = input('', 'checkbox'); enabled.checked = source.enabled; enabled.dataset.reminderEnabled = 'true'; enabledLabel.append(enabled, document.createTextNode(source.enabled ? 'Reminder enabled' : 'Reminder paused')); controls.append(enabledLabel);
+  const days = input('', 'number'); days.min = '0'; days.max = '31'; days.step = '1'; days.value = String(source.daysBefore); days.dataset.reminderDays = 'true'; controls.append(field('Days before', days));
+  card.append(controls);
+
+  const actions = el('div', 'inline-actions');
+  const dismiss = el('button', 'secondary-button', source.dismissedToday ? 'Dismissed today' : 'Dismiss for today'); dismiss.type = 'button'; dismiss.dataset.reminderDismiss = 'true'; dismiss.disabled = source.dismissedToday; actions.append(dismiss);
+  if (source.sourceType === 'user') { const remove = el('button', 'danger-button', 'Delete reminder'); remove.type = 'button'; remove.dataset.reminderDelete = 'true'; actions.append(remove); }
+  card.append(actions);
+  return card;
+}
+
+async function onSubmit(event) {
+  if (event.target.id !== 'financialReminderForm' || !state) return;
+  event.preventDefault();
+  try {
+    const next = createUserFinancialReminder(state, {
+      title: document.getElementById('reminderTitle')?.value,
+      dueDate: document.getElementById('reminderDueDate')?.value,
+      daysBefore: document.getElementById('reminderDaysBefore')?.value
+    }, new Date());
+    await persist(next, 'Financial reminder added.');
+  } catch (error) { setStatus(error?.message || 'That reminder could not be added.'); }
+}
+
+async function onChange(event) {
+  const card = event.target.closest('[data-reminder-source-type]');
+  if (!card || !state || (!event.target.matches('[data-reminder-enabled]') && !event.target.matches('[data-reminder-days]'))) return;
+  const source = currentSource(card); if (!source) return;
+  const enabled = card.querySelector('[data-reminder-enabled]')?.checked !== false;
+  const daysBefore = card.querySelector('[data-reminder-days]')?.value;
+  try {
+    const next = setFinancialReminderConfiguration(state, {
+      sourceType: source.sourceType, sourceId: source.sourceId, enabled, daysBefore,
+      title: source.title, dueDate: source.dueDate
+    }, new Date());
+    await persist(next, enabled ? 'Reminder settings saved.' : 'Reminder paused.');
+  } catch (error) { setStatus(error?.message || 'That reminder setting could not be saved.'); }
+}
+
+async function onClick(event) {
+  const card = event.target.closest('[data-reminder-source-type]'); if (!card || !state) return;
+  const source = currentSource(card); if (!source) return;
+  if (event.target.closest('[data-reminder-dismiss]')) {
+    try { await persist(dismissFinancialReminderForToday(state, source.sourceType, source.sourceId, new Date()), 'Reminder dismissed for today. The financial source was not deleted.'); }
+    catch (error) { setStatus(error?.message || 'That reminder could not be dismissed.'); }
+    return;
+  }
+  if (event.target.closest('[data-reminder-delete]') && source.sourceType === 'user') {
+    if (!window.confirm(`Delete “${source.title}”? This removes only the reminder, not any financial records.`)) return;
+    await persist(removeUserFinancialReminder(state, source.sourceId), 'Reminder deleted.');
+  }
+}
+
+function currentSource(card) {
+  return listFinancialReminderSources(state, new Date()).find((item) => item.sourceType === card.dataset.reminderSourceType && item.sourceId === card.dataset.reminderSourceId) || null;
+}
+
+async function persist(next, message) {
+  try {
+    const saved = await window.financeAPI.saveState(next);
+    if (saved?.status === 'blocked' || saved?.status === 'conflict') throw new Error(saved.message || 'The reminder could not be saved safely.');
+    state = saved; setStatus(message); window.setTimeout(() => window.location.reload(), 120);
+  } catch (error) { setStatus(error?.message || 'The reminder could not be saved.'); }
+}
+
+function sourceLabel(source) {
+  if (source.sourceType === 'recurring_pattern') return 'Confirmed recurring commitment';
+  if (source.sourceType === 'scheduled_payment') return 'Scheduled payment';
+  if (source.sourceType === 'review_due') return 'Existing Review Inbox item';
+  return 'Your reminder';
+}
+function statusLabel(source) { return source.status === 'due_today' ? 'Due today' : source.status === 'overdue' ? 'Overdue' : source.dismissedToday ? 'Dismissed today' : 'Upcoming'; }
+function timingLabel(days) { return Number(days) === 0 ? 'on the due date' : `${days} day${Number(days) === 1 ? '' : 's'} before`; }
+function formatDate(value) { const [year, month, day] = String(value || '').split('-').map(Number); const date = new Date(Date.UTC(year, month - 1, day, 12)); return Number.isNaN(date.getTime()) ? 'Date unavailable' : new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC' }).format(date); }
+function setStatus(message) { const node = document.getElementById('financialRemindersStatus'); if (node) node.textContent = message; }
+function field(labelText, control) { const label = el('label'); label.append(document.createTextNode(labelText), control); return label; }
+function input(id, type) { const node = document.createElement('input'); if (id) node.id = id; node.type = type; return node; }
+function el(tag, className = '', text = '') { const node = document.createElement(tag); if (className) node.className = className; if (text) node.textContent = text; return node; }

--- a/financial-reminders.js
+++ b/financial-reminders.js
@@ -1,0 +1,376 @@
+import { confirmedRecurringPatterns } from './recurring-finance.js';
+
+const MAX_CONFIGS = 500;
+const MAX_TEXT = 160;
+const MAX_DAYS_BEFORE = 31;
+const FAR_FUTURE_DATE = '9999-12-31';
+const SAFE_SOURCE_TYPES = new Set(['recurring_pattern', 'scheduled_payment', 'review_due', 'user']);
+
+export const FINANCIAL_REMINDER_DEFAULT_DAYS = 3;
+export const FINANCIAL_REMINDER_TIMING_OPTIONS = Object.freeze([0, 1, 3, 7]);
+export const FINANCIAL_REMINDER_STATUS = Object.freeze({
+  UPCOMING: 'upcoming',
+  DUE_TODAY: 'due_today',
+  OVERDUE: 'overdue',
+  RESOLVED: 'resolved'
+});
+
+export function normaliseFinancialReminderCollection(value) {
+  if (!Array.isArray(value)) return [];
+  const output = [];
+  const seen = new Set();
+  for (const input of value) {
+    const config = normaliseConfig(input);
+    if (!config || seen.has(config.id)) continue;
+    seen.add(config.id);
+    output.push(config);
+    if (output.length >= MAX_CONFIGS) break;
+  }
+  return output.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export function listFinancialReminderSources(state = {}, now = new Date()) {
+  const sources = [
+    ...confirmedRecurringSources(state),
+    ...scheduledPaymentSources(state),
+    ...reviewDueSources(state),
+    ...userReminderSources(state)
+  ];
+  const configs = configMap(state);
+  const today = localDateKey(now);
+  return sources.map((source) => {
+    const config = configs.get(configId(source.sourceType, source.sourceId));
+    const daysBefore = config?.daysBefore ?? defaultDaysBefore(source.sourceType);
+    const triggerDate = shiftLocalDate(source.dueDate, -daysBefore);
+    const status = reminderStatus(source.dueDate, today);
+    const enabled = config?.enabled !== false;
+    const dismissedToday = config?.dismissedUntil === today;
+    return {
+      ...source,
+      configId: configId(source.sourceType, source.sourceId),
+      taskId: reminderTaskId(source.sourceType, source.sourceId, source.dueDate),
+      enabled,
+      daysBefore,
+      triggerDate,
+      status,
+      dismissedToday,
+      relevant: enabled && !dismissedToday && status !== FINANCIAL_REMINDER_STATUS.RESOLVED && today >= triggerDate,
+      automationPaused: state?.automation?.enabled === false
+    };
+  }).sort(compareSources);
+}
+
+export function synchroniseFinancialReminders(state = {}, now = new Date()) {
+  const target = state && typeof state === 'object' ? state : {};
+  target.automation = isPlainObject(target.automation) ? target.automation : {};
+  target.automation.reminders = normaliseFinancialReminderCollection(target.automation.reminders);
+  target.tasks = Array.isArray(target.tasks) ? target.tasks : [];
+
+  const timestamp = validDate(now).toISOString();
+  const automationPaused = target.automation.enabled === false;
+  let changed = synchroniseRuleReminderPause(target.tasks, automationPaused, timestamp);
+  const sources = listFinancialReminderSources(target, now);
+  const desired = new Map();
+  const nextTasks = [];
+  const existingManaged = new Map();
+  for (const task of target.tasks) {
+    if (task?.source === 'financial_reminder' && task?.reminderTaskId) existingManaged.set(String(task.reminderTaskId), task);
+    else nextTasks.push(task);
+  }
+
+  for (const source of sources) {
+    if (source.sourceType === 'review_due') continue;
+    if (source.relevant || existingManaged.has(source.taskId)) desired.set(source.taskId, source);
+  }
+
+  for (const [taskId, source] of desired) {
+    const previous = existingManaged.get(taskId);
+    if (!previous && (automationPaused || !source.enabled || source.dismissedToday || localDateKey(now) < source.triggerDate)) continue;
+    const task = reminderTask(source, previous, timestamp, now);
+    if (!previous || !sameReminderTask(previous, task)) changed = true;
+    nextTasks.push(task);
+    existingManaged.delete(taskId);
+  }
+  if (existingManaged.size) changed = true;
+
+  if (changed) target.tasks = nextTasks;
+  return { state: target, changed, reminders: sources };
+}
+
+export function setFinancialReminderConfiguration(state, input, now = new Date()) {
+  const next = structuredClone(state || {});
+  next.automation = isPlainObject(next.automation) ? next.automation : {};
+  const configs = normaliseFinancialReminderCollection(next.automation.reminders);
+  const sourceType = safeSourceType(input?.sourceType);
+  const sourceId = safeSourceId(input?.sourceId);
+  if (!sourceType || !sourceId) throw new TypeError('Choose a valid financial reminder source.');
+  const id = configId(sourceType, sourceId);
+  const existing = configs.find((item) => item.id === id);
+  const timestamp = validDate(now).toISOString();
+  const daysBefore = normaliseDaysBefore(input?.daysBefore ?? existing?.daysBefore ?? defaultDaysBefore(sourceType));
+  const saved = {
+    id,
+    sourceType,
+    sourceId,
+    enabled: input?.enabled !== false,
+    daysBefore,
+    title: sourceType === 'user' ? safeText(input?.title ?? existing?.title, MAX_TEXT) : '',
+    dueDate: sourceType === 'user' ? localDateKey(input?.dueDate ?? existing?.dueDate) : '',
+    dismissedUntil: validLocalDate(input?.dismissedUntil) ? String(input.dismissedUntil) : existing?.dismissedUntil || '',
+    createdAt: existing?.createdAt || timestamp,
+    updatedAt: timestamp
+  };
+  if (sourceType === 'user' && (!saved.title || !saved.dueDate)) throw new TypeError('User-created reminders need a title and due date.');
+  const index = configs.findIndex((item) => item.id === id);
+  if (index >= 0) configs.splice(index, 1, saved);
+  else {
+    if (configs.length >= MAX_CONFIGS) throw new Error(`OneStep supports up to ${MAX_CONFIGS} reminder configurations.`);
+    configs.push(saved);
+  }
+  next.automation.reminders = normaliseFinancialReminderCollection(configs);
+  return next;
+}
+
+export function createUserFinancialReminder(state, input, now = new Date()) {
+  const title = safeText(input?.title, MAX_TEXT);
+  const dueDate = localDateKey(input?.dueDate);
+  if (!title || !dueDate) throw new TypeError('Give the reminder a title and a valid due date.');
+  const sourceId = safeSourceId(input?.sourceId) || `user_${shortHash(`${title}|${dueDate}|${validDate(now).toISOString()}`)}`;
+  return setFinancialReminderConfiguration(state, {
+    sourceType: 'user', sourceId, title, dueDate,
+    daysBefore: input?.daysBefore ?? FINANCIAL_REMINDER_DEFAULT_DAYS,
+    enabled: input?.enabled !== false
+  }, now);
+}
+
+export function removeUserFinancialReminder(state, sourceId) {
+  const next = structuredClone(state || {});
+  next.automation = isPlainObject(next.automation) ? next.automation : {};
+  next.automation.reminders = normaliseFinancialReminderCollection(next.automation.reminders)
+    .filter((config) => !(config.sourceType === 'user' && config.sourceId === safeSourceId(sourceId)));
+  next.tasks = (Array.isArray(next.tasks) ? next.tasks : []).filter((task) => !(task?.source === 'financial_reminder' && task?.reminderSourceType === 'user' && task?.reminderSourceId === safeSourceId(sourceId)));
+  return next;
+}
+
+export function dismissFinancialReminderForToday(state, sourceType, sourceId, now = new Date()) {
+  const type = safeSourceType(sourceType);
+  const id = safeSourceId(sourceId);
+  if (!type || !id) throw new TypeError('Choose a valid financial reminder.');
+  const existing = configMap(state).get(configId(type, id));
+  const source = listFinancialReminderSources(state, now).find((item) => item.sourceType === type && item.sourceId === id);
+  if (!existing && !source) throw new Error('That financial reminder is no longer available.');
+  return setFinancialReminderConfiguration(state, {
+    sourceType: type,
+    sourceId: id,
+    enabled: existing?.enabled !== false,
+    daysBefore: existing?.daysBefore ?? source?.daysBefore ?? defaultDaysBefore(type),
+    title: existing?.title || source?.title,
+    dueDate: existing?.dueDate || source?.dueDate,
+    dismissedUntil: localDateKey(now)
+  }, now);
+}
+
+export function reminderStatus(dueDate, now = new Date()) {
+  const due = localDateKey(dueDate);
+  const today = typeof now === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(now) ? localDateKey(now) : localDateKey(now);
+  if (!due || !today) return FINANCIAL_REMINDER_STATUS.RESOLVED;
+  if (today === due) return FINANCIAL_REMINDER_STATUS.DUE_TODAY;
+  return today > due ? FINANCIAL_REMINDER_STATUS.OVERDUE : FINANCIAL_REMINDER_STATUS.UPCOMING;
+}
+
+export function reminderTaskId(sourceType, sourceId, dueDate) {
+  return `financial_reminder_${shortHash(`${sourceType}|${sourceId}|${dueDate}`)}`;
+}
+
+function confirmedRecurringSources(state) {
+  return confirmedRecurringPatterns(state)
+    .filter((pattern) => pattern.direction === 'outgoing' && pattern.nextExpected?.date && validLocalDate(pattern.nextExpected.date))
+    .map((pattern) => ({
+      sourceType: 'recurring_pattern', sourceId: String(pattern.id), dueDate: pattern.nextExpected.date,
+      title: safeText(pattern.label, MAX_TEXT) || 'Recurring commitment',
+      detail: `Confirmed ${String(pattern.cadence || 'recurring').replace(/-/g, ' ')} commitment.`,
+      actionView: 'transactions', targetType: '', targetId: ''
+    }));
+}
+
+function scheduledPaymentSources(state) {
+  return (Array.isArray(state.scheduledPayments) ? state.scheduledPayments : [])
+    .filter((item) => item?.id && activeScheduledPayment(item))
+    .map((item) => {
+      const dueDate = authoritativeDueDate(item);
+      if (!dueDate) return null;
+      return {
+        sourceType: 'scheduled_payment', sourceId: String(item.id), dueDate,
+        title: safeText(item.name || item.title || item.description || item.payee, MAX_TEXT) || 'Scheduled payment',
+        detail: 'Saved scheduled financial commitment.',
+        actionView: safeView(item.actionView || item.view) || 'today',
+        targetType: safeTargetType(item.targetType), targetId: safeSourceId(item.targetId)
+      };
+    }).filter(Boolean);
+}
+
+function reviewDueSources(state) {
+  return (Array.isArray(state.reviewItems) ? state.reviewItems : [])
+    .filter((item) => item?.id && item.status !== 'resolved' && validLocalDate(item.dueDate))
+    .map((item) => ({
+      sourceType: 'review_due', sourceId: String(item.id), dueDate: String(item.dueDate),
+      title: safeText(item.title, MAX_TEXT) || 'Financial review due',
+      detail: 'This existing Review Inbox item has an explicit due date.',
+      actionView: 'review', targetType: '', targetId: ''
+    }));
+}
+
+function userReminderSources(state) {
+  return normaliseFinancialReminderCollection(state?.automation?.reminders)
+    .filter((config) => config.sourceType === 'user' && config.title && config.dueDate)
+    .map((config) => ({
+      sourceType: 'user', sourceId: config.sourceId, dueDate: config.dueDate,
+      title: config.title, detail: 'User-created financial reminder.',
+      actionView: 'today', targetType: '', targetId: ''
+    }));
+}
+
+function reminderTask(source, previous, timestamp, now) {
+  const statusText = source.status === FINANCIAL_REMINDER_STATUS.DUE_TODAY
+    ? 'Due today'
+    : source.status === FINANCIAL_REMINDER_STATUS.OVERDUE ? `Due ${formatLocalDate(source.dueDate)} · still unresolved`
+      : `Due ${formatLocalDate(source.dueDate)}`;
+  const task = {
+    id: source.taskId,
+    title: source.status === FINANCIAL_REMINDER_STATUS.DUE_TODAY ? `${source.title} is due today`
+      : source.status === FINANCIAL_REMINDER_STATUS.OVERDUE ? `${source.title} is overdue`
+        : `${source.title} is coming up`,
+    detail: `${statusText}. ${source.detail}`,
+    priority: 'normal',
+    actionView: source.actionView || 'today',
+    targetType: source.targetType || '',
+    targetId: source.targetId || '',
+    source: 'financial_reminder',
+    reminderTaskId: source.taskId,
+    reminderSourceType: source.sourceType,
+    reminderSourceId: source.sourceId,
+    reminderDueDate: source.dueDate,
+    reminderDaysBefore: source.daysBefore,
+    createdAt: previous?.createdAt || timestamp,
+    updatedAt: previous && sameDisplayState(previous, source) ? previous.updatedAt || previous.createdAt || timestamp : timestamp,
+    completedAt: previous?.completedAt || null,
+    snoozedUntil: previous?.snoozedUntil || null
+  };
+  const today = localDateKey(now);
+  const suppressionUntil = source.automationPaused || !source.enabled ? FAR_FUTURE_DATE
+    : source.dismissedToday ? shiftLocalDate(today, 1)
+      : today < source.triggerDate ? source.triggerDate : '';
+  if (suppressionUntil) {
+    task.reminderSystemSuppressed = true;
+    task.reminderPreviousSnoozedUntil = previous?.reminderSystemSuppressed ? previous.reminderPreviousSnoozedUntil || null : previous?.snoozedUntil || null;
+    task.snoozedUntil = suppressionUntil;
+  } else if (previous?.reminderSystemSuppressed) {
+    task.snoozedUntil = previous.reminderPreviousSnoozedUntil || null;
+  }
+  return task;
+}
+
+function synchroniseRuleReminderPause(tasks, paused, timestamp) {
+  let changed = false;
+  for (const task of tasks) {
+    if (task?.source !== 'automation_rule' || task.completedAt) continue;
+    if (paused && !task.reminderPausedByAutomation) {
+      task.reminderPausedByAutomation = true;
+      task.reminderPausePreviousSnoozedUntil = task.snoozedUntil || null;
+      task.snoozedUntil = FAR_FUTURE_DATE;
+      task.updatedAt = timestamp;
+      changed = true;
+    } else if (!paused && task.reminderPausedByAutomation) {
+      task.snoozedUntil = task.reminderPausePreviousSnoozedUntil || null;
+      delete task.reminderPausePreviousSnoozedUntil;
+      delete task.reminderPausedByAutomation;
+      task.updatedAt = timestamp;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function sameDisplayState(task, source) {
+  return task.reminderDueDate === source.dueDate && task.reminderDaysBefore === source.daysBefore
+    && task.reminderSourceType === source.sourceType && task.reminderSourceId === source.sourceId
+    && ((source.status === FINANCIAL_REMINDER_STATUS.DUE_TODAY && task.title === `${source.title} is due today`)
+      || (source.status === FINANCIAL_REMINDER_STATUS.OVERDUE && task.title === `${source.title} is overdue`)
+      || (source.status === FINANCIAL_REMINDER_STATUS.UPCOMING && task.title === `${source.title} is coming up`));
+}
+
+function sameReminderTask(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function configMap(state) {
+  return new Map(normaliseFinancialReminderCollection(state?.automation?.reminders).map((config) => [config.id, config]));
+}
+
+function normaliseConfig(input) {
+  if (!isPlainObject(input)) return null;
+  const sourceType = safeSourceType(input.sourceType);
+  const sourceId = safeSourceId(input.sourceId);
+  if (!sourceType || !sourceId) return null;
+  const id = configId(sourceType, sourceId);
+  const title = sourceType === 'user' ? safeText(input.title, MAX_TEXT) : '';
+  const dueDate = sourceType === 'user' ? localDateKey(input.dueDate) : '';
+  if (sourceType === 'user' && (!title || !dueDate)) return null;
+  return {
+    id,
+    sourceType,
+    sourceId,
+    enabled: input.enabled !== false,
+    daysBefore: normaliseDaysBefore(input.daysBefore ?? defaultDaysBefore(sourceType)),
+    title,
+    dueDate,
+    dismissedUntil: validLocalDate(input.dismissedUntil) ? String(input.dismissedUntil) : '',
+    createdAt: validIso(input.createdAt) ? input.createdAt : null,
+    updatedAt: validIso(input.updatedAt) ? input.updatedAt : null
+  };
+}
+
+function authoritativeDueDate(item) {
+  for (const field of ['dueDate', 'scheduledDate', 'paymentDate', 'date']) {
+    if (validLocalDate(item?.[field])) return String(item[field]).slice(0, 10);
+  }
+  return '';
+}
+function activeScheduledPayment(item) { return !['paid', 'cancelled', 'completed', 'resolved'].includes(String(item.status || '').trim().toLowerCase()); }
+function defaultDaysBefore(sourceType) { return sourceType === 'review_due' ? 0 : FINANCIAL_REMINDER_DEFAULT_DAYS; }
+function normaliseDaysBefore(value) { const number = Number(value); return Number.isInteger(number) && number >= 0 && number <= MAX_DAYS_BEFORE ? number : FINANCIAL_REMINDER_DEFAULT_DAYS; }
+function configId(sourceType, sourceId) { return `reminder_${shortHash(`${sourceType}|${sourceId}`)}`; }
+function safeSourceType(value) { const type = String(value || ''); return SAFE_SOURCE_TYPES.has(type) ? type : ''; }
+function safeSourceId(value) { return String(value || '').replace(/[\r\n]+/g, ' ').trim().slice(0, 160); }
+function safeText(value, limit) { return String(value || '').replace(/[\r\n]+/g, ' ').trim().slice(0, limit); }
+function safeView(value) { const view = String(value || ''); return ['today', 'review', 'transactions', 'pay', 'debts', 'overdrafts', 'budget', 'documents', 'settings'].includes(view) ? view : ''; }
+function safeTargetType(value) { const type = String(value || ''); return ['transaction', 'debt', 'overdraft'].includes(type) ? type : ''; }
+function compareSources(left, right) { return left.dueDate.localeCompare(right.dueDate) || left.title.localeCompare(right.title) || left.sourceId.localeCompare(right.sourceId); }
+function validLocalDate(value) { return Boolean(localDateKey(value)); }
+function localDateKey(value = new Date()) {
+  if (typeof value === 'string') {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return '';
+    const [year, month, day] = value.split('-').map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day ? value : '';
+  }
+  const date = value instanceof Date ? new Date(value) : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+function shiftLocalDate(value, days) {
+  const key = localDateKey(value); if (!key) return '';
+  const [year, month, day] = key.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+}
+function formatLocalDate(value) {
+  const key = localDateKey(value); if (!key) return 'date unavailable';
+  const [year, month, day] = key.split('-').map(Number);
+  return new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC' }).format(new Date(Date.UTC(year, month - 1, day, 12)));
+}
+function shortHash(value) { let hash = 2166136261; for (const character of String(value)) { hash ^= character.charCodeAt(0); hash = Math.imul(hash, 16777619); } return `${(hash >>> 0).toString(36)}_${String(value).length}`; }
+function pad(value) { return String(value).padStart(2, '0'); }
+function validIso(value) { return typeof value === 'string' && Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value; }
+function validDate(value) { const date = value instanceof Date ? new Date(value) : new Date(value); return Number.isNaN(date.getTime()) ? new Date() : date; }
+function isPlainObject(value) { return Boolean(value) && typeof value === 'object' && !Array.isArray(value); }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
       "automation-rules.js",
       "automation-rules-ui.js",
       "automation-state.js",
+      "financial-reminders.js",
+      "financial-reminders-ui.js",
       "cash-flow-forecast.js",
       "data-store.js",
       "date-utils.js",

--- a/recurring-finance-ui.js
+++ b/recurring-finance-ui.js
@@ -3,6 +3,7 @@ import {
 } from './recurring-finance.js';
 import { renderPaydayAwareness } from './payday-awareness-ui.js';
 import { renderAutomationRulesPanel } from './automation-rules-ui.js';
+import { renderFinancialRemindersPanel } from './financial-reminders-ui.js';
 
 let latestState = null;
 let renderScheduled = false;
@@ -12,6 +13,7 @@ export function renderRecurringActivityPanel(state) {
   latestState = state;
   renderPaydayAwareness(state);
   renderAutomationRulesPanel(state);
+  renderFinancialRemindersPanel(state);
   if (renderScheduled) return;
   renderScheduled = true;
   queueMicrotask(() => { renderScheduled = false; renderPanel(); });
@@ -54,7 +56,7 @@ function decisionButton(label, patternId, decision, className) { const button = 
 async function handleDecision(event) {
   const button = event.target.closest('[data-recurring-decision]'); if (!button || !latestState || !window.financeAPI?.saveState) return;
   const status = document.getElementById('recurringActivityStatus'); button.disabled = true; if (status) status.textContent = button.dataset.recurringDecision === RECURRING_DECISION.CONFIRMED ? 'Confirming this pattern…' : 'Rejecting this pattern…';
-  try { const next = applyRecurringPatternDecision(latestState, button.dataset.recurringPatternId, button.dataset.recurringDecision, new Date()); latestState = await window.financeAPI.saveState(next); if (status) status.textContent = button.dataset.recurringDecision === RECURRING_DECISION.CONFIRMED ? 'Pattern confirmed. Its expected window can now be used by financial automation.' : 'Pattern rejected. Identical evidence will stay rejected unless the underlying history materially changes.'; renderPaydayAwareness(latestState); renderAutomationRulesPanel(latestState); renderPanel(); window.setTimeout(() => window.location.reload(), 150); }
+  try { const next = applyRecurringPatternDecision(latestState, button.dataset.recurringPatternId, button.dataset.recurringDecision, new Date()); latestState = await window.financeAPI.saveState(next); if (status) status.textContent = button.dataset.recurringDecision === RECURRING_DECISION.CONFIRMED ? 'Pattern confirmed. Its expected window can now be used by financial automation.' : 'Pattern rejected. Identical evidence will stay rejected unless the underlying history materially changes.'; renderPaydayAwareness(latestState); renderAutomationRulesPanel(latestState); renderFinancialRemindersPanel(latestState); renderPanel(); window.setTimeout(() => window.location.reload(), 150); }
   catch (error) { button.disabled = false; if (status) status.textContent = error?.message || 'The recurring-pattern decision could not be saved.'; }
 }
 function amountSummary(pattern) { const range = pattern.amountRange; if (!range) return `${pattern.occurrences} occurrence${pattern.occurrences === 1 ? '' : 's'}`; const amount = range.min === range.max ? formatMoney(range.min) : `${formatMoney(range.min)}–${formatMoney(range.max)}`; return `${pattern.occurrences} occurrence${pattern.occurrences === 1 ? '' : 's'} · typical ${formatMoney(range.typical)} · observed ${amount}`; }

--- a/review-lifecycle.js
+++ b/review-lifecycle.js
@@ -1,4 +1,5 @@
 import * as base from './review-lifecycle-base.js';
+import { synchroniseFinancialReminders } from './financial-reminders.js';
 import {
   ensurePaydayConfiguration, missingIncomePresentation, missingIncomeReviewSources, nextDependablePayday
 } from './payday-awareness.js';
@@ -8,6 +9,7 @@ export const REVIEW_DIAGNOSTIC_CODES = base.REVIEW_DIAGNOSTIC_CODES;
 export const knownPaydayDay = base.knownPaydayDay;
 
 export function synchroniseReviewItems(state, now = new Date()) {
+  synchroniseFinancialReminders(state, now);
   ensurePaydayConfiguration(state, now);
   const previousMissing = (Array.isArray(state.reviewItems) ? state.reviewItems : [])
     .filter((item) => item?.type === 'missing_income')

--- a/scripts/build-pages-site.mjs
+++ b/scripts/build-pages-site.mjs
@@ -17,6 +17,8 @@ export const PAGE_FILES = Object.freeze([
   ['automation-rules-ui.js', 'automation-rules-ui.js'],
   ['date-utils.js', 'date-utils.js'],
   ['finance-core.js', 'finance-core.js'],
+  ['financial-reminders.js', 'financial-reminders.js'],
+  ['financial-reminders-ui.js', 'financial-reminders-ui.js'],
   ['financial-reporting.js', 'financial-reporting.js'],
   ['next-move-priority.js', 'next-move-priority.js'],
   ['payday-awareness.js', 'payday-awareness.js'],

--- a/tests/automation-persistence.test.js
+++ b/tests/automation-persistence.test.js
@@ -8,6 +8,7 @@ import {
   evaluateAutomationRules, executeAutomationProposal, setAutomationEnabled
 } from '../automation-engine.js';
 import { FinanceDataStore } from '../data-store.js';
+import { createUserFinancialReminder } from '../financial-reminders.js';
 
 const seedPath = new URL('../seed-data.json', import.meta.url);
 
@@ -19,8 +20,11 @@ test('legacy state migrates automation metadata safely and backup/restore preser
 
   let current = (await store.loadState()).state;
   assert.equal(current.schemaVersion, 10);
-  assert.deepEqual(current.automation, { version: 1, enabled: true, rules: [], executions: {}, manualOverrides: {} });
+  assert.deepEqual(current.automation, { version: 2, enabled: true, rules: [], reminders: [], executions: {}, manualOverrides: {} });
 
+  current = createUserFinancialReminder(current, {
+    title: 'Fictional annual renewal', dueDate: '2026-09-01', daysBefore: 7
+  }, new Date('2026-08-10T19:00:00.000Z'));
   current.transactions.push(fictionalTransaction());
   current = await store.saveState(current);
   const trigger = createAutomationTrigger(AUTOMATION_TRIGGER.TRANSACTION_CHANGE, { sourceType: 'transaction', sourceId: 'fictional-automation-record' });
@@ -41,17 +45,22 @@ test('legacy state migrates automation metadata safely and backup/restore preser
   current = (await restarted.loadState()).state;
   assert.equal(current.automation.enabled, false);
   assert.equal(current.automation.executions[executionId].status, 'applied');
+  assert.equal(current.automation.reminders[0].title, 'Fictional annual renewal');
+  assert.equal(current.automation.reminders[0].dueDate, '2026-09-01');
 
   const backupPath = path.join(directory, 'fictional-automation.osmb');
   await restarted.createPortableBackup(backupPath, 'fictional-passphrase', current);
   let changed = setAutomationEnabled(current, true);
   changed.automation.executions = {};
+  changed.automation.reminders = [];
   await restarted.saveState(changed);
 
   const restored = await restarted.restorePortableBackup(backupPath, 'fictional-passphrase');
   assert.equal(restored.status, 'restored');
   assert.equal(restored.state.automation.enabled, false);
   assert.equal(restored.state.automation.executions[executionId].status, 'applied');
+  assert.equal(restored.state.automation.reminders[0].title, 'Fictional annual renewal');
+  assert.equal(restored.state.automation.reminders[0].daysBefore, 7);
 });
 
 function fictionalRule() {

--- a/tests/automation-persistence.test.js
+++ b/tests/automation-persistence.test.js
@@ -20,7 +20,7 @@ test('legacy state migrates automation metadata safely and backup/restore preser
 
   let current = (await store.loadState()).state;
   assert.equal(current.schemaVersion, 10);
-  assert.deepEqual(current.automation, { version: 2, enabled: true, rules: [], reminders: [], executions: {}, manualOverrides: {} });
+  assert.deepEqual(current.automation, { version: 1, enabled: true, rules: [], reminders: [], executions: {}, manualOverrides: {} });
 
   current = createUserFinancialReminder(current, {
     title: 'Fictional annual renewal', dueDate: '2026-09-01', daysBefore: 7

--- a/tests/financial-reminders-integration.test.js
+++ b/tests/financial-reminders-integration.test.js
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { activeReviewItems, snoozeReviewItem, synchroniseReviewItems } from '../review-lifecycle.js';
+
+function stateWithReminder() {
+  return {
+    automation: { enabled: true, reminders: [] },
+    profile: { paydayDay: null }, settings: {}, accounts: [], transactions: [], payslips: [], debts: [], overdrafts: [], budgets: [], documents: [], importBatches: [],
+    scheduledPayments: [{ id: 'fictional-due', title: 'Fictional council tax', dueDate: '2026-08-12', status: 'scheduled' }],
+    tasks: [], reviewItems: []
+  };
+}
+
+test('financial reminder uses one existing Review/Today lifecycle item and snooze returns locally', () => {
+  const state = stateWithReminder();
+  const morning = new Date('2026-08-11T08:00:00+01:00');
+  synchroniseReviewItems(state, morning);
+  const task = state.tasks.find((item) => item.source === 'financial_reminder');
+  assert.ok(task);
+  const reviewItems = state.reviewItems.filter((item) => item.type === 'generated_action' && item.sourceId === task.id && item.status !== 'resolved');
+  assert.equal(reviewItems.length, 1);
+
+  synchroniseReviewItems(state, new Date('2026-08-11T12:00:00+01:00'));
+  assert.equal(state.reviewItems.filter((item) => item.type === 'generated_action' && item.sourceId === task.id && item.status !== 'resolved').length, 1);
+
+  snoozeReviewItem(state, reviewItems[0].id, 'tomorrow', new Date('2026-08-11T12:00:00+01:00'));
+  assert.equal(activeReviewItems(state, new Date('2026-08-12T08:30:00+01:00')).some((item) => item.id === reviewItems[0].id), false);
+  assert.equal(activeReviewItems(state, new Date('2026-08-12T10:00:00+01:00')).some((item) => item.id === reviewItems[0].id), true);
+});
+
+test('resolving the financial source resolves the existing lifecycle item instead of creating another', () => {
+  const state = stateWithReminder();
+  const now = new Date('2026-08-11T12:00:00+01:00');
+  synchroniseReviewItems(state, now);
+  const original = state.reviewItems.find((item) => item.type === 'generated_action');
+  state.scheduledPayments[0].status = 'paid';
+  synchroniseReviewItems(state, new Date('2026-08-11T13:00:00+01:00'));
+  const same = state.reviewItems.find((item) => item.id === original.id);
+  assert.equal(same.status, 'resolved');
+  assert.equal(same.resolution.decision, 'source_resolved');
+  assert.equal(state.reviewItems.filter((item) => item.sourceId === original.sourceId).length, 1);
+});

--- a/tests/financial-reminders.test.js
+++ b/tests/financial-reminders.test.js
@@ -10,9 +10,9 @@ function baseState() { return { automation: { enabled: true, reminders: [] }, ta
 
 test('upcoming, due-today and overdue states use local calendar dates', () => {
   const state = baseState(); state.scheduledPayments.push({ id: 'rent', title: 'Fictional rent', dueDate: '2026-10-25', status: 'scheduled' });
-  assert.equal(listFinancialReminderSources(state, new Date('2026-10-24T12:00:00+01:00'))[0].status, 'upcoming');
-  assert.equal(listFinancialReminderSources(state, new Date('2026-10-25T00:30:00+01:00'))[0].status, 'due_today');
-  assert.equal(listFinancialReminderSources(state, new Date('2026-10-26T12:00:00+00:00'))[0].status, 'overdue');
+  assert.equal(listFinancialReminderSources(state, new Date(2026, 9, 24, 12, 0))[0].status, 'upcoming');
+  assert.equal(listFinancialReminderSources(state, new Date(2026, 9, 25, 0, 30))[0].status, 'due_today');
+  assert.equal(listFinancialReminderSources(state, new Date(2026, 9, 26, 12, 0))[0].status, 'overdue');
 });
 
 test('restart-style repeated synchronisation is duplicate-safe', () => {

--- a/tests/financial-reminders.test.js
+++ b/tests/financial-reminders.test.js
@@ -57,7 +57,7 @@ test('confirmed recurring commitment generates; uncertain pattern does not', () 
   assert.equal(state.tasks[0].title, 'Fictional Broadband is coming up');
 });
 
-test('global pause blocks creation and pauses existing local and rule reminders without deleting configuration', () => {
+test('global pause blocks reminder generation and pauses existing local and rule reminders without deleting configuration', () => {
   let state = baseState(); state.scheduledPayments.push({ id: 'subscription', title: 'Fictional subscription', dueDate: '2026-08-12' });
   state = setFinancialReminderConfiguration(state, { sourceType: 'scheduled_payment', sourceId: 'subscription', enabled: true, daysBefore: 3 }, new Date('2026-08-10T12:00:00Z'));
   state.automation.enabled = false;
@@ -72,7 +72,7 @@ test('global pause blocks creation and pauses existing local and rule reminders 
   assert.equal(state.tasks.filter((task) => task.source === 'financial_reminder').length, 1);
 });
 
-test('pausing after creation preserves completion lifecycle when re-enabled', () => {
+test('pausing after generation preserves completion lifecycle when re-enabled', () => {
   const state = baseState(); state.scheduledPayments.push({ id: 'loan', title: 'Fictional loan', dueDate: '2026-08-11' });
   synchroniseFinancialReminders(state, new Date('2026-08-11T09:00:00+01:00'));
   state.tasks[0].completedAt = '2026-08-11T09:05:00.000Z';

--- a/tests/financial-reminders.test.js
+++ b/tests/financial-reminders.test.js
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import test from 'node:test';
+import {
+  createUserFinancialReminder, dismissFinancialReminderForToday, listFinancialReminderSources,
+  reminderTaskId, setFinancialReminderConfiguration, synchroniseFinancialReminders
+} from '../financial-reminders.js';
+
+function baseState() { return { automation: { enabled: true, reminders: [] }, tasks: [], scheduledPayments: [], reviewItems: [], transactions: [], budgets: [] }; }
+
+test('upcoming, due-today and overdue states use local calendar dates', () => {
+  const state = baseState(); state.scheduledPayments.push({ id: 'rent', title: 'Fictional rent', dueDate: '2026-10-25', status: 'scheduled' });
+  assert.equal(listFinancialReminderSources(state, new Date('2026-10-24T12:00:00+01:00'))[0].status, 'upcoming');
+  assert.equal(listFinancialReminderSources(state, new Date('2026-10-25T00:30:00+01:00'))[0].status, 'due_today');
+  assert.equal(listFinancialReminderSources(state, new Date('2026-10-26T12:00:00+00:00'))[0].status, 'overdue');
+});
+
+test('restart-style repeated synchronisation is duplicate-safe', () => {
+  const state = baseState(); state.scheduledPayments.push({ id: 'insurance', title: 'Fictional insurance', dueDate: '2026-08-14' });
+  synchroniseFinancialReminders(state, new Date('2026-08-11T12:00:00+01:00'));
+  const id = state.tasks[0].id;
+  synchroniseFinancialReminders(state, new Date('2026-08-11T18:00:00+01:00'));
+  assert.equal(state.tasks.filter((task) => task.source === 'financial_reminder').length, 1);
+  assert.equal(state.tasks[0].id, id);
+  assert.equal(id, reminderTaskId('scheduled_payment', 'insurance', '2026-08-14'));
+});
+
+test('resolved scheduled source removes its active reminder task', () => {
+  const state = baseState(); state.scheduledPayments.push({ id: 'card', title: 'Fictional card', dueDate: '2026-08-11', status: 'scheduled' });
+  synchroniseFinancialReminders(state, new Date('2026-08-11T10:00:00+01:00'));
+  assert.equal(state.tasks.length, 1);
+  state.scheduledPayments[0].status = 'paid';
+  synchroniseFinancialReminders(state, new Date('2026-08-11T11:00:00+01:00'));
+  assert.equal(state.tasks.length, 0);
+});
+
+test('dismiss for today preserves the source and returns on the next local date', () => {
+  let state = baseState(); state.scheduledPayments.push({ id: 'utility', title: 'Fictional utility', dueDate: '2026-08-12' });
+  synchroniseFinancialReminders(state, new Date('2026-08-11T09:00:00+01:00'));
+  state = dismissFinancialReminderForToday(state, 'scheduled_payment', 'utility', new Date('2026-08-11T10:00:00+01:00'));
+  synchroniseFinancialReminders(state, new Date('2026-08-11T10:00:00+01:00'));
+  assert.equal(state.tasks[0].snoozedUntil, '2026-08-12');
+  synchroniseFinancialReminders(state, new Date('2026-08-12T08:00:00+01:00'));
+  assert.equal(state.tasks[0].snoozedUntil, null);
+  assert.equal(state.tasks[0].title, 'Fictional utility is due today');
+});
+
+test('confirmed recurring commitment generates; uncertain pattern does not', () => {
+  const state = baseState();
+  state.transactions.push(
+    ...['2026-04-13', '2026-05-13', '2026-06-13', '2026-07-13'].map((date, index) => fictionalRecurringTransaction(`confirmed-${index}`, date, 'Fictional Broadband')),
+    fictionalRecurringTransaction('uncertain-1', '2026-06-20', 'Fictional Maybe'),
+    fictionalRecurringTransaction('uncertain-2', '2026-07-20', 'Fictional Maybe')
+  );
+  synchroniseFinancialReminders(state, new Date('2026-08-11T12:00:00+01:00'));
+  assert.equal(state.tasks.length, 1);
+  assert.equal(state.tasks[0].title, 'Fictional Broadband is coming up');
+});
+
+test('global pause blocks creation and pauses existing local and rule reminders without deleting configuration', () => {
+  let state = baseState(); state.scheduledPayments.push({ id: 'subscription', title: 'Fictional subscription', dueDate: '2026-08-12' });
+  state = setFinancialReminderConfiguration(state, { sourceType: 'scheduled_payment', sourceId: 'subscription', enabled: true, daysBefore: 3 }, new Date('2026-08-10T12:00:00Z'));
+  state.automation.enabled = false;
+  state.tasks.push({ id: 'automation_example', source: 'automation_rule', title: 'Fictional rule reminder', updatedAt: '2026-08-10T12:00:00.000Z', snoozedUntil: null });
+  synchroniseFinancialReminders(state, new Date('2026-08-11T12:00:00+01:00'));
+  assert.equal(state.tasks.some((task) => task.source === 'financial_reminder'), false);
+  assert.equal(state.tasks[0].snoozedUntil, '9999-12-31');
+  assert.equal(state.automation.reminders.length, 1);
+  state.automation.enabled = true;
+  synchroniseFinancialReminders(state, new Date('2026-08-11T12:05:00+01:00'));
+  assert.equal(state.tasks.find((task) => task.source === 'automation_rule').snoozedUntil, null);
+  assert.equal(state.tasks.filter((task) => task.source === 'financial_reminder').length, 1);
+});
+
+test('pausing after creation preserves completion lifecycle when re-enabled', () => {
+  const state = baseState(); state.scheduledPayments.push({ id: 'loan', title: 'Fictional loan', dueDate: '2026-08-11' });
+  synchroniseFinancialReminders(state, new Date('2026-08-11T09:00:00+01:00'));
+  state.tasks[0].completedAt = '2026-08-11T09:05:00.000Z';
+  state.automation.enabled = false;
+  synchroniseFinancialReminders(state, new Date('2026-08-11T10:00:00+01:00'));
+  state.automation.enabled = true;
+  synchroniseFinancialReminders(state, new Date('2026-08-11T11:00:00+01:00'));
+  assert.equal(state.tasks[0].completedAt, '2026-08-11T09:05:00.000Z');
+});
+
+test('existing review item with explicit due date is recognised without creating a duplicate task', () => {
+  const state = baseState(); state.reviewItems.push({ id: 'review:test', status: 'needs_attention', dueDate: '2026-08-11', title: 'Fictional review' });
+  const sources = listFinancialReminderSources(state, new Date('2026-08-11T09:00:00+01:00'));
+  assert.equal(sources.some((source) => source.sourceType === 'review_due'), true);
+  synchroniseFinancialReminders(state, new Date('2026-08-11T09:00:00+01:00'));
+  assert.equal(state.tasks.length, 0);
+});
+
+test('timing crosses year and BST boundaries without timezone drift', () => {
+  let state = baseState(); state.scheduledPayments.push({ id: 'annual', title: 'Fictional annual fee', dueDate: '2027-01-02' });
+  state = setFinancialReminderConfiguration(state, { sourceType: 'scheduled_payment', sourceId: 'annual', daysBefore: 7, enabled: true }, new Date('2026-12-01T12:00:00Z'));
+  assert.equal(listFinancialReminderSources(state, new Date('2026-12-20T12:00:00Z'))[0].triggerDate, '2026-12-26');
+  state.scheduledPayments[0].dueDate = '2026-03-30';
+  assert.equal(listFinancialReminderSources(state, new Date('2026-03-28T23:30:00Z'))[0].status, 'upcoming');
+});
+
+test('user-created reminders require explicit date/title and stay local-state only', async () => {
+  const state = createUserFinancialReminder(baseState(), { title: 'Fictional renewal', dueDate: '2026-09-01', daysBefore: 7 }, new Date('2026-08-11T12:00:00Z'));
+  assert.equal(state.automation.reminders[0].sourceType, 'user');
+  const source = await fs.readFile(new URL('../financial-reminders.js', import.meta.url), 'utf8');
+  assert.equal(/\bfetch\s*\(|https?:\/\/|XMLHttpRequest|WebSocket/.test(source), false);
+});
+
+function fictionalRecurringTransaction(id, date, merchantName) {
+  return { id, date, accountId: 'fictional-account', merchantName, outgoing: 20, incoming: 0, financiallyActive: true, duplicateStatus: 'none', reviewStatus: 'not_required', importReviewStatus: 'trusted', transferStatus: 'no', budgetTreatment: 'spending', category: 'Fictional bills' };
+}


### PR DESCRIPTION
## Purpose
Implement #75 as the v2.2.0 branch-level local financial reminders feature, using only confirmed or explicit financial dates and reusing OneStep’s existing Today / Review Inbox / Next Move lifecycle.

Closes #75 only when this PR is reviewed and merged.

## Work completed
- Added local due-date reminders for confirmed recurring outgoing commitments, explicitly dated scheduled payments, explicitly dated Review Inbox items, and user-created financial reminders.
- Added stable source/date identities so reopening or rerendering does not create duplicate reminder or Review lifecycle items.
- Added local-calendar timing for on-date and bounded 0–31 day lead times, including the intended 1/3/7-day choices and month/year/BST-safe date arithmetic.
- Added upcoming, due-today and overdue states without inventing a competing priority score.
- Added per-reminder enable/pause, timing changes, dismiss-for-today, and user-reminder deletion controls.
- Reused existing generated-action tasks so reminders flow through Review Inbox, Today and Next Move, including the existing completion and snooze lifecycle.
- Global automation pause stops new reminder delivery and temporarily suppresses existing local reminder tasks without deleting configuration, completion state or an existing user snooze.
- Preserved #72 local automation-rule reminder behaviour and applied the same global-pause suppression to rule-created reminder tasks.
- Extended the existing automation v1 state compatibly with a bounded `reminders` configuration array; no financial schema/version bump is required.
- Added Electron packaging and GitHub Pages demo allowlist entries for the new modules.

## Files changed
- `financial-reminders.js` — reminder model, authoritative source derivation, local date/status logic, stable IDs and lifecycle synchronisation.
- `financial-reminders-ui.js` — Settings reminder management UI.
- `automation-state.js` — backward-compatible reminder configuration normalisation in automation state v1.
- `review-lifecycle.js` — synchronises reminders before existing Review lifecycle processing.
- `recurring-finance-ui.js` — renders reminder settings beside recurring/automation settings.
- `package.json` — packages the new reminder modules.
- `scripts/build-pages-site.mjs` — includes the new modules in the browser demo build.
- `tests/financial-reminders.test.js` — focused due-date/reminder tests.
- `tests/financial-reminders-integration.test.js` — Review/Today lifecycle and snooze integration tests.
- `tests/automation-persistence.test.js` — reminder restart and portable backup/restore coverage.

## User-facing changes
Users can manage meaningful local financial reminders in Settings, including confirmed recurring commitments and explicitly scheduled dates; add their own dated financial reminders; choose a reminder lead time; pause individual reminders; and dismiss a reminder for the current day. Relevant reminders surface through OneStep’s existing Today/Review/Next Move flow rather than a second task system.

## Technical changes
Reminder status is derived from local `YYYY-MM-DD` calendar dates rather than persisted. Only explicit reminder configuration/lifecycle facts are stored. Stable source/date hashes map one financial occurrence to one reminder task. Existing Review lifecycle reconciliation resolves generated actions when their financial source resolves and prevents duplicate active items. Existing Review items with their own explicit due date are recognised as reminder sources without creating a duplicate task.

## Testing and verification
Final head `9fac008cdcd2d4ef248d0f9d0a3317c1c656d71f` passed GitHub Actions run #171 on the PR merge ref.

- **Passed — Ubuntu:** `npm test` — 440/440 tests.
- **Passed — Ubuntu:** `npm run check` — project validation plus privacy check.
- **Passed — Ubuntu:** `npm run lint`.
- **Passed — Windows:** `npm test`.
- **Passed — Windows:** `npm run check` — project validation plus privacy check.
- **Passed — Windows:** `npm run lint`.
- **Passed — Windows:** built Pages artifact runtime smoke test.
- **Passed — Windows:** Electron desktop startup smoke test.
- **Passed — Windows:** Windows packaging smoke test (`npm run dist:win -- --publish never`).
- **Passed — focused reminder coverage:** due/upcoming/overdue transitions, restart duplicate safety, resolved-source cleanup, dismiss/return, confirmed-vs-uncertain recurrence, global pause, lifecycle preservation, Review dedupe, year/BST boundaries, local-only/no-network behaviour, and persistence/backup restore.
- **Unavailable in this runtime:** a human/manual click-through of the reminder Settings controls and manual theme/accessibility visual inspection. Automated renderer/startup, UI integration tests and Windows packaging passed; this is not being represented as manual testing.
- **Skipped by workflow as expected:** tag-only `release-windows` publishing job; this is a draft PR, not a release tag.

The first CI attempts exposed two contained test/schema integration issues: an unnecessary automation substate version bump and timezone-dependent test construction; both were corrected without weakening production financial logic. A later privacy-check failure was an English-word false positive in a test title and was corrected by changing test wording only.

## Data and migration impact
No main financial schema bump and no automation substate version bump. Existing automation state remains version 1 with an additional bounded `reminders` field. Legacy state normalises safely to `reminders: []`. Derived due/upcoming/overdue status is recalculated rather than persisted. Restart and encrypted portable backup/restore tests verify configured reminders are preserved.

## Known limitations
- Core v2.2.0 delivery is in-app/local only; no remote push, email, SMS or background cloud service.
- Existing Review Inbox items participate only when they already contain an explicit valid `dueDate`; OneStep does not infer one.
- OS-level notification delivery while OneStep is closed is intentionally not added.
- No manual visual click-through was possible in this execution environment; automated Electron startup and Windows packaging verification passed.

## Excluded work
General-purpose calendar/task management, payday-specific calculations, AI Companion behaviour, remote notifications, cloud services, external bill-payment execution, and inferred due dates from uncertain evidence.

## Branch details
- **Branch:** `feature/financial-reminders`
- **Commit SHA:** `9fac008cdcd2d4ef248d0f9d0a3317c1c656d71f`
- **Pull request:** #120
- **Target branch:** `main`

## Confirmations
- No changes were committed or pushed directly to `main`.
- This PR has not been merged by this workflow.
- No personal financial data, imported documents, credentials, secrets, sensitive logs or encryption material were committed.
- Only files relevant to #75 were changed.