### PR TITLE
[v2.2.0][Feature] Automation history, explanations and safe undo

### DIFF
--- a/automation-history-runner.js
+++ b/automation-history-runner.js
@@ -1,0 +1,41 @@
+import { recordAutomationHistoryOutcome } from './automation-history.js';
+import { runStoredAutomationRules } from './automation-rules.js';
+
+export async function runStoredAutomationRulesWithHistory(state, options = {}) {
+  const beforeState = structuredClone(state || {});
+  const run = await runStoredAutomationRules(state, options);
+  let current = run.state;
+  let historyChanged = false;
+
+  for (const result of run.results || []) {
+    const recorded = recordAutomationHistoryOutcome(current, {
+      beforeState,
+      proposal: proposalForHistory(current, result),
+      result,
+      now: options.now
+    });
+    current = recorded.state;
+    historyChanged ||= recorded.changed;
+  }
+
+  return {
+    ...run,
+    state: current,
+    historyChanged,
+    changed: Boolean(run.changed || historyChanged)
+  };
+}
+
+function proposalForHistory(state, result) {
+  if (!result?.executionId) return null;
+  const rule = (state?.automation?.rules || []).find((item) => item.id === result.ruleId);
+  const payload = result.actionType === 'add_local_tag' && rule?.action?.type === 'add_tag'
+    ? { tag: rule.action.value }
+    : null;
+  return {
+    executionId: result.executionId,
+    ruleId: result.ruleId,
+    source: { type: result.sourceType, id: result.sourceId },
+    action: { type: result.actionType, payload }
+  };
+}

--- a/automation-history-ui.js
+++ b/automation-history-ui.js
@@ -1,0 +1,252 @@
+import {
+  AUTOMATION_HISTORY_FILTER, automationHistoryEntries, automationHistoryPresentation,
+  undoAutomationHistoryEntry
+} from './automation-history.js';
+
+let state = null;
+let filter = AUTOMATION_HISTORY_FILTER.ALL;
+let refreshRunning = false;
+let refreshQueued = false;
+let statusMessage = '';
+
+function boot() {
+  if (!window.financeAPI?.loadState) return;
+  ensureHost();
+  document.addEventListener('click', handleClick, true);
+  observeApp();
+  scheduleRefresh();
+}
+
+function ensureHost() {
+  if (document.getElementById('automationHistorySettings')) return;
+  const grid = document.querySelector('#view-settings .settings-grid');
+  if (!grid) return;
+  const panel = document.createElement('article');
+  panel.id = 'automationHistorySettings';
+  panel.className = 'panel';
+  panel.setAttribute('aria-labelledby', 'automationHistoryTitle');
+  panel.innerHTML = [
+    '<div class="panel-heading"><div><p class="eyebrow">LOCAL AUTOMATION HISTORY</p><h2 id="automationHistoryTitle">What OneStep changed</h2>',
+    '<p class="muted">See what local automations did, why they did it, and safely undo eligible changes. History stays on this device.</p></div></div>',
+    '<div id="automationHistoryFilters" class="button-row" role="group" aria-label="Automation history filter"></div>',
+    '<div id="automationHistoryList" class="compact-card-list"></div>',
+    '<p id="automationHistoryStatus" class="muted" role="status" aria-live="polite"></p>'
+  ].join('');
+  grid.append(panel);
+}
+
+function observeApp() {
+  const shell = document.getElementById('appShell');
+  const settings = document.getElementById('view-settings');
+  for (const target of [shell, settings].filter(Boolean)) {
+    const observer = new MutationObserver(() => {
+      ensureHost();
+      scheduleRefresh();
+    });
+    observer.observe(target, { attributes: true, childList: true, subtree: target === settings });
+  }
+}
+
+function scheduleRefresh() {
+  if (refreshRunning) {
+    refreshQueued = true;
+    return;
+  }
+  refreshRunning = true;
+  queueMicrotask(refresh);
+}
+
+async function refresh() {
+  try {
+    ensureHost();
+    const loaded = await window.financeAPI.loadState();
+    if (loaded?.status !== 'normal' || !loaded.state) return;
+    state = loaded.state;
+    render();
+  } catch {
+    setStatus('Automation history could not be refreshed. No financial information was changed.');
+  } finally {
+    refreshRunning = false;
+    if (refreshQueued) {
+      refreshQueued = false;
+      scheduleRefresh();
+    }
+  }
+}
+
+function render() {
+  ensureHost();
+  const panel = document.getElementById('automationHistorySettings');
+  if (!panel || !state) return;
+  renderFilters();
+  const list = document.getElementById('automationHistoryList');
+  list.replaceChildren();
+
+  const entries = automationHistoryEntries(state, filter);
+  if (!entries.length) {
+    const empty = document.createElement('p');
+    empty.className = 'muted';
+    empty.textContent = filter === AUTOMATION_HISTORY_FILTER.ALL
+      ? 'No automation history yet. Safe local automation outcomes will appear here.'
+      : 'No history items match this filter.';
+    list.append(empty);
+  }
+
+  for (const entry of entries) {
+    const presentation = automationHistoryPresentation(state, entry);
+    if (!presentation) continue;
+    list.append(historyCard(entry, presentation));
+  }
+  setStatus(statusMessage);
+}
+
+function renderFilters() {
+  const container = document.getElementById('automationHistoryFilters');
+  if (!container) return;
+  container.replaceChildren();
+  const options = [
+    [AUTOMATION_HISTORY_FILTER.ALL, 'All'],
+    [AUTOMATION_HISTORY_FILTER.APPLIED, 'Applied'],
+    [AUTOMATION_HISTORY_FILTER.NEEDS_REVIEW, 'Needs review'],
+    [AUTOMATION_HISTORY_FILTER.BLOCKED, 'Blocked'],
+    [AUTOMATION_HISTORY_FILTER.UNDONE, 'Undone']
+  ];
+  for (const [value, label] of options) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = value === filter ? 'secondary-button active' : 'secondary-button';
+    button.dataset.automationHistoryFilter = value;
+    button.setAttribute('aria-pressed', String(value === filter));
+    button.textContent = label;
+    container.append(button);
+  }
+}
+
+function historyCard(entry, presentation) {
+  const card = document.createElement('article');
+  card.className = 'review-card';
+
+  const heading = document.createElement('div');
+  heading.className = 'review-card-heading';
+  const copy = document.createElement('div');
+  const title = document.createElement('strong');
+  title.textContent = presentation.summary;
+  const meta = document.createElement('span');
+  meta.className = 'muted';
+  meta.textContent = [formatHistoryDate(presentation.timestamp), presentation.sourceLabel, presentation.ruleLabel].filter(Boolean).join(' · ');
+  copy.append(title, meta);
+  const badge = document.createElement('span');
+  badge.className = `badge${entry.result === 'blocked' || entry.result === 'needs_review' ? ' red' : ''}`;
+  badge.textContent = presentation.statusLabel;
+  heading.append(copy, badge);
+  card.append(heading);
+
+  const details = document.createElement('details');
+  const summary = document.createElement('summary');
+  summary.textContent = 'Why?';
+  const why = document.createElement('p');
+  why.className = 'muted';
+  why.textContent = presentation.why;
+  details.append(summary, why);
+  card.append(details);
+
+  const actions = document.createElement('div');
+  actions.className = 'button-row';
+  if (presentation.undo.available) {
+    const undo = document.createElement('button');
+    undo.type = 'button';
+    undo.className = 'secondary-button';
+    undo.dataset.automationHistoryUndo = entry.id;
+    undo.textContent = 'Undo';
+    actions.append(undo);
+  } else if (entry.undoStatus === 'available' || ['newer_change', 'source_missing', 'stale_revision'].includes(presentation.undo.reasonCode)) {
+    const unavailable = document.createElement('span');
+    unavailable.className = 'muted';
+    unavailable.textContent = presentation.undo.message;
+    actions.append(unavailable);
+    const review = document.createElement('button');
+    review.type = 'button';
+    review.className = 'secondary-button';
+    review.dataset.automationHistoryReview = entry.sourceType;
+    review.textContent = entry.sourceType === 'transaction' ? 'Review payment' : 'Open Review Inbox';
+    actions.append(review);
+  }
+  if (actions.childNodes.length) card.append(actions);
+  return card;
+}
+
+async function handleClick(event) {
+  const filterButton = event.target.closest('[data-automation-history-filter]');
+  if (filterButton) {
+    filter = filterButton.dataset.automationHistoryFilter;
+    render();
+    return;
+  }
+
+  const undoButton = event.target.closest('[data-automation-history-undo]');
+  if (undoButton) {
+    await performUndo(undoButton.dataset.automationHistoryUndo, undoButton);
+    return;
+  }
+
+  const reviewButton = event.target.closest('[data-automation-history-review]');
+  if (reviewButton) {
+    const view = reviewButton.dataset.automationHistoryReview === 'transaction' ? 'transactions' : 'review';
+    document.querySelector(`.nav-button[data-view="${view}"]`)?.click();
+  }
+}
+
+async function performUndo(historyId, button) {
+  if (!state || button.disabled) return;
+  button.disabled = true;
+  setStatus('Checking that the automated change is still safe to undo…');
+  try {
+    const loaded = await window.financeAPI.loadState();
+    if (loaded?.status !== 'normal' || !loaded.state) throw new Error('The latest local state is unavailable.');
+    state = loaded.state;
+    const result = undoAutomationHistoryEntry(state, historyId, {
+      expectedRevision: state.meta?.revision,
+      now: new Date()
+    });
+    if (result.status !== 'undone') {
+      state = result.state;
+      statusMessage = result.message;
+      render();
+      return;
+    }
+    const saved = await window.financeAPI.saveState(result.state);
+    if (saved?.status === 'conflict') {
+      state = saved.state;
+      statusMessage = saved.message || 'Your financial information changed. Review the latest state before trying Undo again.';
+      render();
+      return;
+    }
+    if (saved?.status === 'blocked') throw new Error(saved.message || 'Saving is paused while data recovery protections are active.');
+    state = saved;
+    statusMessage = result.message;
+    render();
+  } catch (error) {
+    statusMessage = error?.message || 'Undo could not be completed safely. Nothing was changed.';
+    setStatus(statusMessage);
+    scheduleRefresh();
+  } finally {
+    button.disabled = false;
+  }
+}
+
+function setStatus(message) {
+  statusMessage = message || '';
+  const output = document.getElementById('automationHistoryStatus');
+  if (output) output.textContent = statusMessage;
+}
+
+function formatHistoryDate(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Date unavailable';
+  return new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  if (document.readyState === 'loading') window.addEventListener('DOMContentLoaded', boot, { once: true });
+  else boot();
+}

--- a/automation-history.js
+++ b/automation-history.js
@@ -1,0 +1,396 @@
+import { normaliseAutomationState } from './automation-state.js';
+
+export const AUTOMATION_HISTORY_RESULT = Object.freeze({
+  APPLIED: 'applied',
+  NEEDS_REVIEW: 'needs_review',
+  BLOCKED: 'blocked',
+  SKIPPED: 'skipped',
+  UNDONE: 'undone'
+});
+
+export const AUTOMATION_HISTORY_FILTER = Object.freeze({
+  ALL: 'all',
+  APPLIED: AUTOMATION_HISTORY_RESULT.APPLIED,
+  NEEDS_REVIEW: AUTOMATION_HISTORY_RESULT.NEEDS_REVIEW,
+  BLOCKED: AUTOMATION_HISTORY_RESULT.BLOCKED,
+  UNDONE: AUTOMATION_HISTORY_RESULT.UNDONE
+});
+
+const EXECUTION_ID_PATTERN = /^[0-9a-f]{64}$/;
+const SAFE_CODE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,119}$/;
+const FILTERS = new Set(Object.values(AUTOMATION_HISTORY_FILTER));
+const CATEGORY_FIELDS = ['budgetCategoryId', 'category', 'categorySource', 'automationRuleId'];
+
+export function recordAutomationHistoryOutcome(state, input = {}) {
+  const next = structuredClone(state || {});
+  next.automation = normaliseAutomationState(next.automation);
+
+  const proposal = input.proposal || null;
+  const result = input.result || {};
+  const executionId = safeExecutionId(result.executionId || proposal?.executionId);
+  const ruleIds = safeRuleIds(result.ruleIds || result.ruleId || proposal?.ruleId);
+  const sourceType = safeCode(result.sourceType || proposal?.source?.type, 'state');
+  const sourceId = safeSourceId(result.sourceId || proposal?.source?.id);
+  const actionType = safeCode(result.actionType || proposal?.action?.type, 'unknown_action');
+  const reasonCode = safeCode(result.reasonCode || proposal?.reasonCode, 'unknown_reason');
+  const outcome = historyOutcome(result.status);
+  if (result.status === 'already_applied' && executionId) {
+    const existingExecution = Object.values(next.automation.history)
+      .find((entry) => entry.executionId === executionId && ['applied', 'undone'].includes(entry.result));
+    if (existingExecution) return { state: next, changed: false, entry: existingExecution };
+  }
+  const historyId = stableHistoryId({ executionId, ruleIds, sourceType, sourceId, actionType, reasonCode, outcome });
+
+  if (next.automation.history[historyId]) return { state: next, changed: false, entry: next.automation.history[historyId] };
+
+  const timestamp = validDate(input.now).toISOString();
+  const undo = outcome === AUTOMATION_HISTORY_RESULT.APPLIED
+    ? buildUndoDescriptor(input.beforeState, next, proposal, executionId)
+    : null;
+
+  next.automation.history[historyId] = {
+    id: historyId,
+    executionId,
+    ruleIds,
+    sourceType,
+    sourceId,
+    actionType,
+    result: outcome,
+    timestamp,
+    reasonCode,
+    undoStatus: undo ? 'available' : 'unavailable',
+    undo,
+    undoneAt: null
+  };
+  next.automation = normaliseAutomationState(next.automation);
+  return { state: next, changed: true, entry: next.automation.history[historyId] || null };
+}
+
+export function automationHistoryEntries(state, filter = AUTOMATION_HISTORY_FILTER.ALL) {
+  const automation = normaliseAutomationState(state?.automation);
+  const wanted = FILTERS.has(filter) ? filter : AUTOMATION_HISTORY_FILTER.ALL;
+  return Object.values(automation.history)
+    .filter((entry) => wanted === AUTOMATION_HISTORY_FILTER.ALL || entry.result === wanted)
+    .sort((left, right) => String(right.timestamp || '').localeCompare(String(left.timestamp || '')) || right.id.localeCompare(left.id));
+}
+
+export function automationHistoryPresentation(state, entryOrId) {
+  const automation = normaliseAutomationState(state?.automation);
+  const entry = typeof entryOrId === 'string' ? automation.history[entryOrId] : entryOrId;
+  if (!entry) return null;
+
+  const ruleNames = entry.ruleIds
+    .map((id) => automation.rules.find((rule) => rule.id === id)?.name)
+    .filter(Boolean)
+    .slice(0, 3);
+  const ruleLabel = ruleNames.length ? ruleNames.join(' · ') : entry.ruleIds.length ? 'Previous local rule' : 'OneStep automation';
+  const sourceLabel = resolveSourceLabel(state, entry);
+  const statusLabel = ({
+    applied: 'Applied',
+    needs_review: 'Needs review',
+    blocked: 'Blocked',
+    skipped: 'Skipped',
+    undone: 'Undone'
+  })[entry.result] || 'Recorded';
+  const actionLabel = ({
+    assign_transaction_budget: 'Budget/category assignment',
+    add_local_tag: 'Local tag',
+    create_local_reminder: 'Local reminder'
+  })[entry.actionType] || 'Local automation action';
+  const outcomePhrase = ({
+    applied: 'was applied',
+    needs_review: 'needs review',
+    blocked: 'was blocked',
+    skipped: 'made no additional change',
+    undone: 'was undone'
+  })[entry.result] || 'was recorded';
+  const why = explanationFor(state, entry, ruleNames);
+  const undo = automationUndoAvailability(state, entry);
+
+  return {
+    id: entry.id,
+    statusLabel,
+    actionLabel,
+    summary: `${actionLabel} ${outcomePhrase}.`,
+    sourceLabel,
+    ruleLabel,
+    why,
+    timestamp: entry.timestamp,
+    undo
+  };
+}
+
+export function automationUndoAvailability(state, entryOrId, options = {}) {
+  const automation = normaliseAutomationState(state?.automation);
+  const entry = typeof entryOrId === 'string' ? automation.history[entryOrId] : entryOrId;
+  if (!entry) return unavailable('history_missing', 'This history item is no longer available.');
+  if (Number.isInteger(options.expectedRevision) && Number(state?.meta?.revision) !== options.expectedRevision) {
+    return unavailable('stale_revision', 'Your financial information changed. Review the latest state before undoing this action.');
+  }
+  if (entry.result === AUTOMATION_HISTORY_RESULT.UNDONE || entry.undoStatus === 'completed') {
+    return unavailable('already_undone', 'This automation action has already been undone.');
+  }
+  if (entry.undoStatus === 'expired') {
+    return unavailable('undo_expired', 'Undo is no longer available for this older history item.');
+  }
+  if (entry.undoStatus !== 'available' || !entry.undo) {
+    return unavailable('not_reversible', 'This automation action cannot be undone safely.');
+  }
+
+  if (entry.undo.kind === 'transaction_fields') {
+    const transaction = transactionById(state, entry.sourceId);
+    if (!transaction) return unavailable('source_missing', 'The payment no longer exists, so OneStep will not guess how to undo this.');
+    if (!sameValue(captureFields(transaction, entry.undo.fields), entry.undo.after)) {
+      return unavailable('newer_change', 'This payment changed after the automation ran. Undo is blocked to protect the newer choice.');
+    }
+    return available();
+  }
+
+  if (entry.undo.kind === 'transaction_tag') {
+    const transaction = transactionById(state, entry.sourceId);
+    if (!transaction) return unavailable('source_missing', 'The payment no longer exists, so OneStep will not guess how to undo this.');
+    if (!sameValue({ present: Object.hasOwn(transaction, 'automationTags'), tags: safeTags(transaction.automationTags) },
+      { present: entry.undo.afterPresent, tags: entry.undo.afterTags })) {
+      return unavailable('newer_change', 'The payment tags changed after the automation ran. Undo is blocked to protect the newer choice.');
+    }
+    return available();
+  }
+
+  if (entry.undo.kind === 'created_task') {
+    const task = (state?.tasks || []).find((item) => String(item?.id) === entry.undo.taskId);
+    if (!task) return unavailable('source_missing', 'The reminder no longer exists, so there is nothing safe to undo.');
+    if (!sameValue(captureTask(task), entry.undo.after)) {
+      return unavailable('newer_change', 'The reminder changed after the automation ran. Undo is blocked to protect the newer choice.');
+    }
+    return available();
+  }
+
+  return unavailable('not_reversible', 'This automation action cannot be undone safely.');
+}
+
+export function undoAutomationHistoryEntry(state, historyId, options = {}) {
+  const next = structuredClone(state || {});
+  next.automation = normaliseAutomationState(next.automation);
+  const entry = next.automation.history[String(historyId || '')];
+  const availability = automationUndoAvailability(next, entry, options);
+  if (!availability.available) {
+    return { state: next, status: 'blocked', reasonCode: availability.reasonCode, message: availability.message };
+  }
+
+  if (entry.undo.kind === 'transaction_fields') {
+    const transaction = transactionById(next, entry.sourceId);
+    restoreFields(transaction, entry.undo.before);
+  } else if (entry.undo.kind === 'transaction_tag') {
+    const transaction = transactionById(next, entry.sourceId);
+    const tags = (Array.isArray(transaction.automationTags) ? transaction.automationTags : [])
+      .filter((tag) => tag !== entry.undo.tag);
+    if (entry.undo.beforePresent) transaction.automationTags = tags;
+    else if (tags.length) transaction.automationTags = tags;
+    else delete transaction.automationTags;
+  } else if (entry.undo.kind === 'created_task') {
+    next.tasks = (Array.isArray(next.tasks) ? next.tasks : []).filter((task) => String(task?.id) !== entry.undo.taskId);
+  }
+
+  entry.result = AUTOMATION_HISTORY_RESULT.UNDONE;
+  entry.undoStatus = 'completed';
+  entry.undoneAt = validDate(options.now).toISOString();
+  next.automation = normaliseAutomationState(next.automation);
+  return {
+    state: next,
+    status: 'undone',
+    reasonCode: 'undo_applied',
+    message: 'The local automation change was undone without overwriting newer information.'
+  };
+}
+
+function buildUndoDescriptor(beforeState, afterState, proposal, executionId) {
+  if (!beforeState || !proposal || !executionId) return null;
+  const actionType = proposal.action?.type;
+  const sourceId = proposal.source?.id;
+
+  if (actionType === 'assign_transaction_budget') {
+    const before = transactionById(beforeState, sourceId);
+    const after = transactionById(afterState, sourceId);
+    if (!before || !after) return null;
+    return {
+      kind: 'transaction_fields',
+      fields: CATEGORY_FIELDS,
+      before: captureFields(before, CATEGORY_FIELDS),
+      after: captureFields(after, CATEGORY_FIELDS)
+    };
+  }
+
+  if (actionType === 'add_local_tag') {
+    const before = transactionById(beforeState, sourceId);
+    const after = transactionById(afterState, sourceId);
+    const tag = String(proposal.action?.payload?.tag || '').trim().slice(0, 80);
+    if (!before || !after || !tag) return null;
+    const beforeTags = Array.isArray(before.automationTags) ? before.automationTags : [];
+    const afterTags = Array.isArray(after.automationTags) ? after.automationTags : [];
+    if (beforeTags.includes(tag) || !afterTags.includes(tag)) return null;
+    return {
+      kind: 'transaction_tag',
+      tag,
+      beforePresent: Object.hasOwn(before, 'automationTags'),
+      afterPresent: Object.hasOwn(after, 'automationTags'),
+      afterTags: safeTags(after.automationTags)
+    };
+  }
+
+  if (actionType === 'create_local_reminder') {
+    const taskId = `automation_${executionId.slice(0, 32)}`;
+    const existedBefore = (beforeState?.tasks || []).some((task) => String(task?.id) === taskId);
+    const after = (afterState?.tasks || []).find((task) => String(task?.id) === taskId);
+    if (existedBefore || !after || after.automationExecutionId !== executionId || after.source !== 'automation_rule') return null;
+    return { kind: 'created_task', taskId, after: captureTask(after) };
+  }
+
+  return null;
+}
+
+function explanationFor(state, entry, ruleNames) {
+  const rule = entry.ruleIds.map((id) => normaliseAutomationState(state?.automation).rules.find((item) => item.id === id)).find(Boolean);
+  const ruleContext = ruleNames.length
+    ? `${ruleNames.join(' and ')} matched its saved local conditions.`
+    : entry.ruleIds.length ? 'The original local rule is no longer present, but this result remains in local history.' : '';
+
+  const reasons = {
+    applied: 'OneStep considered the action certain and inside the approved local automation boundary.',
+    manual_override: 'A manual choice already existed, so OneStep left it unchanged.',
+    rule_conflict: 'Two or more rules wanted incompatible results, so OneStep left the financial state unchanged for review.',
+    source_information_missing: 'The source information was incomplete, so OneStep did not make an automatic change.',
+    source_information_conflicting: 'The source information conflicted, so OneStep left the decision for review.',
+    review_required: 'The available information was not certain enough for an automatic change.',
+    financial_safety_required: 'Financial Safety needed an authoritative answer before an automatic financial action could continue.',
+    financial_safety_blocked: 'Financial Safety blocked the automatic action.',
+    stale_state_revision: 'The financial state changed before the action could run, so OneStep protected the newer state.',
+    automation_paused: 'Automations were paused, so no automatic change was made.',
+    recovery_mode_active: 'Data recovery protections were active, so automatic changes were blocked.',
+    recovery_status_unknown: 'OneStep could not confirm that stored data was safe to change automatically.',
+    already_applied: 'The same stable execution had already run, so OneStep did not apply it twice.',
+    compatible_duplicate_rule_action: 'Another rule requested the same compatible change, so OneStep avoided a duplicate execution.',
+    handler_missing: 'No approved local executor was available for this action.',
+    handler_failed: 'The local executor failed, so the original financial state was kept.'
+  };
+  const reason = reasons[entry.reasonCode] || (entry.result === 'undone'
+    ? 'You reversed this local automation action after OneStep verified that the automated change was still unchanged.'
+    : 'OneStep recorded this local automation outcome so it can be explained later.');
+  const savedExplanation = rule?.explanation ? ` ${rule.explanation}` : '';
+  return `${ruleContext}${ruleContext ? ' ' : ''}${reason}${savedExplanation}`.trim();
+}
+
+function resolveSourceLabel(state, entry) {
+  if (entry.sourceType === 'transaction') {
+    const transaction = transactionById(state, entry.sourceId);
+    const name = String(transaction?.userDescription || transaction?.description || transaction?.merchantName || transaction?.payee || '').trim();
+    return name ? `Payment · ${name.slice(0, 120)}` : 'Payment';
+  }
+  if (entry.sourceType === 'recurring_pattern') return 'Confirmed recurring item';
+  if (entry.sourceType === 'state') return 'Local financial state';
+  return entry.sourceType.replace(/[_-]+/g, ' ').replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function historyOutcome(status) {
+  if (status === 'applied') return AUTOMATION_HISTORY_RESULT.APPLIED;
+  if (status === 'review_required') return AUTOMATION_HISTORY_RESULT.NEEDS_REVIEW;
+  if (status === 'blocked' || status === 'failed') return AUTOMATION_HISTORY_RESULT.BLOCKED;
+  return AUTOMATION_HISTORY_RESULT.SKIPPED;
+}
+
+function stableHistoryId(parts) {
+  if (parts.executionId) return `history_${parts.executionId}_${parts.outcome}_${parts.reasonCode}`.slice(0, 200);
+  const identity = [parts.ruleIds.join(','), parts.sourceType, parts.sourceId, parts.actionType, parts.reasonCode, parts.outcome].join('|');
+  return `history_${stableId(identity)}`;
+}
+
+function captureFields(value, fields) {
+  return Object.fromEntries(fields.map((field) => [field, {
+    present: Object.hasOwn(value, field),
+    value: safeScalar(value[field])
+  }]));
+}
+
+function restoreFields(target, snapshot) {
+  for (const [field, record] of Object.entries(snapshot || {})) {
+    if (record?.present) target[field] = structuredClone(record.value);
+    else delete target[field];
+  }
+}
+
+function safeTags(value) {
+  return Array.isArray(value) ? value.map((tag) => String(tag).slice(0, 80)).slice(0, 20) : [];
+}
+
+function captureTask(task) {
+  return {
+    id: String(task?.id || ''),
+    title: String(task?.title || '').slice(0, 160),
+    detail: String(task?.detail || '').slice(0, 240),
+    priority: String(task?.priority || '').slice(0, 40),
+    actionView: String(task?.actionView || '').slice(0, 80),
+    source: String(task?.source || '').slice(0, 80),
+    automationRuleId: String(task?.automationRuleId || '').slice(0, 120),
+    automationExecutionId: String(task?.automationExecutionId || '').slice(0, 64),
+    createdAt: String(task?.createdAt || '').slice(0, 40),
+    updatedAt: String(task?.updatedAt || '').slice(0, 40),
+    completedAt: task?.completedAt || null
+  };
+}
+
+function sameValue(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function stableId(value) {
+  let hash = 14695981039346656037n;
+  const prime = 1099511628211n;
+  const mask = 0xffffffffffffffffn;
+  for (const character of String(value)) {
+    hash ^= BigInt(character.codePointAt(0));
+    hash = (hash * prime) & mask;
+  }
+  return `${hash.toString(16).padStart(16, '0')}_${String(value).length.toString(36)}`;
+}
+
+function transactionById(state, id) {
+  return (state?.transactions || []).find((transaction) => String(transaction?.id) === String(id)) || null;
+}
+
+function safeExecutionId(value) {
+  const id = String(value || '');
+  return EXECUTION_ID_PATTERN.test(id) ? id : null;
+}
+
+function safeRuleIds(value) {
+  const rows = Array.isArray(value) ? value : String(value || '').split(',');
+  return [...new Set(rows.map((entry) => safeCode(entry, '')).filter(Boolean))].sort().slice(0, 8);
+}
+
+function safeSourceId(value) {
+  return String(value || 'global').slice(0, 240);
+}
+
+function safeCode(value, fallback) {
+  const code = String(value || '').toLowerCase();
+  return SAFE_CODE_PATTERN.test(code) ? code : fallback;
+}
+
+function safeScalar(value) {
+  if (value === null || value === undefined) return null;
+  if (['string', 'boolean'].includes(typeof value)) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return null;
+}
+
+function validDate(value) {
+  const date = value === undefined ? new Date() : value instanceof Date ? new Date(value) : new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+function available() {
+  return { available: true, reasonCode: null, message: 'Undo is available because the automated change is still unchanged.' };
+}
+
+function unavailable(reasonCode, message) {
+  return { available: false, reasonCode, message };
+}

--- a/automation-state.js
+++ b/automation-state.js
@@ -16,7 +16,7 @@ const MAX_REVIEW_SIGNALS = 500;
 export const MAX_AUTOMATION_HISTORY_ENTRIES = 1000;
 export const MAX_ACTIVE_AUTOMATION_UNDO_ENTRIES = 250;
 
-export const AUTOMATION_STATE_VERSION = 2;
+export const AUTOMATION_STATE_VERSION = 1;
 
 export function normaliseAutomationState(value) {
   const automation = isPlainObject(value) ? value : {};

--- a/automation-state.js
+++ b/automation-state.js
@@ -2,15 +2,21 @@ import { normaliseAutomationRuleCollection } from './automation-rule-model.js';
 import { normaliseFinancialReminderCollection } from './financial-reminders.js';
 
 const EXECUTION_ID_PATTERN = /^[0-9a-f]{64}$/;
+const HISTORY_ID_PATTERN = /^history_[a-z0-9][a-z0-9._-]{0,198}$/;
 const REVIEW_SIGNAL_ID_PATTERN = /^review_signal_[a-z0-9_]{1,80}$/;
 const SAFE_CODE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,119}$/;
 const REVIEW_SIGNAL_KINDS = new Set(['rule_conflict', 'engine_review']);
 const REVIEW_PRIORITIES = new Set(['high', 'normal', 'low']);
+const HISTORY_RESULTS = new Set(['applied', 'needs_review', 'blocked', 'skipped', 'undone']);
+const UNDO_STATUSES = new Set(['available', 'unavailable', 'expired', 'completed']);
+const UNDO_KINDS = new Set(['transaction_fields', 'transaction_tag', 'created_task']);
 const MAX_EXECUTIONS = 5000;
 const MAX_MANUAL_OVERRIDES = 1000;
 const MAX_REVIEW_SIGNALS = 500;
+export const MAX_AUTOMATION_HISTORY_ENTRIES = 1000;
+export const MAX_ACTIVE_AUTOMATION_UNDO_ENTRIES = 250;
 
-export const AUTOMATION_STATE_VERSION = 1;
+export const AUTOMATION_STATE_VERSION = 2;
 
 export function normaliseAutomationState(value) {
   const automation = isPlainObject(value) ? value : {};
@@ -21,7 +27,8 @@ export function normaliseAutomationState(value) {
     reminders: normaliseFinancialReminderCollection(automation.reminders),
     executions: normaliseExecutions(automation.executions),
     manualOverrides: normaliseManualOverrides(automation.manualOverrides),
-    reviewSignals: normaliseReviewSignals(automation.reviewSignals)
+    reviewSignals: normaliseReviewSignals(automation.reviewSignals),
+    history: normaliseHistory(automation.history)
   };
 }
 
@@ -94,6 +101,119 @@ function normaliseReviewSignal(id, value) {
   };
 }
 
+function normaliseHistory(value) {
+  if (!isPlainObject(value)) return {};
+  const ordered = Object.entries(value)
+    .map(([id, record]) => [id, normaliseHistoryEntry(id, record)])
+    .filter(([, record]) => Boolean(record))
+    .sort((left, right) => compareTimestampThenId(left, right, 'timestamp'));
+
+  const available = ordered.filter(([, record]) => record.undoStatus === 'available' && record.undo);
+  const protectedRows = available.slice(-MAX_ACTIVE_AUTOMATION_UNDO_ENTRIES);
+  const protectedIds = new Set(protectedRows.map(([id]) => id));
+
+  const safeRows = ordered.map(([id, record]) => {
+    if (record.undoStatus === 'available' && record.undo && !protectedIds.has(id)) {
+      return [id, { ...record, undoStatus: 'expired', undo: null }];
+    }
+    return [id, record];
+  });
+  const protectedSafeRows = safeRows.filter(([id]) => protectedIds.has(id));
+  const otherRows = safeRows
+    .filter(([id]) => !protectedIds.has(id))
+    .slice(-(MAX_AUTOMATION_HISTORY_ENTRIES - protectedSafeRows.length));
+  return Object.fromEntries([...otherRows, ...protectedSafeRows]
+    .sort((left, right) => compareTimestampThenId(left, right, 'timestamp')));
+}
+
+function normaliseHistoryEntry(id, value) {
+  if (!HISTORY_ID_PATTERN.test(id) || !isPlainObject(value)) return null;
+  const result = HISTORY_RESULTS.has(value.result) ? value.result : '';
+  if (!result) return null;
+  const executionId = EXECUTION_ID_PATTERN.test(String(value.executionId || '')) ? String(value.executionId) : null;
+  const ruleIds = [...new Set((Array.isArray(value.ruleIds) ? value.ruleIds : [])
+    .map((entry) => safeCode(entry, '')).filter(Boolean))].sort().slice(0, 8);
+  const sourceType = safeCode(value.sourceType, 'state');
+  const sourceId = String(value.sourceId || 'global').slice(0, 240);
+  const actionType = safeCode(value.actionType, 'unknown_action');
+  const reasonCode = safeCode(value.reasonCode, 'unknown_reason');
+  const undo = normaliseUndo(value.undo);
+  let undoStatus = UNDO_STATUSES.has(value.undoStatus) ? value.undoStatus : undo ? 'available' : 'unavailable';
+  if (!undo && undoStatus === 'available') undoStatus = 'unavailable';
+  if (result === 'undone') undoStatus = 'completed';
+  return {
+    id,
+    executionId,
+    ruleIds,
+    sourceType,
+    sourceId,
+    actionType,
+    result,
+    timestamp: validIsoDate(value.timestamp) ? value.timestamp : null,
+    reasonCode,
+    undoStatus,
+    undo: undoStatus === 'available' ? undo : null,
+    undoneAt: validIsoDate(value.undoneAt) ? value.undoneAt : null
+  };
+}
+
+function normaliseUndo(value) {
+  if (!isPlainObject(value) || !UNDO_KINDS.has(value.kind)) return null;
+  if (value.kind === 'transaction_fields') {
+    const fields = [...new Set((Array.isArray(value.fields) ? value.fields : [])
+      .map((field) => safeFieldName(field)).filter(Boolean))].slice(0, 12);
+    if (!fields.length) return null;
+    const before = normaliseFieldSnapshot(value.before, fields);
+    const after = normaliseFieldSnapshot(value.after, fields);
+    if (!before || !after) return null;
+    return { kind: value.kind, fields, before, after };
+  }
+  if (value.kind === 'transaction_tag') {
+    const tag = String(value.tag || '').trim().slice(0, 80);
+    if (!tag || typeof value.beforePresent !== 'boolean' || typeof value.afterPresent !== 'boolean') return null;
+    const afterTags = normaliseTags(value.afterTags);
+    if (!afterTags.includes(tag)) return null;
+    return { kind: value.kind, tag, beforePresent: value.beforePresent, afterPresent: value.afterPresent, afterTags };
+  }
+  const taskId = String(value.taskId || '').slice(0, 120);
+  if (!/^automation_[0-9a-f]{32}$/.test(taskId)) return null;
+  const after = normaliseTaskSnapshot(value.after);
+  if (!after || after.id !== taskId) return null;
+  return { kind: value.kind, taskId, after };
+}
+
+function normaliseFieldSnapshot(value, fields) {
+  if (!isPlainObject(value)) return null;
+  const output = {};
+  for (const field of fields) {
+    const snapshot = value[field];
+    if (!isPlainObject(snapshot) || typeof snapshot.present !== 'boolean') return null;
+    output[field] = { present: snapshot.present, value: normaliseScalar(snapshot.value) };
+  }
+  return output;
+}
+
+function normaliseTags(value) {
+  return Array.isArray(value) ? value.map((tag) => String(tag).slice(0, 80)).slice(0, 20) : [];
+}
+
+function normaliseTaskSnapshot(value) {
+  if (!isPlainObject(value)) return null;
+  return {
+    id: String(value.id || '').slice(0, 120),
+    title: String(value.title || '').slice(0, 160),
+    detail: String(value.detail || '').slice(0, 240),
+    priority: String(value.priority || '').slice(0, 40),
+    actionView: String(value.actionView || '').slice(0, 80),
+    source: String(value.source || '').slice(0, 80),
+    automationRuleId: String(value.automationRuleId || '').slice(0, 120),
+    automationExecutionId: String(value.automationExecutionId || '').slice(0, 64),
+    createdAt: String(value.createdAt || '').slice(0, 40),
+    updatedAt: String(value.updatedAt || '').slice(0, 40),
+    completedAt: value.completedAt === null || typeof value.completedAt === 'string' ? value.completedAt : null
+  };
+}
+
 function validExecutionRecord(value) {
   return isPlainObject(value) && value.status === 'applied';
 }
@@ -102,9 +222,21 @@ function compareTimestampThenId(left, right, field = 'appliedAt') {
   return String(left[1][field] || '').localeCompare(String(right[1][field] || '')) || left[0].localeCompare(right[0]);
 }
 
+function safeFieldName(value) {
+  const field = String(value || '');
+  return /^[A-Za-z][A-Za-z0-9]{0,79}$/.test(field) ? field : '';
+}
+
 function safeCode(value, fallback) {
   const code = String(value || '').toLowerCase();
   return SAFE_CODE_PATTERN.test(code) ? code : fallback;
+}
+
+function normaliseScalar(value) {
+  if (value === null || value === undefined) return null;
+  if (['string', 'boolean'].includes(typeof value)) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return null;
 }
 
 function validIsoDate(value) {

--- a/main-entry.js
+++ b/main-entry.js
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron';
-import { previewStoredAutomationRules, runStoredAutomationRules } from './automation-rules.js';
+import { runStoredAutomationRulesWithHistory } from './automation-history-runner.js';
+import { previewStoredAutomationRules } from './automation-rules.js';
 import './main-process.js';
 
 const MAX_AUTOMATION_STATE_BYTES = 25_000_000;
@@ -14,7 +15,7 @@ ipcMain.handle('automation:preview', (_event, state, options = {}) => {
 
 ipcMain.handle('automation:run', async (_event, state, options = {}) => {
   validateStatePayload(state);
-  return runStoredAutomationRules(state, {
+  return runStoredAutomationRulesWithHistory(state, {
     now: safeNow(options?.now),
     recoveryMode: 'normal'
   });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "asar": true,
     "files": [
       "automation-engine.js",
+      "automation-history.js",
+      "automation-history-runner.js",
+      "automation-history-ui.js",
       "automation-review-integration.js",
       "automation-rule-model.js",
       "automation-rules.js",

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -54,10 +54,25 @@ function loadFinancialPresentationModules() {
   }
 }
 
+function loadAutomationHistoryModule() {
+  const source = 'automation-history-ui.js';
+  if (document.querySelector(`script[data-automation-history="${source}"]`)) return;
+  const script = document.createElement('script');
+  script.type = 'module';
+  script.src = source;
+  script.dataset.automationHistory = source;
+  document.head.append(script);
+}
+
+function loadLocalPresentationModules() {
+  loadFinancialPresentationModules();
+  loadAutomationHistoryModule();
+}
+
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   if (document.readyState === 'loading') {
-    window.addEventListener('DOMContentLoaded', loadFinancialPresentationModules, { once: true });
+    window.addEventListener('DOMContentLoaded', loadLocalPresentationModules, { once: true });
   } else {
-    loadFinancialPresentationModules();
+    loadLocalPresentationModules();
   }
 }

--- a/tests/automation-history.test.js
+++ b/tests/automation-history.test.js
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import test from 'node:test';
+import {
+  AUTOMATION_HISTORY_FILTER, automationHistoryEntries, automationHistoryPresentation,
+  automationUndoAvailability, recordAutomationHistoryOutcome, undoAutomationHistoryEntry
+} from '../automation-history.js';
+import { runStoredAutomationRulesWithHistory } from '../automation-history-runner.js';
+import { MAX_AUTOMATION_HISTORY_ENTRIES, normaliseAutomationState } from '../automation-state.js';
+
+const NOW = '2026-08-11T20:00:00.000Z';
+
+async function applied() {
+  return runStoredAutomationRulesWithHistory(baseState(), { now: NOW, recoveryMode: 'normal' });
+}
+
+test('successful automation records exactly one history entry and repeat evaluation does not duplicate it', async () => {
+  const first = await applied();
+  assert.equal(first.changed, true);
+  assert.equal(first.historyChanged, true);
+  assert.equal(first.state.transactions[0].category, 'Food');
+  assert.equal(automationHistoryEntries(first.state).length, 1);
+  const second = await runStoredAutomationRulesWithHistory(first.state, { now: '2026-08-11T20:01:00.000Z', recoveryMode: 'normal' });
+  assert.equal(second.historyChanged, false);
+  assert.equal(automationHistoryEntries(second.state).length, 1);
+});
+
+test('blocked and review-required outcomes are explainable without copied financial content', () => {
+  let next = recordAutomationHistoryOutcome(baseState(), { result: engineResult('blocked', 'manual_override', 'a'), now: NOW }).state;
+  next = recordAutomationHistoryOutcome(next, { result: { ...engineResult('review_required', 'rule_conflict'), executionId: null }, now: NOW }).state;
+  const rows = automationHistoryEntries(next);
+  assert.match(automationHistoryPresentation(next, rows.find((row) => row.result === 'blocked')).why, /manual choice/i);
+  assert.match(automationHistoryPresentation(next, rows.find((row) => row.result === 'needs_review')).why, /rules/i);
+  const stored = JSON.stringify(next.automation.history);
+  assert.doesNotMatch(stored, /Corner Shop|12\.34/);
+});
+
+test('unchanged category assignment can be undone', async () => {
+  const first = await applied();
+  const entry = automationHistoryEntries(first.state, AUTOMATION_HISTORY_FILTER.APPLIED)[0];
+  const result = undoAutomationHistoryEntry(first.state, entry.id, { expectedRevision: first.state.meta.revision, now: NOW });
+  assert.equal(result.status, 'undone');
+  assert.equal(result.state.transactions[0].category, undefined);
+  assert.equal(result.state.transactions[0].budgetCategoryId, undefined);
+  assert.equal(automationHistoryEntries(result.state, AUTOMATION_HISTORY_FILTER.UNDONE).length, 1);
+});
+
+test('newer manual edit blocks undo and remains authoritative', async () => {
+  const first = await applied();
+  const entry = automationHistoryEntries(first.state, AUTOMATION_HISTORY_FILTER.APPLIED)[0];
+  const edited = structuredClone(first.state);
+  Object.assign(edited.transactions[0], { budgetCategoryId: 'budget_travel', category: 'Travel', categorySource: 'manual' });
+  delete edited.transactions[0].automationRuleId;
+  const availability = automationUndoAvailability(edited, entry, { expectedRevision: edited.meta.revision });
+  assert.equal(availability.reasonCode, 'newer_change');
+  const result = undoAutomationHistoryEntry(edited, entry.id, { expectedRevision: edited.meta.revision, now: NOW });
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.state.transactions[0].category, 'Travel');
+});
+
+test('undo cannot run twice and the original execution remains deduplicated', async () => {
+  const first = await applied();
+  const entry = automationHistoryEntries(first.state, AUTOMATION_HISTORY_FILTER.APPLIED)[0];
+  const undone = undoAutomationHistoryEntry(first.state, entry.id, { expectedRevision: first.state.meta.revision, now: NOW });
+  const repeat = undoAutomationHistoryEntry(undone.state, entry.id, { expectedRevision: undone.state.meta.revision, now: NOW });
+  assert.equal(repeat.reasonCode, 'already_undone');
+  const rerun = await runStoredAutomationRulesWithHistory(undone.state, { now: '2026-08-11T21:00:00.000Z', recoveryMode: 'normal' });
+  assert.equal(rerun.state.transactions[0].category, undefined);
+  assert.equal(automationHistoryEntries(rerun.state, AUTOMATION_HISTORY_FILTER.UNDONE).length, 1);
+});
+
+test('undo/history survives serialisation used by restart and backup restore', async () => {
+  const first = await applied();
+  const entry = automationHistoryEntries(first.state, AUTOMATION_HISTORY_FILTER.APPLIED)[0];
+  const undone = undoAutomationHistoryEntry(first.state, entry.id, { expectedRevision: first.state.meta.revision, now: NOW });
+  const restored = JSON.parse(JSON.stringify(undone.state));
+  restored.automation = normaliseAutomationState(restored.automation);
+  assert.equal(automationHistoryEntries(restored, AUTOMATION_HISTORY_FILTER.UNDONE)[0].undoStatus, 'completed');
+  assert.equal(restored.automation.executions[entry.executionId].status, 'applied');
+});
+
+test('stale state revision blocks undo before mutation', async () => {
+  const first = await applied();
+  const entry = automationHistoryEntries(first.state, AUTOMATION_HISTORY_FILTER.APPLIED)[0];
+  const result = undoAutomationHistoryEntry(first.state, entry.id, { expectedRevision: first.state.meta.revision + 1, now: NOW });
+  assert.equal(result.reasonCode, 'stale_revision');
+  assert.equal(result.state.transactions[0].category, 'Food');
+});
+
+test('history is bounded without dropping recent active undo state', () => {
+  const history = {};
+  for (let i = 0; i < MAX_AUTOMATION_HISTORY_ENTRIES + 30; i += 1) history[`history_${i.toString(16).padStart(64, '0')}`] = historyRow(i);
+  const activeId = `history_${'f'.repeat(64)}`;
+  history[activeId] = {
+    ...historyRow(1), id: activeId, executionId: 'e'.repeat(64), sourceType: 'transaction', sourceId: 'tx_1',
+    actionType: 'assign_transaction_budget', result: 'applied', timestamp: '2026-08-11T22:00:00.000Z', reasonCode: 'applied',
+    undoStatus: 'available', undo: { kind: 'transaction_fields', fields: ['category'], before: { category: { present: false, value: null } }, after: { category: { present: true, value: 'Food' } } }
+  };
+  const normalised = normaliseAutomationState({ history });
+  assert.ok(Object.keys(normalised.history).length <= MAX_AUTOMATION_HISTORY_ENTRIES);
+  assert.equal(normalised.history[activeId].undoStatus, 'available');
+});
+
+test('invalid history is rejected independently', () => {
+  const normalised = normaliseAutomationState({ enabled: true, history: { bad: { result: 'applied' }, [`history_${'a'.repeat(64)}`]: { result: 'unknown' } } });
+  assert.equal(normalised.enabled, true);
+  assert.deepEqual(normalised.history, {});
+});
+
+test('history UI exposes filters, Why and Undo locally without network or telemetry dependencies', async () => {
+  const [preload, ui, core, runner] = await Promise.all(['preload-bridge.cjs', 'automation-history-ui.js', 'automation-history.js', 'automation-history-runner.js']
+    .map((file) => fs.readFile(new URL(`../${file}`, import.meta.url), 'utf8')));
+  assert.match(preload, /automation-history-ui\.js/);
+  for (const label of ['Applied', 'Needs review', 'Blocked', 'Undone', 'Why?', 'Undo']) assert.ok(ui.includes(label));
+  assert.doesNotMatch(`${ui}\n${core}\n${runner}`, /\bfetch\s*\(|telemetry|analytics|node:(?:http|https|net|tls|dns)/i);
+});
+
+function engineResult(status, reasonCode, seed = 'b') {
+  return { status, reasonCode, executionId: seed.repeat(64), ruleId: 'rule_food', sourceType: 'transaction', sourceId: 'tx_1', actionType: 'assign_transaction_budget' };
+}
+
+function historyRow(index) {
+  const id = `history_${index.toString(16).padStart(64, '0')}`;
+  return { id, executionId: null, ruleIds: [], sourceType: 'state', sourceId: `source_${index}`, actionType: 'local_action', result: 'blocked', timestamp: new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(), reasonCode: 'review_required', undoStatus: 'unavailable', undo: null, undoneAt: null };
+}
+
+function baseState() {
+  return {
+    meta: { revision: 7, createdAt: NOW, updatedAt: NOW },
+    automation: { enabled: true, rules: [{ id: 'rule_food', name: 'Food purchases', enabled: true, trigger: 'transaction_change', conditions: [{ id: 'merchant_match', field: 'merchant', operator: 'equals', value: 'Corner Shop' }], action: { type: 'assign_budget', value: 'budget_food' }, explanation: 'Categorise this known local merchant as Food.', createdAt: NOW, updatedAt: NOW }], executions: {}, manualOverrides: {}, reviewSignals: {}, history: {} },
+    transactions: [{ id: 'tx_1', date: '2026-08-11', description: 'Corner Shop', outgoing: 12.34, incoming: 0 }],
+    budgets: [{ id: 'budget_food', category: 'Food', monthlyAmount: 300 }, { id: 'budget_travel', category: 'Travel', monthlyAmount: 100 }],
+    tasks: []
+  };
+}

--- a/tests/automation-persistence.test.js
+++ b/tests/automation-persistence.test.js
@@ -22,7 +22,7 @@ test('legacy state migrates automation metadata safely and backup/restore preser
 
   let current = (await store.loadState()).state;
   assert.equal(current.schemaVersion, 10);
-  assert.deepEqual(current.automation, { version: 2, enabled: true, rules: [], reminders: [], executions: {}, manualOverrides: {}, reviewSignals: {}, history: {} });
+  assert.deepEqual(current.automation, { version: 1, enabled: true, rules: [], reminders: [], executions: {}, manualOverrides: {}, reviewSignals: {}, history: {} });
 
   current = createUserFinancialReminder(current, {
     title: 'Fictional annual renewal', dueDate: '2026-09-01', daysBefore: 7

--- a/tests/automation-persistence.test.js
+++ b/tests/automation-persistence.test.js
@@ -22,7 +22,7 @@ test('legacy state migrates automation metadata safely and backup/restore preser
 
   let current = (await store.loadState()).state;
   assert.equal(current.schemaVersion, 10);
-  assert.deepEqual(current.automation, { version: 1, enabled: true, rules: [], reminders: [], executions: {}, manualOverrides: {}, reviewSignals: {} });
+  assert.deepEqual(current.automation, { version: 2, enabled: true, rules: [], reminders: [], executions: {}, manualOverrides: {}, reviewSignals: {}, history: {} });
 
   current = createUserFinancialReminder(current, {
     title: 'Fictional annual renewal', dueDate: '2026-09-01', daysBefore: 7
@@ -61,6 +61,7 @@ test('legacy state migrates automation metadata safely and backup/restore preser
   current = (await restarted.loadState()).state;
   assert.equal(current.automation.enabled, false);
   assert.equal(current.automation.executions[executionId].status, 'applied');
+  assert.deepEqual(current.automation.history, {});
   assert.equal(current.automation.reminders[0].title, 'Fictional annual renewal');
   assert.equal(current.automation.reminders[0].dueDate, '2026-09-01');
   assert.equal(Object.keys(current.automation.reviewSignals).length, 1);
@@ -72,6 +73,7 @@ test('legacy state migrates automation metadata safely and backup/restore preser
   changed.automation.executions = {};
   changed.automation.reminders = [];
   changed.automation.reviewSignals = {};
+  changed.automation.history = {};
   changed.reviewItems = [];
   await restarted.saveState(changed);
 
@@ -79,6 +81,7 @@ test('legacy state migrates automation metadata safely and backup/restore preser
   assert.equal(restored.status, 'restored');
   assert.equal(restored.state.automation.enabled, false);
   assert.equal(restored.state.automation.executions[executionId].status, 'applied');
+  assert.deepEqual(restored.state.automation.history, {});
   assert.equal(restored.state.automation.reminders[0].title, 'Fictional annual renewal');
   assert.equal(restored.state.automation.reminders[0].daysBefore, 7);
   assert.equal(Object.keys(restored.state.automation.reviewSignals).length, 1);


### PR DESCRIPTION
## Purpose
Implement #78 so meaningful local automation outcomes are auditable, understandable and safely reversible where OneStep can prove an undo will not overwrite newer information.

This clean draft supersedes #136, which is preserved rather than history-rewritten after CI exposed the repository's commit-message convention.

## Work completed
- Added bounded local automation history for applied, skipped, blocked and review-required outcomes.
- Added plain-language `Why?` explanations using current local source/rule context at render time.
- Added safe undo for automated budget/category assignment, local tags and automation-created reminders when the current state still exactly matches the automated change.
- Kept stable execution records applied after undo so the same automation execution cannot immediately reapply itself.
- Added revision/newer-change/source-missing protection and idempotent repeated-undo blocking.
- Added a Settings history panel with All / Applied / Needs review / Blocked / Undone filters.
- Added bounded history normalisation and packaging entries.
- Kept history as an additive field in the existing automation-state v1 format so strict recovery validation remains compatible.
- Updated persistence expectations and added focused automated coverage using fictional data only.

## Files changed
- `automation-history.js`
- `automation-history-runner.js`
- `automation-history-ui.js`
- `automation-state.js`
- `main-entry.js`
- `preload-bridge.cjs`
- `package.json`
- `tests/automation-history.test.js`
- `tests/automation-persistence.test.js`

## User-facing changes
- Settings exposes **What OneStep changed** automation history.
- Each item shows a concise outcome, date/time, source and rule where available.
- `Why?` explains the decision in plain language.
- `Undo` appears only when the recorded local mutation is still safely reversible.
- If the underlying payment/reminder changed later, Undo is blocked rather than overwriting the newer choice.

## Technical changes
- Automation execution remains authoritative through the existing #71/#72 engine and rule handlers; #78 adds history around that existing mutation path rather than creating a second mutation system.
- History stores internal source references and minimal structured undo snapshots instead of copied full transaction/document contents.
- Automation history is additive within automation-state version 1, preserving the existing strict storage/recovery validator while normalisation adds or repairs the bounded history collection.
- History is capped at 1,000 entries; only the most recent bounded active undo set is retained as reversible and older reversible descriptors expire conservatively.
- Undo keeps the original stable execution record in `applied` state; execution identity excludes mutable state revision, preserving engine deduplication after undo/save.
- Renderer history code is local/browser-safe and introduces no new network, telemetry or analytics dependency.

## Testing and verification
- **Passed — JavaScript syntax:** new/modified automation history, state, runner, UI, main-entry, preload and focused test files.
- **Passed — focused safety checks:** category undo, repeated undo blocking, newer manual change blocking, stale-revision blocking, bounded retention and privacy-safe stored history.
- **Passed — package JSON parse:** build manifest remains valid and includes the new modules.
- **Passed — Linux CI:** Git/PR conventions, `npm ci`, full `npm test`, `npm run check` including privacy checks, and `npm run lint`.
- **Passed — Windows CI:** `npm ci`, full `npm test`, `npm run check` including privacy checks, `npm run lint`, built Pages runtime smoke, Electron desktop startup smoke, and Windows packaging smoke.
- **Skipped by workflow — release-windows:** expected for a pull-request CI run; this is not a release publication workflow.
- **Unavailable as manual local verification:** the execution sandbox could not resolve `github.com`, so dependency-backed manual Electron `Why?`/Undo interaction was not presented as completed manual testing.

## Data and migration impact
- Additive automation-state field only; no destructive schema rewrite and no automation-state version bump required.
- Existing finance data is preserved.
- History is included in normal local state backup/restore because it lives inside the existing `automation` state object.
- Invalid history rows are normalised/rejected independently rather than making wider financial state unrecoverable.
- No cloud storage, telemetry, remote crash reporting or new network service added.

## Known limitations
- Undo is deliberately conservative: it is unavailable once a newer incompatible/manual edit exists or the source record has disappeared.
- Historical entries whose reversible descriptor ages outside the bounded active undo window remain visible but no longer expose Undo.
- Manual Electron `Why?`/Undo interaction remains unverified in this sandbox; automated Windows Electron startup/package checks passed.

## Excluded work
- General-purpose application audit logging.
- Source-control-style time travel.
- Deleted document restoration.
- External money movement or reversal.
- AI Companion work.

## Branch details
- **Branch:** `feature/automation-history-safe-undo`
- **Commit SHA:** `941a35bea7689ed407dc3a98a7521e0037ae1947`
- **Pull request:** #137
- **Target branch:** `main`

## Confirmations
- No changes were committed or pushed directly to `main`.
- This PR has **not** been merged by this workflow.
- No personal financial data, imported documents, credentials, secrets or sensitive logs were committed.
- Only files relevant to #78 and its persistence expectation were changed.

Closes #78