### PR TITLE
[v2.2.0][Feature] Complete multi-horizon cash-flow forecasting

### DIFF
--- a/financial-presentation-debt.js
+++ b/financial-presentation-debt.js
@@ -1,0 +1,1 @@
+// Local presentation hook for #86. The issue branch replaces this bootstrap stub.

--- a/financial-presentation-forecast.js
+++ b/financial-presentation-forecast.js
@@ -1,1 +1,257 @@
-// Local presentation hook for #84. The issue branch replaces this bootstrap stub.
+import { buildCashFlowForecast, CASH_FLOW_CERTAINTY, CASH_FLOW_HORIZON } from './cash-flow-forecast.js';
+import { formatCurrency, formatDate } from './finance-core.js';
+
+const HORIZON_ORDER = Object.freeze([
+  CASH_FLOW_HORIZON.TODAY,
+  CASH_FLOW_HORIZON.BEFORE_PAYDAY,
+  CASH_FLOW_HORIZON.SEVEN_DAYS,
+  CASH_FLOW_HORIZON.THIRTY_DAYS,
+  CASH_FLOW_HORIZON.NEXT_PAYDAY,
+  CASH_FLOW_HORIZON.THREE_MONTHS
+]);
+
+const RISK_COPY = Object.freeze({
+  projected_negative: 'The ordinary projection falls below £0 before this horizon.',
+  safe_negative: 'The conservative safe projection falls below £0 before this horizon.',
+  buffer_breach: 'The protected buffer may be breached before this horizon.'
+});
+
+let selectedHorizon = CASH_FLOW_HORIZON.SEVEN_DAYS;
+let refreshQueued = false;
+let refreshInFlight = false;
+let rerunRefresh = false;
+
+export function buildForecastPresentationModel(forecast, horizonId = CASH_FLOW_HORIZON.SEVEN_DAYS) {
+  const available = Array.isArray(forecast?.horizons) ? forecast.horizons : [];
+  const selected = available.find((item) => item.id === horizonId)
+    || available.find((item) => item.status === 'available')
+    || available[0]
+    || null;
+  const endDate = selected?.date || forecast?.asOf || null;
+  const timeline = (forecast?.events || [])
+    .filter((item) => !endDate || item.date <= endDate)
+    .slice(0, 10);
+  return {
+    status: forecast?.status || 'unavailable',
+    asOf: forecast?.asOf || null,
+    selected,
+    horizons: HORIZON_ORDER.map((id) => available.find((item) => item.id === id)).filter(Boolean),
+    timeline,
+    blockers: Array.isArray(forecast?.blockers) ? forecast.blockers : [],
+    why: Array.isArray(forecast?.why) ? forecast.why : [],
+    budgetTreatment: forecast?.budgetContext?.treatment || 'context_only'
+  };
+}
+
+function boot() {
+  if (!window.financeAPI?.loadState) return;
+  ensureHost();
+  document.addEventListener('click', handleDocumentClick, true);
+  document.addEventListener('change', handleDocumentChange, true);
+  observeExternalRenders();
+  scheduleRefresh();
+}
+
+function ensureHost() {
+  if (document.getElementById('cashFlowForecastPanel')) return;
+  const today = document.getElementById('view-today');
+  const metrics = today?.querySelector('.metric-grid');
+  if (!today || !metrics) return;
+  const panel = document.createElement('section');
+  panel.id = 'cashFlowForecastPanel';
+  panel.className = 'panel';
+  panel.setAttribute('aria-labelledby', 'cashFlowForecastTitle');
+  panel.innerHTML = [
+    '<div class="panel-heading"><div><p class="eyebrow">LOOKING AHEAD</p><h2 id="cashFlowForecastTitle">Cash-flow forecast</h2><p class="muted">A conservative local view of what is already known, what is expected, and what is only planned.</p></div></div>',
+    '<div id="cashFlowForecastHorizons" class="button-row" role="group" aria-label="Forecast horizon"></div>',
+    '<div id="cashFlowForecastSummary" class="metric-grid three"></div>',
+    '<div id="cashFlowForecastWarnings" class="warning-box" hidden></div>',
+    '<div class="two-column"><div><h3>Major expected movements</h3><div id="cashFlowForecastTimeline" class="dashboard-list"></div></div><div><h3>Assumptions</h3><div id="cashFlowForecastAssumptions"></div></div></div>',
+    '<p id="cashFlowForecastStatus" class="muted" role="status" aria-live="polite"></p>'
+  ].join('');
+  metrics.after(panel);
+}
+
+function handleDocumentClick(event) {
+  const horizon = event.target.closest('[data-cash-flow-horizon]');
+  if (horizon) {
+    selectedHorizon = horizon.dataset.cashFlowHorizon;
+    scheduleRefresh();
+    return;
+  }
+  if (event.target.closest('.nav-button, [data-view-target], [data-add], [data-edit], [data-review-route], [data-review-decision], [data-review-snooze], #saveSettingsButton, #saveEditButton, #confirmImportButton, #confirmRestoreButton')) {
+    window.setTimeout(scheduleRefresh, 120);
+  }
+}
+
+function handleDocumentChange(event) {
+  if (document.getElementById('cashFlowForecastPanel')?.contains(event.target)) return;
+  window.setTimeout(scheduleRefresh, 120);
+}
+
+function observeExternalRenders() {
+  const targets = ['appShell', 'view-today', 'todayDebtValue', 'todayOverdraftValue', 'marginValue', 'dashboardUpcomingValue'];
+  for (const id of targets) {
+    const target = document.getElementById(id);
+    if (!target) continue;
+    const observer = new MutationObserver(() => scheduleRefresh());
+    observer.observe(target, { attributes: true, childList: true, characterData: true, subtree: id !== 'appShell' && id !== 'view-today' });
+  }
+}
+
+function scheduleRefresh() {
+  if (refreshQueued) return;
+  refreshQueued = true;
+  window.setTimeout(() => {
+    refreshQueued = false;
+    refreshForecast();
+  }, 40);
+}
+
+async function refreshForecast() {
+  if (refreshInFlight) {
+    rerunRefresh = true;
+    return;
+  }
+  refreshInFlight = true;
+  try {
+    ensureHost();
+    const loaded = await window.financeAPI.loadState();
+    if (loaded?.status !== 'normal' || !loaded.state) {
+      renderUnavailable('Forecasting is unavailable while financial data is not in normal mode.');
+      return;
+    }
+    const forecast = buildCashFlowForecast(loaded.state);
+    renderForecast(buildForecastPresentationModel(forecast, selectedHorizon));
+  } catch {
+    renderUnavailable('The forecast could not be calculated. No financial data was changed.');
+  } finally {
+    refreshInFlight = false;
+    if (rerunRefresh) {
+      rerunRefresh = false;
+      scheduleRefresh();
+    }
+  }
+}
+
+function renderForecast(model) {
+  const panel = document.getElementById('cashFlowForecastPanel');
+  if (!panel) return;
+  const controls = document.getElementById('cashFlowForecastHorizons');
+  controls.replaceChildren();
+  for (const horizon of model.horizons) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = horizon.id === model.selected?.id ? 'primary-button' : 'secondary-button';
+    button.dataset.cashFlowHorizon = horizon.id;
+    button.textContent = horizon.label;
+    button.disabled = horizon.status !== 'available';
+    button.setAttribute('aria-pressed', String(horizon.id === model.selected?.id));
+    if (horizon.date) button.title = `Through ${safeDate(horizon.date)}`;
+    controls.append(button);
+  }
+
+  const summary = document.getElementById('cashFlowForecastSummary');
+  summary.replaceChildren();
+  if (!model.selected || model.selected.status !== 'available') {
+    summary.append(metric('Projected balance', 'Unavailable', 'Add a dependable payday or the missing trusted information.'));
+  } else {
+    summary.append(
+      metric('Projected balance', money(model.selected.projectedBalance), 'Includes expected scheduled income and expected outgoings.'),
+      metric('Safe view', money(model.selected.safeProjectedBalance), 'Expected future income is not counted until it is received.'),
+      metric('Forecast through', safeDate(model.selected.date), `${model.selected.eventCount || 0} major movement${model.selected.eventCount === 1 ? '' : 's'} included.`)
+    );
+  }
+
+  const warnings = document.getElementById('cashFlowForecastWarnings');
+  const warningCopy = [...new Set((model.selected?.riskFlags || []).map((flag) => RISK_COPY[flag]).filter(Boolean))];
+  warnings.hidden = warningCopy.length === 0;
+  warnings.replaceChildren();
+  if (warningCopy.length) {
+    const strong = document.createElement('strong');
+    strong.textContent = 'Check this horizon';
+    const list = document.createElement('ul');
+    for (const copy of warningCopy) list.append(listItem(copy));
+    warnings.append(strong, list);
+  }
+
+  const timeline = document.getElementById('cashFlowForecastTimeline');
+  timeline.replaceChildren();
+  if (!model.timeline.length) timeline.append(emptyText('No scheduled or strongly evidenced movements fall inside this horizon.'));
+  for (const event of model.timeline) timeline.append(timelineRow(event));
+
+  const assumptions = document.getElementById('cashFlowForecastAssumptions');
+  assumptions.replaceChildren();
+  if (model.blockers.length) {
+    const blocker = document.createElement('div');
+    blocker.className = 'check-card warning';
+    const title = document.createElement('h3'); title.textContent = 'Needs review';
+    const list = document.createElement('ul');
+    for (const item of model.blockers) list.append(listItem(item.explanation || 'A financial fact needs review.'));
+    blocker.append(title, list); assumptions.append(blocker);
+  }
+  const details = document.createElement('details');
+  details.className = 'plan-why';
+  const summaryNode = document.createElement('summary'); summaryNode.textContent = 'Why?';
+  const whyList = document.createElement('ul');
+  for (const copy of model.why) whyList.append(listItem(copy));
+  if (model.budgetTreatment === 'context_only') whyList.append(listItem('Budget allowances remain planning context and are not treated as mandatory bills.'));
+  details.append(summaryNode, whyList);
+  assumptions.append(details);
+
+  document.getElementById('cashFlowForecastStatus').textContent = model.status === 'available'
+    ? 'Forecast calculated locally from the current trusted financial profile. Derived totals are not stored as authoritative data.'
+    : 'Forecast shown conservatively because one or more trusted inputs need review.';
+}
+
+function renderUnavailable(message) {
+  ensureHost();
+  const status = document.getElementById('cashFlowForecastStatus');
+  if (status) status.textContent = message;
+}
+
+function metric(label, value, hint) {
+  const article = document.createElement('article'); article.className = 'metric-card';
+  const span = document.createElement('span'); span.textContent = label;
+  const strong = document.createElement('strong'); strong.textContent = value;
+  const small = document.createElement('small'); small.textContent = hint;
+  article.append(span, strong, small); return article;
+}
+
+function timelineRow(event) {
+  const row = document.createElement('div'); row.className = 'dashboard-list-row horizontal';
+  const copy = document.createElement('div');
+  const title = document.createElement('strong'); title.textContent = event.explanation || event.sourceType || 'Forecast movement';
+  const meta = document.createElement('span');
+  meta.textContent = `${safeDate(event.date)} · ${certaintyLabel(event.certainty)}${event.certainty === CASH_FLOW_CERTAINTY.EXPECTED && event.delta > 0 ? ' · not counted in safe view until received' : ''}`;
+  copy.append(title, meta);
+  const amount = document.createElement('strong');
+  amount.className = event.delta < 0 ? 'outgoing' : 'incoming';
+  amount.textContent = `${event.delta < 0 ? '−' : '+'}${money(Math.abs(event.delta))}`;
+  row.append(copy, amount); return row;
+}
+
+function certaintyLabel(value) {
+  if (value === CASH_FLOW_CERTAINTY.CONFIRMED) return 'Confirmed';
+  if (value === CASH_FLOW_CERTAINTY.EXPECTED) return 'Expected';
+  return 'Possible · plan only';
+}
+
+function safeDate(value) {
+  if (!value) return 'Unavailable';
+  try { return formatDate(value); } catch { return String(value); }
+}
+
+function money(value) {
+  return Number.isFinite(Number(value)) ? formatCurrency(Number(value)) : 'Unavailable';
+}
+
+function listItem(text) {
+  const item = document.createElement('li'); item.textContent = text; return item;
+}
+
+function emptyText(text) {
+  const p = document.createElement('p'); p.className = 'muted'; p.textContent = text; return p;
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') boot();

--- a/financial-presentation-forecast.js
+++ b/financial-presentation-forecast.js
@@ -1,0 +1,1 @@
+// Local presentation hook for #84. The issue branch replaces this bootstrap stub.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
       "automation-state.js",
       "financial-reminders.js",
       "financial-reminders-ui.js",
+      "financial-presentation-forecast.js",
+      "financial-presentation-debt.js",
       "cash-flow-forecast.js",
       "data-store.js",
       "date-utils.js",

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -54,8 +54,10 @@ function loadFinancialPresentationModules() {
   }
 }
 
-if (document.readyState === 'loading') {
-  window.addEventListener('DOMContentLoaded', loadFinancialPresentationModules, { once: true });
-} else {
-  loadFinancialPresentationModules();
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', loadFinancialPresentationModules, { once: true });
+  } else {
+    loadFinancialPresentationModules();
+  }
 }

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -42,3 +42,20 @@ contextBridge.exposeInMainWorld('financeAPI', Object.freeze({
     return () => ipcRenderer.removeListener('backup:restore-progress', listener);
   }
 }));
+
+function loadFinancialPresentationModules() {
+  for (const source of ['financial-presentation-forecast.js', 'financial-presentation-debt.js']) {
+    if (document.querySelector(`script[data-financial-presentation="${source}"]`)) continue;
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.src = source;
+    script.dataset.financialPresentation = source;
+    document.head.append(script);
+  }
+}
+
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', loadFinancialPresentationModules, { once: true });
+} else {
+  loadFinancialPresentationModules();
+}

--- a/tests/financial-presentation-forecast.test.js
+++ b/tests/financial-presentation-forecast.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildForecastPresentationModel } from '../financial-presentation-forecast.js';
+
+test('forecast presentation selects a horizon and limits timeline to it', () => {
+  const model = buildForecastPresentationModel({
+    status: 'available',
+    asOf: '2026-08-11',
+    horizons: [
+      { id: '7_days', label: '7 days', status: 'available', date: '2026-08-18', projectedBalance: 420, safeProjectedBalance: 300, eventCount: 2, riskFlags: [] },
+      { id: '30_days', label: '30 days', status: 'available', date: '2026-09-10', projectedBalance: 510, safeProjectedBalance: 210, eventCount: 3, riskFlags: ['buffer_breach'] }
+    ],
+    events: [
+      { id: 'bill', date: '2026-08-13', delta: -80, certainty: 'confirmed' },
+      { id: 'pay', date: '2026-08-17', delta: 200, certainty: 'expected' },
+      { id: 'later', date: '2026-08-25', delta: -50, certainty: 'expected' }
+    ],
+    blockers: [],
+    why: ['Expected income is excluded from the safe view until received.'],
+    budgetContext: { treatment: 'context_only' }
+  }, '7_days');
+
+  assert.equal(model.selected.id, '7_days');
+  assert.deepEqual(model.timeline.map((item) => item.id), ['bill', 'pay']);
+  assert.equal(model.budgetTreatment, 'context_only');
+});


### PR DESCRIPTION
## Purpose
Complete #84 by connecting the already-merged conservative cash-flow forecast engine to the desktop presentation layer.

## Work completed
- Added the shared local presentation bootstrap used by the remaining #84/#86 renderer integrations.
- Added Today-page controls for Today, Before next payday, 7 days, 30 days, Next payday and 3 months.
- Added ordinary projected balance and conservative Safe view side-by-side.
- Added a major-movements timeline with Confirmed, Expected and Possible distinctions.
- Clearly labels expected future income as excluded from the Safe view until received.
- Added negative-balance/protected-buffer warnings, input blockers and a Why? explanation.
- Keeps budget allowances as planning context rather than silently treating them as mandatory outflows.
- Added focused presentation-model test coverage.
- Hardened the preload bootstrap so it remains inert when no renderer DOM exists.

## Files changed
- `preload-bridge.cjs`
- `package.json`
- `financial-presentation-forecast.js`
- `financial-presentation-debt.js` (shared bootstrap stub for #86)
- `tests/financial-presentation-forecast.test.js`

## User-facing changes
The Today view now exposes the multi-horizon forecast already calculated locally by OneStep Money. Users can change horizon, compare the ordinary and conservative projections, see significant expected movements and inspect why the forecast was produced or blocked.

## Technical changes
The existing sandboxed preload loads packaged local presentation modules after DOM readiness. The forecast UI calls the existing `buildCashFlowForecast` engine and reads current state only through the existing local `financeAPI.loadState()` bridge. Forecast values remain derived and non-authoritative; no new persistence path is introduced.

## Testing and verification
- Passed: Git/PR convention validation.
- Passed: Linux `npm test` — 441 tests, including the new forecast presentation coverage.
- Passed: Linux `npm run check` including privacy checks.
- Passed: Linux `npm run lint`.
- Passed: Windows `npm test`.
- Passed: Windows `npm run check` including privacy checks.
- Passed: Windows `npm run lint`.
- Passed: built GitHub Pages runtime smoke test on Windows.
- Passed: Electron desktop startup smoke test on Windows.
- Passed: Windows packaging smoke test.
- Passed: local syntax validation of the new presentation module and preload fix.
- Note: the first CI run exposed a DOM assumption in the preload unit-test context; commit `2a9fe43` fixed it and the complete rerun passed.
- Manual Windows interaction/visual review: not performed by automation; remains for user review before merge.

## Data and migration impact
No stored-data format change or migration. Forecast output is derived and not persisted. No import/export behaviour changes.

## Security and privacy
No telemetry, analytics, remote storage, new network services or financial logging. The presentation reads the existing local financial state and renders derived values only.

## Known limitations
Automated Electron startup and Windows packaging passed, but this workflow does not claim human visual/interaction testing.

## Excluded work
- No automatic payments or money movement.
- No changes to the forecast calculation contract beyond presentation.
- No unrelated v2.2.0 features.

## Branch details
- Branch: `feature/cash-flow-forecasting`
- Commit SHA: `2a9fe43aeee72047308cfeb5cd66f355379558f0`
- Pull request: #125
- Target branch: `main`

## Confirmations
- No changes were committed or pushed directly to `main`.
- This PR has not been merged by this workflow.
- No personal financial data, imported documents, credentials, secrets or sensitive logs were committed.
- Only files relevant to the #84/#86 shared presentation bootstrap and #84 completion were changed.