### PR TITLE
[v2.2.0][Feature] Add automation Test Rule and dry-run preview

### DIFF
--- a/automation-rule-model.js
+++ b/automation-rule-model.js
@@ -25,6 +25,11 @@ export const AUTOMATION_RULE_ACTION = Object.freeze({
   CREATE_REMINDER: 'create_reminder'
 });
 
+export const AUTOMATION_RULE_ACTIVATION = Object.freeze({
+  LEGACY_EXISTING: 'legacy_existing',
+  FUTURE_ONLY: 'future_only'
+});
+
 const TRIGGERS = new Set(Object.values(AUTOMATION_RULE_TRIGGER));
 const CONDITIONS = new Set(Object.values(AUTOMATION_RULE_CONDITION));
 const ACTIONS = new Set(Object.values(AUTOMATION_RULE_ACTION));
@@ -67,6 +72,10 @@ export function validateAutomationRule(input) {
   const explanation = safeText(rule.explanation, 240) || explainRule({ trigger, conditions, action });
   const createdAt = validIso(rule.createdAt) ? rule.createdAt : null;
   const updatedAt = validIso(rule.updatedAt) ? rule.updatedAt : createdAt;
+  const activatedAt = validIso(rule.activatedAt) ? rule.activatedAt : null;
+  const activationMode = rule.activationMode === AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY || activatedAt
+    ? AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY
+    : AUTOMATION_RULE_ACTIVATION.LEGACY_EXISTING;
   const enabled = rule.enabled !== false;
 
   return {
@@ -80,6 +89,8 @@ export function validateAutomationRule(input) {
       conditions,
       action,
       explanation,
+      activationMode,
+      activatedAt,
       createdAt,
       updatedAt
     }
@@ -125,8 +136,13 @@ export function setAutomationRuleEnabled(state, ruleId, enabled, now = new Date(
   next.automation = normaliseAutomationRuleState(next.automation);
   const rule = next.automation.rules.find((item) => item.id === safeId(ruleId));
   if (!rule) throw new Error('That automation rule is no longer available.');
+  const timestamp = validDate(now).toISOString();
   rule.enabled = Boolean(enabled);
-  rule.updatedAt = validDate(now).toISOString();
+  rule.updatedAt = timestamp;
+  if (rule.enabled) {
+    rule.activationMode = AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY;
+    rule.activatedAt = timestamp;
+  }
   return next;
 }
 
@@ -138,6 +154,8 @@ export function duplicateAutomationRule(state, ruleId, newId, now = new Date()) 
     id: safeId(newId),
     name: `${source.name} copy`.slice(0, MAX_TEXT),
     enabled: false,
+    activationMode: AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY,
+    activatedAt: null,
     createdAt: null,
     updatedAt: null
   }, now);

--- a/automation-rules-core.js
+++ b/automation-rules-core.js
@@ -1,0 +1,336 @@
+import {
+  AUTOMATION_CERTAINTY, AUTOMATION_EXECUTION_STATUS, AUTOMATION_REASON, AUTOMATION_SAFETY_CLASS, AUTOMATION_TRIGGER,
+  createAutomationTrigger, evaluateAutomationRules
+} from './automation-engine.js';
+import {
+  AUTOMATION_RULE_ACTION, AUTOMATION_RULE_ACTIVATION, AUTOMATION_RULE_CONDITION, AUTOMATION_RULE_TRIGGER, validateAutomationRule
+} from './automation-rule-model.js';
+import { deriveRecurringPatterns, RECURRING_CONFIDENCE } from './recurring-finance.js';
+import { resolveTransactionBudgetAssignment } from './transaction-categorisation.js';
+
+const EXECUTION_TRIGGERS = new Set([AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE, AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY]);
+
+export function ruleActionHandlers() {
+  return {
+    assign_transaction_budget: ({ state, proposal }) => {
+      const transaction = transactionById(state, proposal.source.id);
+      const budget = (state.budgets || []).find((item) => String(item.id) === String(proposal.action.payload?.budgetId || ''));
+      if (!transaction || !budget) return { state };
+      if (transaction.categorySource === 'manual') return { state };
+      transaction.budgetCategoryId = budget.id;
+      transaction.category = budget.category;
+      transaction.categorySource = 'automation';
+      transaction.automationRuleId = proposal.ruleId;
+      return { state };
+    },
+    add_local_tag: ({ state, proposal }) => {
+      const transaction = transactionById(state, proposal.source.id);
+      if (!transaction) return { state };
+      const value = String(proposal.action.payload?.tag || '').trim().slice(0, 80);
+      if (!value) return { state };
+      transaction.automationTags = [...new Set([...(Array.isArray(transaction.automationTags) ? transaction.automationTags : []), value])].slice(-20);
+      return { state };
+    },
+    create_local_reminder: ({ state, proposal }) => {
+      const title = String(proposal.action.payload?.title || '').trim().slice(0, 160);
+      if (!title) return { state };
+      state.tasks = Array.isArray(state.tasks) ? state.tasks : [];
+      const id = `automation_${proposal.executionId.slice(0, 32)}`;
+      const existing = state.tasks.find((task) => String(task.id) === id);
+      const timestamp = new Date().toISOString();
+      const task = {
+        id,
+        title,
+        detail: String(proposal.action.payload?.detail || 'Created by a local automation rule.').slice(0, 240),
+        priority: 'normal',
+        actionView: 'today',
+        source: 'automation_rule',
+        automationRuleId: proposal.ruleId,
+        automationExecutionId: proposal.executionId,
+        createdAt: existing?.createdAt || timestamp,
+        updatedAt: timestamp,
+        completedAt: existing?.completedAt || null
+      };
+      if (existing) Object.assign(existing, task);
+      else state.tasks.push(task);
+      return { state };
+    }
+  };
+}
+
+export function resolveRuleProposalConflicts(proposals = []) {
+  const ordered = [...proposals].sort((left, right) => left.executionId.localeCompare(right.executionId));
+  const executable = [];
+  const duplicates = [];
+  const conflicts = [];
+  const categoryGroups = new Map();
+
+  for (const proposal of ordered) {
+    if (proposal.action.type !== 'assign_transaction_budget') {
+      executable.push(proposal);
+      continue;
+    }
+    const key = `${proposal.source.type}:${proposal.source.id}:budget-category`;
+    if (!categoryGroups.has(key)) categoryGroups.set(key, []);
+    categoryGroups.get(key).push(proposal);
+  }
+
+  for (const rows of categoryGroups.values()) {
+    const byValue = new Map();
+    for (const row of rows) {
+      const value = String(row.action.payload?.budgetId || '');
+      if (!byValue.has(value)) byValue.set(value, []);
+      byValue.get(value).push(row);
+    }
+    if (byValue.size > 1) {
+      conflicts.push({
+        source: rows[0].source,
+        ruleIds: rows.map((row) => row.ruleId).sort(),
+        actionType: 'assign_transaction_budget',
+        values: [...byValue.keys()].sort()
+      });
+      continue;
+    }
+    const compatible = [...rows].sort((left, right) => left.ruleId.localeCompare(right.ruleId));
+    executable.push(compatible[0]);
+    duplicates.push(...compatible.slice(1));
+  }
+
+  executable.sort((left, right) => left.executionId.localeCompare(right.executionId));
+  return { executable, duplicates, conflicts };
+}
+
+export function evaluateContexts(state, rules, contexts, includeDisabled, now, options = {}) {
+  const proposals = [];
+  const runtimeRules = rules
+    .filter((rule) => includeDisabled || rule.enabled)
+    .map((rule) => compileStoredRule(rule, now, options))
+    .filter(Boolean);
+  for (const context of contexts) {
+    const trigger = createAutomationTrigger(context.triggerType, {
+      sourceType: context.sourceType,
+      sourceId: context.sourceId,
+      occurredAt: validDate(now).toISOString()
+    });
+    proposals.push(...evaluateAutomationRules(state, trigger, runtimeRules));
+  }
+  return proposals;
+}
+
+function compileStoredRule(rule, now, options = {}) {
+  const checked = validateAutomationRule(rule);
+  if (!checked.valid || !EXECUTION_TRIGGERS.has(checked.rule.trigger)) return null;
+  const stored = checked.rule;
+  const scopeConditions = options.includeExisting === true ? [] : [{
+    id: 'activation_scope',
+    test: ({ state, trigger }) => ruleExecutionScopeMatches(stored, state, trigger)
+  }];
+  return {
+    id: stored.id,
+    triggers: [stored.trigger, AUTOMATION_TRIGGER.EXPLICIT_TEST],
+    conditions: [
+      ...scopeConditions,
+      ...stored.conditions.map((condition) => ({
+        id: condition.id,
+        test: ({ state, trigger }) => conditionMatches(condition, state, trigger, now)
+      }))
+    ],
+    propose: ({ state, trigger }) => proposalForRule(stored, state, trigger, now)
+  };
+}
+
+function proposalForRule(rule, state, trigger, now) {
+  const source = { type: trigger.sourceType, id: trigger.sourceId };
+  const manualCategory = rule.action.type === AUTOMATION_RULE_ACTION.ASSIGN_BUDGET
+    && transactionById(state, trigger.sourceId)?.categorySource === 'manual';
+  const base = {
+    source,
+    sourceStatus: 'ready',
+    safetyClass: manualCategory ? AUTOMATION_SAFETY_CLASS.BLOCKED : AUTOMATION_SAFETY_CLASS.SAFE_AUTOMATIC,
+    certainty: AUTOMATION_CERTAINTY.CERTAIN,
+    reasonCode: manualCategory ? AUTOMATION_REASON.MANUAL_OVERRIDE : 'user_defined_local_rule',
+    explanation: rule.explanation
+  };
+
+  if (rule.action.type === AUTOMATION_RULE_ACTION.ASSIGN_BUDGET) {
+    const transaction = transactionById(state, trigger.sourceId);
+    const budget = (state.budgets || []).find((item) => String(item.id) === String(rule.action.value));
+    if (!transaction || !budget) return { ...base, sourceStatus: 'missing' };
+    return {
+      ...base,
+      action: {
+        type: 'assign_transaction_budget',
+        key: 'budget-category',
+        risk: 'housekeeping',
+        identityContext: { budgetId: budget.id, ruleUpdatedAt: rule.updatedAt },
+        payload: { budgetId: budget.id }
+      }
+    };
+  }
+
+  if (rule.action.type === AUTOMATION_RULE_ACTION.ADD_TAG) {
+    if (!transactionById(state, trigger.sourceId)) return { ...base, sourceStatus: 'missing' };
+    return {
+      ...base,
+      action: {
+        type: 'add_local_tag',
+        key: `tag:${normalise(rule.action.value)}`,
+        risk: 'housekeeping',
+        identityContext: { tag: normalise(rule.action.value), ruleUpdatedAt: rule.updatedAt },
+        payload: { tag: rule.action.value }
+      }
+    };
+  }
+
+  const pattern = recurringPatternForTrigger(state, trigger);
+  const dueDate = pattern?.nextExpected?.date || '';
+  return {
+    ...base,
+    action: {
+      type: 'create_local_reminder',
+      key: 'local-reminder',
+      risk: 'housekeeping',
+      identityContext: { title: rule.action.value, dueDate, ruleUpdatedAt: rule.updatedAt },
+      payload: {
+        title: rule.action.value,
+        detail: pattern ? `${pattern.label} · expected ${dueDate}` : rule.explanation
+      }
+    }
+  };
+}
+
+function conditionMatches(condition, state, trigger, now) {
+  const transaction = transactionById(state, trigger.sourceId);
+  const pattern = recurringPatternForTrigger(state, trigger);
+
+  if (condition.field === AUTOMATION_RULE_CONDITION.MERCHANT) {
+    if (!transaction) return false;
+    const merchant = normalise(transaction.merchantName || transaction.payee || transaction.description || transaction.userDescription);
+    return textMatches(merchant, condition);
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.PURPOSE) {
+    if (!transaction) return false;
+    const assignment = resolveTransactionBudgetAssignment(transaction, { budgets: state.budgets || [], transactions: state.transactions || [] });
+    const values = [
+      assignment.budget?.id,
+      assignment.budget?.category,
+      transaction.transactionPurpose,
+      transaction.category,
+      transaction.budgetCategoryId
+    ].map(normalise).filter(Boolean);
+    return values.some((value) => textMatches(value, condition));
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.ACCOUNT) return Boolean(transaction) && String(transaction.accountId || '') === String(condition.value);
+  if (condition.field === AUTOMATION_RULE_CONDITION.DIRECTION) {
+    if (!transaction) return false;
+    const direction = Number(transaction.incoming || 0) > 0 ? 'incoming' : Number(transaction.outgoing || 0) > 0 ? 'outgoing' : '';
+    return direction === condition.value;
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.AMOUNT) {
+    if (!transaction) return false;
+    const amount = Number(transaction.incoming || 0) > 0 ? Number(transaction.incoming) : Number(transaction.outgoing || 0);
+    return rangeMatches(amount, condition);
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.RECURRING_CADENCE) return pattern?.cadence === condition.value;
+  if (condition.field === AUTOMATION_RULE_CONDITION.REVIEW_STATE) {
+    if (!transaction) return false;
+    const stateValue = transaction.reviewStatus || transaction.importReviewStatus || 'none';
+    return stateValue === condition.value;
+  }
+  if (condition.field === AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE) {
+    if (!pattern?.nextExpected?.date) return false;
+    return rangeMatches(daysBetween(localDateKey(validDate(now)), pattern.nextExpected.date), condition);
+  }
+  return false;
+}
+
+export function evaluationContexts(state, now, includeDisabled = false, candidateRules = state.automation.rules) {
+  const contexts = [];
+  const rules = Array.isArray(candidateRules) ? candidateRules : [];
+  const hasTransactionRules = rules.some((rule) => (includeDisabled || rule.enabled) && rule.trigger === AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE);
+  if (hasTransactionRules) {
+    for (const transaction of state.transactions || []) {
+      if (!transaction?.id || transaction.deletedAt) continue;
+      contexts.push({ triggerType: AUTOMATION_TRIGGER.TRANSACTION_CHANGE, sourceType: 'transaction', sourceId: String(transaction.id) });
+    }
+  }
+  const hasDateRules = rules.some((rule) => (includeDisabled || rule.enabled) && rule.trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY);
+  if (hasDateRules) {
+    for (const pattern of deriveRecurringPatterns(state, { includeRejected: false })) {
+      if (pattern.confidence !== RECURRING_CONFIDENCE.CONFIRMED || !pattern.nextExpected?.date) continue;
+      contexts.push({ triggerType: AUTOMATION_TRIGGER.DATE_BOUNDARY, sourceType: 'recurring_pattern', sourceId: pattern.id });
+    }
+  }
+  return contexts;
+}
+
+function ruleExecutionScopeMatches(rule, state, trigger) {
+  if (rule.activationMode !== AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY || !rule.activatedAt) return true;
+  if (rule.trigger !== AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE) return true;
+  const transaction = transactionById(state, trigger.sourceId);
+  if (!transaction) return false;
+  const activityAt = transactionActivityAt(state, transaction);
+  return activityAt !== null && activityAt > Date.parse(rule.activatedAt);
+}
+
+function transactionActivityAt(state, transaction) {
+  const timestamps = [transaction.updatedAt, transaction.createdAt, transaction.importedAt]
+    .map(timestampOrNull).filter((value) => value !== null);
+  const document = transaction.sourceDocumentId
+    ? (state.documents || []).find((item) => String(item.id) === String(transaction.sourceDocumentId))
+    : null;
+  const documentImportedAt = timestampOrNull(document?.importedAt);
+  if (documentImportedAt !== null) timestamps.push(documentImportedAt);
+  return timestamps.length ? Math.max(...timestamps) : null;
+}
+
+function recurringPatternForTrigger(state, trigger) {
+  const patterns = deriveRecurringPatterns(state, { includeRejected: false });
+  if (trigger.sourceType === 'recurring_pattern') return patterns.find((pattern) => pattern.id === trigger.sourceId) || null;
+  if (trigger.sourceType === 'transaction') return patterns.find((pattern) => pattern.sourceTransactionIds.includes(String(trigger.sourceId))) || null;
+  return null;
+}
+
+function timestampOrNull(value) {
+  if (typeof value !== 'string' || !Number.isFinite(Date.parse(value))) return null;
+  const date = new Date(value);
+  return date.toISOString() === value ? date.getTime() : null;
+}
+
+function transactionById(state, id) {
+  return (state.transactions || []).find((transaction) => String(transaction.id) === String(id)) || null;
+}
+
+function textMatches(value, condition) {
+  const expected = normalise(condition.value);
+  if (!expected) return false;
+  return condition.operator === 'contains' ? value.includes(expected) : value === expected;
+}
+
+function rangeMatches(value, condition) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return false;
+  const first = Number(condition.value);
+  if (!Number.isFinite(first)) return false;
+  if (condition.operator === 'at_least') return number >= first;
+  if (condition.operator === 'at_most') return number <= first;
+  if (condition.operator === 'between') {
+    const second = Number(condition.value2);
+    return Number.isFinite(second) && number >= first && number <= second;
+  }
+  return number === first;
+}
+
+function daysBetween(left, right) {
+  const [ly, lm, ld] = String(left).split('-').map(Number);
+  const [ry, rm, rd] = String(right).split('-').map(Number);
+  return Math.round((Date.UTC(ry, rm - 1, rd) - Date.UTC(ly, lm - 1, ld)) / 86_400_000);
+}
+function localDateKey(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+function normalise(value) { return String(value || '').trim().toLowerCase().replace(/\s+/g, ' '); }
+export function validDate(value) {
+  const candidate = value === undefined ? new Date() : value instanceof Date ? value : new Date(value);
+  return Number.isNaN(candidate.getTime()) ? new Date() : candidate;
+}

--- a/automation-rules-ui.js
+++ b/automation-rules-ui.js
@@ -1,15 +1,18 @@
 import {
-  AUTOMATION_RULE_ACTION, AUTOMATION_RULE_CONDITION, AUTOMATION_RULE_TRIGGER,
+  AUTOMATION_RULE_ACTION, AUTOMATION_RULE_ACTIVATION, AUTOMATION_RULE_CONDITION, AUTOMATION_RULE_TRIGGER,
   actionLabel, conditionLabel, duplicateAutomationRule, normaliseAutomationRuleState,
   removeAutomationRule, setAutomationRuleEnabled, upsertAutomationRule
 } from './automation-rule-model.js';
 
+const PREVIEW_PAGE_SIZE = 20;
 let state = null;
 let editId = '';
 let draft = null;
 let lastCycleSignature = '';
 let cycleRunning = false;
 let runSummary = null;
+let previewState = null;
+let previewVisibleCount = PREVIEW_PAGE_SIZE;
 
 export function renderAutomationRulesPanel(nextState) {
   if (typeof document === 'undefined' || typeof window === 'undefined') return;
@@ -41,13 +44,14 @@ function render() {
   for (const rule of automation.rules) list.append(ruleCard(rule));
   panel.append(list);
   if (draft) panel.append(ruleForm());
+  if (previewState) panel.append(previewPanel());
 }
 
 function heading(automation) {
   const wrapper = el('div', 'panel-heading');
   const copy = el('div');
   copy.append(el('p', 'eyebrow', 'LOCAL AUTOMATION'), el('h2', '', 'Simple rules'),
-    el('p', 'muted', 'Build small “When… If… Then…” rules. They stay local, use OneStep’s shared safety engine, and never move money or contact an external service.'));
+    el('p', 'muted', 'Build small “When… If… Then…” rules. Test them locally before activation. New and materially changed rules start paused and only affect future matching activity once enabled.'));
   const label = el('label', 'confirmation-check');
   const toggle = document.createElement('input'); toggle.type = 'checkbox'; toggle.checked = automation.enabled; toggle.dataset.automationGlobal = 'true';
   label.append(toggle, document.createTextNode(automation.enabled ? 'Automations enabled' : 'Automations paused'));
@@ -57,7 +61,7 @@ function heading(automation) {
 
 function statusLine(automation) {
   const output = el('p', 'muted'); output.id = 'automationRulesStatus'; output.setAttribute('role', 'status'); output.setAttribute('aria-live', 'polite');
-  if (!automation.enabled) output.textContent = 'Paused. Rules can still be edited and previewed, but automatic changes are blocked.';
+  if (!automation.enabled) output.textContent = 'Paused. Rules can still be edited and tested, but automatic changes are blocked.';
   else if (runSummary?.conflicts) output.textContent = `${runSummary.conflicts} conflicting rule decision${runSummary.conflicts === 1 ? '' : 's'} need review. No conflicting category was applied.`;
   else if (runSummary?.applied) output.textContent = `${runSummary.applied} safe local automation change${runSummary.applied === 1 ? '' : 's'} applied.`;
   return output;
@@ -69,9 +73,14 @@ function ruleCard(rule) {
   const copy = el('div'); copy.append(el('strong', '', rule.name), el('span', 'muted', rule.explanation));
   head.append(copy, el('span', 'badge', rule.enabled ? 'Enabled' : 'Paused')); card.append(head);
   card.append(el('p', 'muted', `${triggerLabel(rule.trigger)} · ${rule.conditions.map(conditionLabel).join(' · ')} · ${actionLabel(rule.action)}`));
+  if (rule.activationMode === AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY) {
+    card.append(el('p', 'muted', rule.enabled && rule.activatedAt
+      ? `Future activity only · enabled ${formatLocalDateTime(rule.activatedAt)}`
+      : 'Future activity only when enabled · existing records will not be rewritten automatically.'));
+  }
   card.append(buttonRow(
     button('Edit', 'secondary-button', { automationEdit: rule.id }),
-    button('Preview', 'secondary-button', { automationPreview: rule.id }),
+    button('Test Rule', 'secondary-button', { automationPreview: rule.id }),
     button(rule.enabled ? 'Pause rule' : 'Enable rule', 'secondary-button', { automationToggle: rule.id }),
     button('Duplicate', 'secondary-button', { automationDuplicate: rule.id }),
     button('Delete', 'danger-button', { automationDelete: rule.id })
@@ -95,7 +104,13 @@ function ruleForm() {
   form.append(field('Then…', select('ruleAction', actionOptions(draft.trigger), draft.action.type)));
   form.append(field('Action value', actionValueInput(draft.action)));
   const why = field('Why this rule exists', input('ruleExplanation', draft.explanation || '', 'text', false)); why.classList.add('wide-field'); form.append(why);
-  const actions = buttonRow(button(editId ? 'Save rule' : 'Create rule', 'primary-button', {}, 'submit'), button('Cancel', 'secondary-button', { automationCancel: 'true' }));
+  const note = el('p', 'muted', 'Test Rule is read-only. New rules and edits that change matching or actions are saved paused; enabling them later affects future matching activity only.');
+  note.classList.add('wide-field'); form.append(note);
+  const actions = buttonRow(
+    button('Test Rule', 'secondary-button', { automationDraftPreview: 'true' }),
+    button(editId ? 'Save rule' : 'Create rule', 'primary-button', {}, 'submit'),
+    button('Cancel', 'secondary-button', { automationCancel: 'true' })
+  );
   actions.classList.add('wide-field'); form.append(actions);
   return form;
 }
@@ -110,22 +125,79 @@ function conditionRow(condition, index) {
   return row;
 }
 
+function previewPanel() {
+  const wrapper = el('section', 'review-card');
+  wrapper.setAttribute('aria-label', 'Test Rule preview');
+  const result = previewState.result;
+  wrapper.append(el('p', 'eyebrow', 'TEST RULE · LOCAL DRY RUN'), el('h3', '', 'Preview before activation'));
+  const unchanged = el('p', '', result.unchangedMessage || 'Preview only — nothing has been changed.');
+  unchanged.setAttribute('role', 'status'); wrapper.append(unchanged);
+  wrapper.append(el('p', 'muted', `${result.evaluatedCount} existing record${result.evaluatedCount === 1 ? '' : 's'} evaluated · ${result.matchedRecordCount} matched · ${result.wouldApplyCount} would apply · ${result.reviewRequiredCount} need review · ${result.blockedCount} blocked.`));
+  wrapper.append(el('p', 'muted', result.existingImpact?.message || 'Existing data was checked locally.'));
+  wrapper.append(el('p', 'muted', result.futureImpact?.message || 'After activation, future matching activity is handled by this rule.'));
+  wrapper.append(el('p', 'muted', result.retrospective?.message || 'Existing records are never changed automatically by this preview.'));
+
+  if (result.truncated) {
+    wrapper.append(el('p', 'muted', `This rule has a large preview. Details are capped at the first ${result.detailLimit} outcomes; narrow the rule to inspect a smaller set.`));
+  }
+
+  const details = el('div', 'compact-card-list');
+  const visible = (result.items || []).slice(0, previewVisibleCount);
+  if (!visible.length) details.append(el('p', 'muted', 'No matching outcomes to show.'));
+  for (const item of visible) details.append(previewOutcomeCard(item));
+  wrapper.append(details);
+
+  const actions = [];
+  if (previewVisibleCount < (result.items || []).length) actions.push(button('Show 20 more', 'secondary-button', { automationPreviewMore: 'true' }));
+  if (previewState.activationIntent && previewState.ruleId && !rules().find((rule) => rule.id === previewState.ruleId)?.enabled) {
+    actions.push(button('Enable for future activity', 'primary-button', { automationActivate: previewState.ruleId }));
+  }
+  actions.push(button('Close preview', 'secondary-button', { automationPreviewClose: 'true' }));
+  wrapper.append(buttonRow(...actions));
+  return wrapper;
+}
+
+function previewOutcomeCard(item) {
+  const card = el('article', 'review-card');
+  const head = el('div', 'review-card-heading');
+  const copy = el('div'); copy.append(el('strong', '', previewSourceLabel(item)), el('span', 'muted', item.actionLabel || 'Automation action'));
+  head.append(copy, el('span', 'badge', previewStatusLabel(item.status))); card.append(head);
+  card.append(el('p', 'muted', item.explanation || previewReasonLabel(item.reasonCode)));
+  return card;
+}
+
 async function onClick(event) {
   const target = event.target;
-  if (target.closest('[data-automation-create]')) { editId = ''; draft = blankRule(); render(); return; }
-  if (target.closest('[data-automation-cancel]')) { editId = ''; draft = null; render(); return; }
+  if (target.closest('[data-automation-create]')) { editId = ''; draft = blankRule(); clearPreview(); render(); return; }
+  if (target.closest('[data-automation-cancel]')) { editId = ''; draft = null; clearPreview(); render(); return; }
+  if (target.closest('[data-automation-preview-close]')) { clearPreview(); render(); return; }
+  if (target.closest('[data-automation-preview-more]')) { previewVisibleCount += PREVIEW_PAGE_SIZE; render(); return; }
   const edit = target.closest('[data-automation-edit]');
-  if (edit) { const rule = rules().find((item) => item.id === edit.dataset.automationEdit); if (rule) { editId = rule.id; draft = structuredClone(rule); render(); } return; }
+  if (edit) { const rule = rules().find((item) => item.id === edit.dataset.automationEdit); if (rule) { editId = rule.id; draft = structuredClone(rule); clearPreview(); render(); } return; }
   const add = target.closest('[data-condition-add]');
-  if (add) { captureDraft(); if (draft.conditions.length < 8) draft.conditions.push(defaultCondition(draft.trigger)); render(); return; }
+  if (add) { captureDraft(); if (draft.conditions.length < 8) draft.conditions.push(defaultCondition(draft.trigger)); clearPreview(); render(); return; }
   const removeCondition = target.closest('[data-condition-remove]');
-  if (removeCondition) { captureDraft(); draft.conditions.splice(Number(removeCondition.dataset.conditionRemove), 1); render(); return; }
+  if (removeCondition) { captureDraft(); draft.conditions.splice(Number(removeCondition.dataset.conditionRemove), 1); clearPreview(); render(); return; }
+  const draftPreview = target.closest('[data-automation-draft-preview]');
+  if (draftPreview) { captureDraft(); await previewDraftRule(); return; }
   const toggle = target.closest('[data-automation-toggle]');
-  if (toggle) { const rule = rules().find((item) => item.id === toggle.dataset.automationToggle); await persist(setAutomationRuleEnabled(state, rule.id, !rule.enabled), rule.enabled ? 'Rule paused.' : 'Rule enabled.'); return; }
+  if (toggle) {
+    const rule = rules().find((item) => item.id === toggle.dataset.automationToggle);
+    if (!rule) return;
+    if (rule.enabled) {
+      clearPreview();
+      await persist(setAutomationRuleEnabled(state, rule.id, false), 'Rule paused. Existing financial history was left unchanged.');
+    } else {
+      await previewRule(rule.id, { activationIntent: true });
+    }
+    return;
+  }
+  const activate = target.closest('[data-automation-activate]');
+  if (activate) { await activatePreviewedRule(activate.dataset.automationActivate); return; }
   const duplicate = target.closest('[data-automation-duplicate]');
-  if (duplicate) { await persist(duplicateAutomationRule(state, duplicate.dataset.automationDuplicate, createRuleId()), 'Rule duplicated in a paused state.'); return; }
+  if (duplicate) { clearPreview(); await persist(duplicateAutomationRule(state, duplicate.dataset.automationDuplicate, createRuleId()), 'Rule duplicated in a paused state. Test it before enabling it.'); return; }
   const remove = target.closest('[data-automation-delete]');
-  if (remove) { const rule = rules().find((item) => item.id === remove.dataset.automationDelete); if (rule && window.confirm(`Delete “${rule.name}”? Existing financial history will not be reversed.`)) await persist(removeAutomationRule(state, rule.id), 'Rule deleted. Existing history was left unchanged.'); return; }
+  if (remove) { const rule = rules().find((item) => item.id === remove.dataset.automationDelete); if (rule && window.confirm(`Delete “${rule.name}”? Existing financial history will not be reversed.`)) { clearPreview(); await persist(removeAutomationRule(state, rule.id), 'Rule deleted. Existing history was left unchanged.'); } return; }
   const preview = target.closest('[data-automation-preview]');
   if (preview) await previewRule(preview.dataset.automationPreview);
 }
@@ -133,9 +205,10 @@ async function onClick(event) {
 async function onChange(event) {
   if (event.target.matches('[data-automation-global]')) {
     const next = structuredClone(state); next.automation = normaliseAutomationRuleState(next.automation); next.automation.enabled = event.target.checked;
-    await persist(next, event.target.checked ? 'Automations enabled.' : 'All automations paused.'); return;
+    clearPreview(); await persist(next, event.target.checked ? 'Automations enabled.' : 'All automations paused.'); return;
   }
   if (!draft) return;
+  clearPreview();
   if (event.target.id === 'ruleTrigger') {
     captureDraft(); draft.trigger = event.target.value;
     if (draft.trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY) {
@@ -145,9 +218,7 @@ async function onChange(event) {
     render(); return;
   }
   if (event.target.id === 'ruleAction') {
-    captureDraft();
-    draft.action = { type: event.target.value, value: '' };
-    render(); return;
+    captureDraft(); draft.action = { type: event.target.value, value: '' }; render(); return;
   }
   if (/^condition(Field|Operator)/.test(event.target.id)) {
     captureDraft();
@@ -161,9 +232,23 @@ async function onSubmit(event) {
   if (event.target.id !== 'automationRuleForm') return;
   event.preventDefault(); captureDraft();
   const existing = rules().find((item) => item.id === editId);
+  const materialChanged = !existing || materialRuleChanged(existing, draft);
   try {
-    const next = upsertAutomationRule(state, { ...(existing || {}), ...draft, id: existing?.id || createRuleId(), enabled: existing?.enabled ?? true });
-    editId = ''; draft = null; await persist(next, existing ? 'Rule saved.' : 'Rule created.');
+    const next = upsertAutomationRule(state, {
+      ...(existing || {}),
+      ...draft,
+      id: existing?.id || createRuleId(),
+      enabled: materialChanged ? false : existing.enabled,
+      activationMode: materialChanged ? AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY : existing.activationMode,
+      activatedAt: materialChanged ? null : existing.activatedAt
+    });
+    editId = ''; draft = null; clearPreview();
+    const message = !existing
+      ? 'Rule created in a paused state. Test it, then enable it for future activity.'
+      : materialChanged
+        ? 'Rule saved and paused because its matching or action changed. Test it before enabling it again.'
+        : 'Rule saved.';
+    await persist(next, message);
   } catch (error) { setStatus(error?.message || 'That rule could not be saved.'); }
 }
 
@@ -182,13 +267,45 @@ function captureDraft() {
   });
 }
 
-async function previewRule(ruleId) {
-  if (!window.financeAPI?.previewAutomationRules) { setStatus('Rule preview is available in the desktop app. No data was sent anywhere.'); return; }
-  setStatus('Checking this rule locally…');
+async function previewDraftRule() {
+  const existing = rules().find((item) => item.id === editId);
+  const candidate = {
+    ...(existing || {}), ...structuredClone(draft),
+    id: existing?.id || 'rule_preview_draft',
+    enabled: false,
+    activationMode: AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY,
+    activatedAt: null
+  };
+  await previewRule(candidate.id, { rule: candidate, activationIntent: false });
+}
+
+async function previewRule(ruleId, options = {}) {
+  if (!window.financeAPI?.previewAutomationRules) { setStatus('Test Rule is available in the desktop app. No data was sent anywhere.'); return; }
+  setStatus('Testing this rule locally…');
   try {
-    const result = await window.financeAPI.previewAutomationRules(state, { ruleId, now: new Date().toISOString() });
-    setStatus(`${result.matchCount} matching local action${result.matchCount === 1 ? '' : 's'} found${result.conflicts?.length ? `, with ${result.conflicts.length} conflict${result.conflicts.length === 1 ? '' : 's'}` : ''}. Preview changed nothing.`);
-  } catch (error) { setStatus(error?.message || 'The local preview could not be completed.'); }
+    const result = await window.financeAPI.previewAutomationRules(state, {
+      ruleId,
+      rule: options.rule || null,
+      now: new Date().toISOString()
+    });
+    previewState = { ruleId, result, activationIntent: options.activationIntent === true };
+    previewVisibleCount = PREVIEW_PAGE_SIZE;
+    render();
+    setStatus(`${result.matchedRecordCount} existing record${result.matchedRecordCount === 1 ? '' : 's'} matched. Preview only — nothing has been changed.`);
+  } catch (error) { clearPreview(); render(); setStatus(error?.message || 'The local Test Rule preview could not be completed.'); }
+}
+
+async function activatePreviewedRule(ruleId) {
+  const rule = rules().find((item) => item.id === ruleId);
+  if (!rule || rule.enabled || previewState?.ruleId !== ruleId || !previewState?.result?.nothingChanged) return;
+  const matches = Number(previewState.result.matchedRecordCount || 0);
+  const confirmed = window.confirm(`Enable “${rule.name}” for future matching activity? ${matches} existing matching record${matches === 1 ? '' : 's'} shown by Test Rule will not be changed. Retrospective application is not available in this release.`);
+  if (!confirmed) { setStatus('Activation cancelled. Nothing was changed.'); return; }
+  try {
+    const next = setAutomationRuleEnabled(state, rule.id, true, new Date());
+    clearPreview();
+    await persist(next, 'Rule enabled for future matching activity. Existing records were left unchanged.');
+  } catch (error) { setStatus(error?.message || 'The rule could not be enabled safely.'); }
 }
 
 async function persist(next, message) {
@@ -203,7 +320,7 @@ function scheduleCycle() {
   if (!state || !window.financeAPI?.runAutomationRules || !window.financeAPI?.saveState || cycleRunning) return;
   const automation = normaliseAutomationRuleState(state.automation);
   if (!automation.enabled || !automation.rules.some((rule) => rule.enabled)) return;
-  const signature = `${state.meta?.revision ?? 0}:${automation.rules.map((rule) => `${rule.id}:${rule.enabled}:${rule.updatedAt || ''}`).join('|')}`;
+  const signature = `${state.meta?.revision ?? 0}:${automation.rules.map((rule) => `${rule.id}:${rule.enabled}:${rule.updatedAt || ''}:${rule.activatedAt || ''}`).join('|')}`;
   if (signature === lastCycleSignature) return;
   lastCycleSignature = signature; cycleRunning = true; queueMicrotask(runCycle);
 }
@@ -222,7 +339,14 @@ async function runCycle() {
   finally { cycleRunning = false; }
 }
 
-function blankRule() { return { name: '', enabled: true, trigger: AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE, conditions: [defaultCondition(AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE)], action: { type: AUTOMATION_RULE_ACTION.ASSIGN_BUDGET, value: '' }, explanation: '' }; }
+function blankRule() {
+  return {
+    name: '', enabled: false, trigger: AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE,
+    conditions: [defaultCondition(AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE)],
+    action: { type: AUTOMATION_RULE_ACTION.ASSIGN_BUDGET, value: '' }, explanation: '',
+    activationMode: AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY, activatedAt: null
+  };
+}
 function defaultCondition(trigger) { return trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY ? { id: createConditionId(), field: AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE, operator: 'between', value: 0, value2: 3 } : { id: createConditionId(), field: AUTOMATION_RULE_CONDITION.MERCHANT, operator: 'equals', value: '' }; }
 function defaultConditionForField(field, id = createConditionId()) {
   if (field === AUTOMATION_RULE_CONDITION.AMOUNT) return { id, field, operator: 'at_least', value: 0, value2: null };
@@ -243,6 +367,50 @@ function conditionValueInput(condition, index, part) {
   if (condition.field === 'review_state') return select(id, [['none','No review state'],['pending','Pending'],['accepted','Accepted'],['rejected','Rejected'],['in_progress','In progress'],['snoozed','Snoozed']], value);
   return input(id, value, numericCondition(condition.field) ? 'number' : 'text', true);
 }
+function materialRuleChanged(existing, nextDraft) {
+  return JSON.stringify(materialRuleSignature(existing)) !== JSON.stringify(materialRuleSignature(nextDraft));
+}
+function materialRuleSignature(rule) {
+  return {
+    trigger: rule?.trigger || '',
+    conditions: (rule?.conditions || []).map((condition) => ({
+      id: condition?.id || '',
+      field: condition?.field || '',
+      operator: condition?.operator || 'equals',
+      value: normaliseConditionComparisonValue(condition?.field, condition?.value),
+      value2: normaliseConditionComparisonValue(condition?.field, condition?.value2)
+    })),
+    action: { type: rule?.action?.type || '', value: String(rule?.action?.value ?? '') }
+  };
+}
+function normaliseConditionComparisonValue(field, value) {
+  if (value === '' || value === null || value === undefined) return null;
+  if (numericCondition(field)) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : String(value);
+  }
+  return String(value);
+}
+function previewSourceLabel(item) {
+  if (item.sourceType !== 'transaction') return `Recurring item · ${item.sourceId}`;
+  const transaction = (state.transactions || []).find((entry) => String(entry.id) === String(item.sourceId));
+  if (!transaction) return `Payment · ${item.sourceId}`;
+  const label = transaction.merchantName || transaction.payee || transaction.userDescription || transaction.description || 'Payment';
+  const amount = Number(transaction.incoming || 0) > 0 ? Number(transaction.incoming) : Number(transaction.outgoing || 0);
+  const amountText = Number.isFinite(amount) && amount ? ` · ${amount.toFixed(2)}` : '';
+  return `${transaction.date || 'No date'} · ${label}${amountText}`;
+}
+function previewStatusLabel(status) {
+  if (status === 'would_apply') return 'Would apply';
+  if (status === 'conflict') return 'Conflict';
+  if (status === 'review_required') return 'Needs review';
+  if (status === 'blocked') return 'Blocked';
+  if (status === 'already_applied') return 'Already applied';
+  return 'Skipped';
+}
+function previewReasonLabel(reason) { return String(reason || 'preview').replace(/_/g, ' '); }
+function clearPreview() { previewState = null; previewVisibleCount = PREVIEW_PAGE_SIZE; }
+function formatLocalDateTime(value) { const date = new Date(value); return Number.isNaN(date.getTime()) ? 'recently' : date.toLocaleString(); }
 function numericCondition(field) { return [AUTOMATION_RULE_CONDITION.AMOUNT, AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE].includes(field); }
 function rules() { return normaliseAutomationRuleState(state.automation).rules; }
 function triggerLabel(trigger) { return trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY ? 'When: recurring date' : 'When: payment changes'; }

--- a/automation-rules.js
+++ b/automation-rules.js
@@ -1,29 +1,104 @@
+import { AUTOMATION_EXECUTION_STATUS, AUTOMATION_REASON, executeAutomationProposal } from './automation-engine.js';
 import {
-  AUTOMATION_CERTAINTY, AUTOMATION_EXECUTION_STATUS, AUTOMATION_REASON, AUTOMATION_SAFETY_CLASS,
-  AUTOMATION_TRIGGER, createAutomationTrigger, evaluateAutomationRules, executeAutomationProposal
-} from './automation-engine.js';
-import {
-  AUTOMATION_RULE_ACTION, AUTOMATION_RULE_CONDITION, AUTOMATION_RULE_TRIGGER,
-  normaliseAutomationRuleCollection, normaliseAutomationRuleState, validateAutomationRule
+  AUTOMATION_RULE_ACTIVATION, normaliseAutomationRuleCollection, normaliseAutomationRuleState, validateAutomationRule
 } from './automation-rule-model.js';
 import { synchroniseAutomationReviewSignals } from './automation-review-integration.js';
-import { deriveRecurringPatterns, RECURRING_CONFIDENCE } from './recurring-finance.js';
-import { resolveTransactionBudgetAssignment } from './transaction-categorisation.js';
+import {
+  evaluationContexts, evaluateContexts, resolveRuleProposalConflicts, ruleActionHandlers, validDate
+} from './automation-rules-core.js';
 
-const EXECUTION_TRIGGERS = new Set([AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE, AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY]);
+const MAX_PREVIEW_ITEMS = 100;
 
-export function previewStoredAutomationRules(state, options = {}) {
+export async function previewStoredAutomationRules(state, options = {}) {
   const safeState = withNormalisedRules(state);
-  const selectedRuleId = String(options.ruleId || '');
-  const rules = safeState.automation.rules.filter((rule) => !selectedRuleId || rule.id === selectedRuleId);
-  const contexts = evaluationContexts(safeState, options.now, true);
-  const proposals = evaluateContexts(safeState, rules, contexts, true, options.now);
-  const resolution = resolveRuleProposalConflicts(proposals);
+  const now = validDate(options.now);
+  const transientRule = options.rule ? previewRuleInput(options.rule, now) : null;
+  const selectedRuleId = transientRule?.id || String(options.ruleId || '');
+  const selectedRules = transientRule
+    ? [transientRule]
+    : safeState.automation.rules.filter((rule) => !selectedRuleId || rule.id === selectedRuleId);
+
+  if (selectedRuleId && !selectedRules.length) throw new Error('That automation rule is no longer available.');
+  if (!selectedRules.length) return emptyPreview();
+
+  const contexts = evaluationContexts(safeState, now, true, selectedRules);
+  const selectedProposals = evaluateContexts(safeState, selectedRules, contexts, true, now, { includeExisting: true });
+  const selectedRuleIds = new Set(selectedRules.map((rule) => rule.id));
+  const peerRules = selectedRuleId
+    ? safeState.automation.rules.filter((rule) => rule.enabled && !selectedRuleIds.has(rule.id))
+    : [];
+  const peerProposals = peerRules.length
+    ? evaluateContexts(safeState, peerRules, contexts, false, now, { includeExisting: true })
+    : [];
+  const resolution = resolveRuleProposalConflicts([...selectedProposals, ...peerProposals]);
+  const selectedExecutable = resolution.executable.filter((proposal) => selectedRuleIds.has(proposal.ruleId));
+  const selectedDuplicates = resolution.duplicates.filter((proposal) => selectedRuleIds.has(proposal.ruleId));
+  const selectedConflicts = resolution.conflicts.filter((conflict) => conflict.ruleIds.some((ruleId) => selectedRuleIds.has(ruleId)));
+  const results = [];
+
+  for (const proposal of selectedExecutable) {
+    const preview = await executeAutomationProposal(safeState, proposal, ruleActionHandlers(), {
+      recoveryMode: normalisePreviewRecoveryMode(options.recoveryMode),
+      now,
+      previewOnly: true
+    });
+    results.push({ proposal, result: preview.result });
+  }
+
+  const matchedSources = new Set(selectedProposals.map((proposal) => sourceKey(proposal.source)));
+  const proposalItems = results.map(({ proposal, result }) => previewProposalItem(safeState, proposal, result));
+  const duplicateItems = selectedDuplicates.map((proposal) => previewDuplicateItem(safeState, proposal));
+  const conflictItems = selectedConflicts.map((conflict) => previewConflictItem(safeState, conflict));
+  const allItems = [...conflictItems, ...proposalItems, ...duplicateItems]
+    .sort((left, right) => previewStatusRank(left.status) - previewStatusRank(right.status)
+      || left.sourceType.localeCompare(right.sourceType) || left.sourceId.localeCompare(right.sourceId)
+      || left.ruleId.localeCompare(right.ruleId));
+  const items = allItems.slice(0, MAX_PREVIEW_ITEMS);
+  const wouldApplyCount = proposalItems.filter((item) => item.status === 'would_apply').length;
+  const reviewRequiredCount = proposalItems.filter((item) => item.status === AUTOMATION_EXECUTION_STATUS.REVIEW_REQUIRED).length + selectedConflicts.length;
+  const blockedCount = proposalItems.filter((item) => item.status === AUTOMATION_EXECUTION_STATUS.BLOCKED).length;
+  const alreadyAppliedCount = proposalItems.filter((item) => item.status === AUTOMATION_EXECUTION_STATUS.ALREADY_APPLIED).length;
+
   return {
-    proposals: resolution.executable,
-    conflicts: resolution.conflicts,
-    duplicates: resolution.duplicates,
-    matchCount: resolution.executable.length + resolution.conflicts.length + resolution.duplicates.length
+    previewMode: 'dry_run',
+    nothingChanged: true,
+    unchangedMessage: 'Preview only — nothing has been changed.',
+    evaluatedCount: contexts.length,
+    matchedRecordCount: matchedSources.size,
+    matchCount: matchedSources.size,
+    proposedActionCount: selectedProposals.length,
+    notMatchedCount: Math.max(0, contexts.length - matchedSources.size),
+    wouldApplyCount,
+    reviewRequiredCount,
+    conflictCount: selectedConflicts.length,
+    duplicateCount: selectedDuplicates.length,
+    blockedCount,
+    alreadyAppliedCount,
+    proposals: selectedExecutable.slice(0, MAX_PREVIEW_ITEMS),
+    conflicts: selectedConflicts.slice(0, MAX_PREVIEW_ITEMS),
+    duplicates: selectedDuplicates.slice(0, MAX_PREVIEW_ITEMS),
+    items,
+    totalDetailCount: allItems.length,
+    truncated: allItems.length > items.length,
+    detailLimit: MAX_PREVIEW_ITEMS,
+    existingImpact: {
+      evaluatedCount: contexts.length,
+      matchedRecordCount: matchedSources.size,
+      proposedActionCount: selectedProposals.length,
+      message: matchedSources.size
+        ? `${matchedSources.size} existing record${matchedSources.size === 1 ? '' : 's'} would match this rule now.`
+        : 'No existing records match this rule now.'
+    },
+    futureImpact: {
+      activationMode: AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY,
+      message: 'After activation, the rule applies only to future matching activity. Existing records shown in this preview are not changed automatically.'
+    },
+    retrospective: {
+      supported: false,
+      automatic: false,
+      requiresSeparateConfirmation: true,
+      message: 'Retrospective apply is not available in this release. Existing records are never rewritten automatically when a rule is enabled.'
+    }
   };
 }
 
@@ -37,7 +112,7 @@ export async function runStoredAutomationRules(state, options = {}) {
     return { state: reviewSync.state, changed: false, reviewChanged: reviewSync.changed, results: [], conflicts: [] };
   }
   const contexts = evaluationContexts(current, options.now);
-  const proposals = evaluateContexts(current, current.automation.rules, contexts, false, options.now);
+  const proposals = evaluateContexts(current, current.automation.rules, contexts, false, options.now, { includeExisting: false });
   const resolution = resolveRuleProposalConflicts(proposals);
   const results = [
     ...resolution.duplicates.map((entry) => ({
@@ -80,259 +155,108 @@ export async function runStoredAutomationRules(state, options = {}) {
   return { state: current, changed, reviewChanged: reviewSync.changed, results, conflicts: resolution.conflicts };
 }
 
-export function ruleActionHandlers() {
+function previewRuleInput(input, now) {
+  const candidate = structuredClone(input || {});
+  if (!candidate.id) candidate.id = 'rule_preview_draft';
+  candidate.updatedAt = validDate(now).toISOString();
+  candidate.enabled = false;
+  candidate.activationMode = AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY;
+  candidate.activatedAt = null;
+  const checked = validateAutomationRule(candidate);
+  if (!checked.valid) {
+    const error = new Error(checked.errors.join(' '));
+    error.code = 'AUTOMATION_RULE_INVALID';
+    error.validationErrors = checked.errors;
+    throw error;
+  }
+  return checked.rule;
+}
+
+function previewProposalItem(state, proposal, result) {
+  const status = result.reasonCode === AUTOMATION_REASON.PREVIEW_ONLY ? 'would_apply' : result.status;
   return {
-    assign_transaction_budget: ({ state, proposal }) => {
-      const transaction = transactionById(state, proposal.source.id);
-      const budget = (state.budgets || []).find((item) => String(item.id) === String(proposal.action.payload?.budgetId || ''));
-      if (!transaction || !budget) return { state };
-      if (transaction.categorySource === 'manual') return { state };
-      transaction.budgetCategoryId = budget.id;
-      transaction.category = budget.category;
-      transaction.categorySource = 'automation';
-      transaction.automationRuleId = proposal.ruleId;
-      return { state };
-    },
-    add_local_tag: ({ state, proposal }) => {
-      const transaction = transactionById(state, proposal.source.id);
-      if (!transaction) return { state };
-      const value = String(proposal.action.payload?.tag || '').trim().slice(0, 80);
-      if (!value) return { state };
-      transaction.automationTags = [...new Set([...(Array.isArray(transaction.automationTags) ? transaction.automationTags : []), value])].slice(-20);
-      return { state };
-    },
-    create_local_reminder: ({ state, proposal }) => {
-      const title = String(proposal.action.payload?.title || '').trim().slice(0, 160);
-      if (!title) return { state };
-      state.tasks = Array.isArray(state.tasks) ? state.tasks : [];
-      const id = `automation_${proposal.executionId.slice(0, 32)}`;
-      const existing = state.tasks.find((task) => String(task.id) === id);
-      const timestamp = new Date().toISOString();
-      const task = {
-        id,
-        title,
-        detail: String(proposal.action.payload?.detail || 'Created by a local automation rule.').slice(0, 240),
-        priority: 'normal',
-        actionView: 'today',
-        source: 'automation_rule',
-        automationRuleId: proposal.ruleId,
-        automationExecutionId: proposal.executionId,
-        createdAt: existing?.createdAt || timestamp,
-        updatedAt: timestamp,
-        completedAt: existing?.completedAt || null
-      };
-      if (existing) Object.assign(existing, task);
-      else state.tasks.push(task);
-      return { state };
-    }
+    kind: 'proposal',
+    status,
+    reasonCode: result.reasonCode,
+    explanation: result.explanation,
+    requiresReview: result.status === AUTOMATION_EXECUTION_STATUS.REVIEW_REQUIRED,
+    ruleId: proposal.ruleId,
+    sourceType: proposal.source.type,
+    sourceId: proposal.source.id,
+    actionType: proposal.action.type,
+    actionLabel: previewActionLabel(state, proposal)
   };
 }
 
-export function resolveRuleProposalConflicts(proposals = []) {
-  const ordered = [...proposals].sort((left, right) => left.executionId.localeCompare(right.executionId));
-  const executable = [];
-  const duplicates = [];
-  const conflicts = [];
-  const categoryGroups = new Map();
-
-  for (const proposal of ordered) {
-    if (proposal.action.type !== 'assign_transaction_budget') {
-      executable.push(proposal);
-      continue;
-    }
-    const key = `${proposal.source.type}:${proposal.source.id}:budget-category`;
-    if (!categoryGroups.has(key)) categoryGroups.set(key, []);
-    categoryGroups.get(key).push(proposal);
-  }
-
-  for (const rows of categoryGroups.values()) {
-    const byValue = new Map();
-    for (const row of rows) {
-      const value = String(row.action.payload?.budgetId || '');
-      if (!byValue.has(value)) byValue.set(value, []);
-      byValue.get(value).push(row);
-    }
-    if (byValue.size > 1) {
-      conflicts.push({
-        source: rows[0].source,
-        ruleIds: rows.map((row) => row.ruleId).sort(),
-        actionType: 'assign_transaction_budget',
-        values: [...byValue.keys()].sort()
-      });
-      continue;
-    }
-    const compatible = [...rows].sort((left, right) => left.ruleId.localeCompare(right.ruleId));
-    executable.push(compatible[0]);
-    duplicates.push(...compatible.slice(1));
-  }
-
-  executable.sort((left, right) => left.executionId.localeCompare(right.executionId));
-  return { executable, duplicates, conflicts };
-}
-
-function evaluateContexts(state, rules, contexts, includeDisabled, now) {
-  const proposals = [];
-  const runtimeRules = rules
-    .filter((rule) => includeDisabled || rule.enabled)
-    .map((rule) => compileStoredRule(rule, now))
-    .filter(Boolean);
-  for (const context of contexts) {
-    const trigger = createAutomationTrigger(context.triggerType, {
-      sourceType: context.sourceType,
-      sourceId: context.sourceId,
-      occurredAt: validDate(now).toISOString()
-    });
-    proposals.push(...evaluateAutomationRules(state, trigger, runtimeRules));
-  }
-  return proposals;
-}
-
-function compileStoredRule(rule, now) {
-  const checked = validateAutomationRule(rule);
-  if (!checked.valid || !EXECUTION_TRIGGERS.has(checked.rule.trigger)) return null;
-  const stored = checked.rule;
+function previewDuplicateItem(state, proposal) {
   return {
-    id: stored.id,
-    triggers: [stored.trigger, AUTOMATION_TRIGGER.EXPLICIT_TEST],
-    conditions: stored.conditions.map((condition) => ({
-      id: condition.id,
-      test: ({ state, trigger }) => conditionMatches(condition, state, trigger, now)
-    })),
-    propose: ({ state, trigger }) => proposalForRule(stored, state, trigger, now)
+    kind: 'duplicate',
+    status: AUTOMATION_EXECUTION_STATUS.SKIPPED,
+    reasonCode: 'compatible_duplicate_rule_action',
+    explanation: 'Another matching rule proposes the same action, so OneStep would apply that action only once.',
+    requiresReview: false,
+    ruleId: proposal.ruleId,
+    sourceType: proposal.source.type,
+    sourceId: proposal.source.id,
+    actionType: proposal.action.type,
+    actionLabel: previewActionLabel(state, proposal)
   };
 }
 
-function proposalForRule(rule, state, trigger, now) {
-  const source = { type: trigger.sourceType, id: trigger.sourceId };
-  const manualCategory = rule.action.type === AUTOMATION_RULE_ACTION.ASSIGN_BUDGET
-    && transactionById(state, trigger.sourceId)?.categorySource === 'manual';
-  const base = {
-    source,
-    sourceStatus: 'ready',
-    safetyClass: manualCategory ? AUTOMATION_SAFETY_CLASS.BLOCKED : AUTOMATION_SAFETY_CLASS.SAFE_AUTOMATIC,
-    certainty: AUTOMATION_CERTAINTY.CERTAIN,
-    reasonCode: manualCategory ? AUTOMATION_REASON.MANUAL_OVERRIDE : 'user_defined_local_rule',
-    explanation: rule.explanation
-  };
-
-  if (rule.action.type === AUTOMATION_RULE_ACTION.ASSIGN_BUDGET) {
-    const transaction = transactionById(state, trigger.sourceId);
-    const budget = (state.budgets || []).find((item) => String(item.id) === String(rule.action.value));
-    if (!transaction || !budget) return { ...base, sourceStatus: 'missing' };
-    return {
-      ...base,
-      action: {
-        type: 'assign_transaction_budget',
-        key: 'budget-category',
-        risk: 'housekeeping',
-        identityContext: { budgetId: budget.id, ruleUpdatedAt: rule.updatedAt },
-        payload: { budgetId: budget.id }
-      }
-    };
-  }
-
-  if (rule.action.type === AUTOMATION_RULE_ACTION.ADD_TAG) {
-    if (!transactionById(state, trigger.sourceId)) return { ...base, sourceStatus: 'missing' };
-    return {
-      ...base,
-      action: {
-        type: 'add_local_tag',
-        key: `tag:${normalise(rule.action.value)}`,
-        risk: 'housekeeping',
-        identityContext: { tag: normalise(rule.action.value), ruleUpdatedAt: rule.updatedAt },
-        payload: { tag: rule.action.value }
-      }
-    };
-  }
-
-  const pattern = recurringPatternForTrigger(state, trigger);
-  const dueDate = pattern?.nextExpected?.date || '';
+function previewConflictItem(state, conflict) {
+  const labels = (conflict.values || []).map((value) => budgetLabel(state, value)).filter(Boolean);
   return {
-    ...base,
-    action: {
-      type: 'create_local_reminder',
-      key: 'local-reminder',
-      risk: 'housekeeping',
-      identityContext: { title: rule.action.value, dueDate, ruleUpdatedAt: rule.updatedAt },
-      payload: {
-        title: rule.action.value,
-        detail: pattern ? `${pattern.label} · expected ${dueDate}` : rule.explanation
-      }
-    }
+    kind: 'conflict',
+    status: 'conflict',
+    reasonCode: 'rule_conflict',
+    explanation: 'Matching rules disagree, so OneStep would leave this item unchanged and require review.',
+    requiresReview: true,
+    ruleId: conflict.ruleIds.join(','),
+    ruleIds: [...conflict.ruleIds],
+    sourceType: conflict.source.type,
+    sourceId: conflict.source.id,
+    actionType: conflict.actionType,
+    actionLabel: labels.length ? `Conflicting budget/category choices: ${labels.join(' / ')}` : 'Conflicting rule actions'
   };
 }
 
-function conditionMatches(condition, state, trigger, now) {
-  const transaction = transactionById(state, trigger.sourceId);
-  const pattern = recurringPatternForTrigger(state, trigger);
-
-  if (condition.field === AUTOMATION_RULE_CONDITION.MERCHANT) {
-    if (!transaction) return false;
-    const merchant = normalise(transaction.merchantName || transaction.payee || transaction.description || transaction.userDescription);
-    return textMatches(merchant, condition);
-  }
-  if (condition.field === AUTOMATION_RULE_CONDITION.PURPOSE) {
-    if (!transaction) return false;
-    const assignment = resolveTransactionBudgetAssignment(transaction, { budgets: state.budgets || [], transactions: state.transactions || [] });
-    const values = [
-      assignment.budget?.id,
-      assignment.budget?.category,
-      transaction.transactionPurpose,
-      transaction.category,
-      transaction.budgetCategoryId
-    ].map(normalise).filter(Boolean);
-    return values.some((value) => textMatches(value, condition));
-  }
-  if (condition.field === AUTOMATION_RULE_CONDITION.ACCOUNT) return Boolean(transaction) && String(transaction.accountId || '') === String(condition.value);
-  if (condition.field === AUTOMATION_RULE_CONDITION.DIRECTION) {
-    if (!transaction) return false;
-    const direction = Number(transaction.incoming || 0) > 0 ? 'incoming' : Number(transaction.outgoing || 0) > 0 ? 'outgoing' : '';
-    return direction === condition.value;
-  }
-  if (condition.field === AUTOMATION_RULE_CONDITION.AMOUNT) {
-    if (!transaction) return false;
-    const amount = Number(transaction.incoming || 0) > 0 ? Number(transaction.incoming) : Number(transaction.outgoing || 0);
-    return rangeMatches(amount, condition);
-  }
-  if (condition.field === AUTOMATION_RULE_CONDITION.RECURRING_CADENCE) return pattern?.cadence === condition.value;
-  if (condition.field === AUTOMATION_RULE_CONDITION.REVIEW_STATE) {
-    if (!transaction) return false;
-    const stateValue = transaction.reviewStatus || transaction.importReviewStatus || 'none';
-    return stateValue === condition.value;
-  }
-  if (condition.field === AUTOMATION_RULE_CONDITION.DAYS_UNTIL_DUE) {
-    if (!pattern?.nextExpected?.date) return false;
-    return rangeMatches(daysBetween(localDateKey(validDate(now)), pattern.nextExpected.date), condition);
-  }
-  return false;
+function previewActionLabel(state, proposal) {
+  if (proposal.action.type === 'assign_transaction_budget') return `Assign budget/category “${budgetLabel(state, proposal.action.payload?.budgetId)}”`;
+  if (proposal.action.type === 'add_local_tag') return `Add local tag “${String(proposal.action.payload?.tag || '')}”`;
+  if (proposal.action.type === 'create_local_reminder') return `Create local reminder “${String(proposal.action.payload?.title || '')}”`;
+  return proposal.action.type.replace(/_/g, ' ');
 }
 
-function evaluationContexts(state, now, includeDisabled = false) {
-  const contexts = [];
-  const hasTransactionRules = state.automation.rules.some((rule) => (includeDisabled || rule.enabled) && rule.trigger === AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE);
-  if (hasTransactionRules) {
-    for (const transaction of state.transactions || []) {
-      if (!transaction?.id || transaction.deletedAt) continue;
-      contexts.push({ triggerType: AUTOMATION_TRIGGER.TRANSACTION_CHANGE, sourceType: 'transaction', sourceId: String(transaction.id) });
-    }
-  }
-  const hasDateRules = state.automation.rules.some((rule) => (includeDisabled || rule.enabled) && rule.trigger === AUTOMATION_RULE_TRIGGER.DATE_BOUNDARY);
-  if (hasDateRules) {
-    for (const pattern of deriveRecurringPatterns(state, { includeRejected: false })) {
-      if (pattern.confidence !== RECURRING_CONFIDENCE.CONFIRMED || !pattern.nextExpected?.date) continue;
-      contexts.push({ triggerType: AUTOMATION_TRIGGER.DATE_BOUNDARY, sourceType: 'recurring_pattern', sourceId: pattern.id });
-    }
-  }
-  return contexts;
+function budgetLabel(state, budgetId) {
+  const budget = (state.budgets || []).find((item) => String(item.id) === String(budgetId || ''));
+  return String(budget?.category || budgetId || 'Unknown');
 }
 
-function recurringPatternForTrigger(state, trigger) {
-  const patterns = deriveRecurringPatterns(state, { includeRejected: false });
-  if (trigger.sourceType === 'recurring_pattern') return patterns.find((pattern) => pattern.id === trigger.sourceId) || null;
-  if (trigger.sourceType === 'transaction') return patterns.find((pattern) => pattern.sourceTransactionIds.includes(String(trigger.sourceId))) || null;
-  return null;
+function normalisePreviewRecoveryMode(value) {
+  return ['normal', 'recovery_required', 'resolution_in_progress', 'backup_in_progress', 'restore_in_progress'].includes(value)
+    ? value
+    : 'normal';
 }
 
+function emptyPreview() {
+  return {
+    previewMode: 'dry_run', nothingChanged: true, unchangedMessage: 'Preview only — nothing has been changed.',
+    evaluatedCount: 0, matchedRecordCount: 0, matchCount: 0, proposedActionCount: 0, notMatchedCount: 0,
+    wouldApplyCount: 0, reviewRequiredCount: 0, conflictCount: 0, duplicateCount: 0, blockedCount: 0,
+    alreadyAppliedCount: 0, proposals: [], conflicts: [], duplicates: [], items: [], totalDetailCount: 0,
+    truncated: false, detailLimit: MAX_PREVIEW_ITEMS,
+    existingImpact: { evaluatedCount: 0, matchedRecordCount: 0, proposedActionCount: 0, message: 'No existing records match this rule now.' },
+    futureImpact: { activationMode: AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY, message: 'After activation, the rule applies only to future matching activity. Existing records shown in this preview are not changed automatically.' },
+    retrospective: { supported: false, automatic: false, requiresSeparateConfirmation: true, message: 'Retrospective apply is not available in this release. Existing records are never rewritten automatically when a rule is enabled.' }
+  };
+}
+
+function previewStatusRank(status) {
+  return status === 'conflict' ? 0 : status === AUTOMATION_EXECUTION_STATUS.REVIEW_REQUIRED ? 1
+    : status === AUTOMATION_EXECUTION_STATUS.BLOCKED ? 2 : status === 'would_apply' ? 3 : 4;
+}
+
+function sourceKey(source) { return `${source?.type || 'state'}:${source?.id || 'global'}`; }
 function withNormalisedRules(state) {
   const next = structuredClone(state || {});
   next.automation = normaliseAutomationRuleState(next.automation);
@@ -340,40 +264,3 @@ function withNormalisedRules(state) {
   return next;
 }
 
-function transactionById(state, id) {
-  return (state.transactions || []).find((transaction) => String(transaction.id) === String(id)) || null;
-}
-
-function textMatches(value, condition) {
-  const expected = normalise(condition.value);
-  if (!expected) return false;
-  return condition.operator === 'contains' ? value.includes(expected) : value === expected;
-}
-
-function rangeMatches(value, condition) {
-  const number = Number(value);
-  if (!Number.isFinite(number)) return false;
-  const first = Number(condition.value);
-  if (!Number.isFinite(first)) return false;
-  if (condition.operator === 'at_least') return number >= first;
-  if (condition.operator === 'at_most') return number <= first;
-  if (condition.operator === 'between') {
-    const second = Number(condition.value2);
-    return Number.isFinite(second) && number >= first && number <= second;
-  }
-  return number === first;
-}
-
-function daysBetween(left, right) {
-  const [ly, lm, ld] = String(left).split('-').map(Number);
-  const [ry, rm, rd] = String(right).split('-').map(Number);
-  return Math.round((Date.UTC(ry, rm - 1, rd) - Date.UTC(ly, lm - 1, ld)) / 86_400_000);
-}
-function localDateKey(date) {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
-}
-function normalise(value) { return String(value || '').trim().toLowerCase().replace(/\s+/g, ' '); }
-function validDate(value) {
-  const candidate = value === undefined ? new Date() : value instanceof Date ? value : new Date(value);
-  return Number.isNaN(candidate.getTime()) ? new Date() : candidate;
-}

--- a/main-entry.js
+++ b/main-entry.js
@@ -4,11 +4,14 @@ import { previewStoredAutomationRules } from './automation-rules.js';
 import './main-process.js';
 
 const MAX_AUTOMATION_STATE_BYTES = 25_000_000;
+const PREVIEW_RECOVERY_MODES = new Set(['normal', 'recovery_required', 'resolution_in_progress', 'backup_in_progress', 'restore_in_progress']);
 
-ipcMain.handle('automation:preview', (_event, state, options = {}) => {
+ipcMain.handle('automation:preview', async (_event, state, options = {}) => {
   validateStatePayload(state);
   return previewStoredAutomationRules(state, {
     ruleId: String(options?.ruleId || ''),
+    rule: validRulePayload(options?.rule),
+    recoveryMode: PREVIEW_RECOVERY_MODES.has(options?.recoveryMode) ? options.recoveryMode : 'normal',
     now: safeNow(options?.now)
   });
 });
@@ -24,6 +27,13 @@ ipcMain.handle('automation:run', async (_event, state, options = {}) => {
 function validateStatePayload(state) {
   if (!state || typeof state !== 'object' || Array.isArray(state)) throw new TypeError('Automation state is invalid.');
   if (JSON.stringify(state).length > MAX_AUTOMATION_STATE_BYTES) throw new TypeError('Automation state is too large.');
+}
+
+function validRulePayload(rule) {
+  if (rule === undefined || rule === null) return null;
+  if (!rule || typeof rule !== 'object' || Array.isArray(rule)) throw new TypeError('Automation rule preview is invalid.');
+  if (JSON.stringify(rule).length > 25_000) throw new TypeError('Automation rule preview is too large.');
+  return structuredClone(rule);
 }
 
 function safeNow(value) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
       "automation-history-ui.js",
       "automation-review-integration.js",
       "automation-rule-model.js",
+      "automation-rules-core.js",
       "automation-rules.js",
       "automation-rules-ui.js",
       "automation-state.js",

--- a/tests/automation-preview-ui.test.js
+++ b/tests/automation-preview-ui.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const ui = fs.readFileSync(new URL('../automation-rules-ui.js', import.meta.url), 'utf8');
+
+test('Test Rule is explicit and preview copy promises no mutation', () => {
+  assert.match(ui, /Test Rule/);
+  assert.match(ui, /Preview only — nothing has been changed/);
+  assert.match(ui, /previewAutomationRules/);
+});
+
+test('new and materially edited rules are saved paused', () => {
+  assert.match(ui, /enabled: false/);
+  assert.match(ui, /materialRuleChanged/);
+  assert.match(ui, /enabled: materialChanged \? false : existing\.enabled/);
+  assert.match(ui, /Rule saved and paused because its matching or action changed/);
+});
+
+test('activation requires preview and separate confirmation for future activity', () => {
+  assert.match(ui, /activationIntent: true/);
+  assert.match(ui, /Enable for future activity/);
+  assert.match(ui, /window\.confirm\(`/);
+  assert.match(ui, /existing matching record/);
+  assert.match(ui, /Retrospective application is not available/);
+  assert.match(ui, /setAutomationRuleEnabled\(state, rule\.id, true/);
+});
+
+test('large previews use bounded progressive disclosure', () => {
+  assert.match(ui, /const PREVIEW_PAGE_SIZE = 20/);
+  assert.match(ui, /slice\(0, previewVisibleCount\)/);
+  assert.match(ui, /Show 20 more/);
+  assert.match(ui, /Details are capped at the first/);
+});
+
+test('preview UI adds no network, telemetry or analytics path', () => {
+  assert.doesNotMatch(ui, /\bfetch\s*\(/);
+  assert.doesNotMatch(ui, /node:(?:http|https|net|tls|dns)/);
+  assert.doesNotMatch(ui, /telemetry|analytics/i);
+});

--- a/tests/automation-preview.test.js
+++ b/tests/automation-preview.test.js
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  AUTOMATION_RULE_ACTION, AUTOMATION_RULE_ACTIVATION, AUTOMATION_RULE_CONDITION, AUTOMATION_RULE_TRIGGER,
+  setAutomationRuleEnabled, upsertAutomationRule
+} from '../automation-rule-model.js';
+import { previewStoredAutomationRules, runStoredAutomationRules } from '../automation-rules.js';
+
+function stateWithTransactions(count = 1) {
+  const transactions = Array.from({ length: count }, (_, index) => ({
+    id: `tx-${index + 1}`, accountId: 'account-main', date: '2026-08-10', merchantName: 'Fictional Fuel', description: 'Fictional Fuel',
+    outgoing: 25 + index, incoming: 0, category: '', budgetCategoryId: '', categorySource: 'imported', financiallyActive: true,
+    sourceDocumentId: `doc-${index + 1}`
+  }));
+  return {
+    meta: { revision: 11 },
+    automation: { version: 1, enabled: true, rules: [], reminders: [], executions: {}, manualOverrides: {}, reviewSignals: {} },
+    accounts: [{ id:'account-main', name:'Main account' }],
+    budgets: [{ id:'budget-fuel', category:'Fuel' }, { id:'budget-food', category:'Food' }],
+    transactions,
+    documents: transactions.map((tx, index)=>({ id:tx.sourceDocumentId, importedAt:`2026-08-10T10:${String(index % 60).padStart(2,'0')}:00.000Z` })),
+    tasks: [], reviewItems: []
+  };
+}
+
+function fuelRule(overrides={}) {
+  return {
+    id:'rule_fictional_fuel', name:'Fictional fuel to Fuel', enabled:false,
+    trigger:AUTOMATION_RULE_TRIGGER.TRANSACTION_CHANGE,
+    conditions:[{ id:'merchant', field:AUTOMATION_RULE_CONDITION.MERCHANT, operator:'equals', value:'Fictional Fuel' }],
+    action:{ type:AUTOMATION_RULE_ACTION.ASSIGN_BUDGET, value:'budget-fuel' },
+    explanation:'Assign the fictional fuel merchant to Fuel.',
+    activationMode:AUTOMATION_RULE_ACTIVATION.FUTURE_ONLY, activatedAt:null,
+    ...overrides
+  };
+}
+
+test('dry run uses real proposal execution guard without mutating state or revision', async () => {
+  let state = stateWithTransactions();
+  state = upsertAutomationRule(state, fuelRule(), new Date('2026-08-11T11:00:00.000Z'));
+  const before = structuredClone(state);
+  const preview = await previewStoredAutomationRules(state, { ruleId:'rule_fictional_fuel', now:new Date('2026-08-11T12:00:00.000Z') });
+  assert.deepEqual(state, before);
+  assert.equal(state.meta.revision, 11);
+  assert.equal(Object.keys(state.automation.executions).length, 0);
+  assert.equal(state.tasks.length, 0);
+  assert.equal(state.reviewItems.length, 0);
+  assert.equal(preview.nothingChanged, true);
+  assert.equal(preview.matchedRecordCount, 1);
+  assert.equal(preview.wouldApplyCount, 1);
+  assert.equal(preview.items[0].reasonCode, 'preview_only');
+});
+
+test('unsaved disabled rule can be tested without persisting it', async () => {
+  const state = stateWithTransactions();
+  const before = structuredClone(state);
+  const preview = await previewStoredAutomationRules(state, { rule:fuelRule({ id:'rule_preview_draft' }), now:new Date('2026-08-11T12:00:00.000Z') });
+  assert.equal(preview.matchedRecordCount, 1);
+  assert.deepEqual(state, before);
+  assert.equal(state.automation.rules.length, 0);
+});
+
+test('preview explains conflicts with an active peer rule', async () => {
+  let state = stateWithTransactions();
+  state = upsertAutomationRule(state, fuelRule(), new Date('2026-08-11T10:00:00.000Z'));
+  state = upsertAutomationRule(state, fuelRule({ id:'rule_food', name:'Conflicting food rule', enabled:true, action:{ type:AUTOMATION_RULE_ACTION.ASSIGN_BUDGET, value:'budget-food' } }), new Date('2026-08-11T10:05:00.000Z'));
+  const before = structuredClone(state);
+  const preview = await previewStoredAutomationRules(state, { ruleId:'rule_fictional_fuel', now:new Date('2026-08-11T12:00:00.000Z') });
+  assert.equal(preview.conflictCount, 1);
+  assert.equal(preview.reviewRequiredCount, 1);
+  assert.equal(preview.items[0].status, 'conflict');
+  assert.match(preview.items[0].explanation, /leave this item unchanged/i);
+  assert.deepEqual(state, before);
+});
+
+test('large previews are bounded while keeping full counts', async () => {
+  let state = stateWithTransactions(150);
+  state = upsertAutomationRule(state, fuelRule(), new Date('2026-08-11T11:00:00.000Z'));
+  const preview = await previewStoredAutomationRules(state, { ruleId:'rule_fictional_fuel', now:new Date('2026-08-11T12:00:00.000Z') });
+  assert.equal(preview.evaluatedCount, 150);
+  assert.equal(preview.matchedRecordCount, 150);
+  assert.equal(preview.totalDetailCount, 150);
+  assert.equal(preview.items.length, 100);
+  assert.equal(preview.truncated, true);
+  assert.equal(preview.detailLimit, 100);
+});
+
+test('activation leaves existing imported records alone and permits later imported matches', async () => {
+  let state = stateWithTransactions();
+  state = upsertAutomationRule(state, fuelRule(), new Date('2026-08-11T11:00:00.000Z'));
+  state = setAutomationRuleEnabled(state, 'rule_fictional_fuel', true, new Date('2026-08-11T12:00:00.000Z'));
+  assert.equal(state.automation.rules[0].activatedAt, '2026-08-11T12:00:00.000Z');
+  let result = await runStoredAutomationRules(state, { now:new Date('2026-08-11T12:10:00.000Z'), recoveryMode:'normal' });
+  assert.equal(result.changed, false);
+  assert.equal(result.state.transactions[0].budgetCategoryId, '');
+
+  state = result.state;
+  state.transactions.push({ id:'tx-new', accountId:'account-main', date:'2026-08-01', merchantName:'Fictional Fuel', description:'Fictional Fuel', outgoing:40, incoming:0, category:'', budgetCategoryId:'', categorySource:'imported', financiallyActive:true, sourceDocumentId:'doc-new' });
+  state.documents.push({ id:'doc-new', importedAt:'2026-08-11T12:30:00.000Z' });
+  result = await runStoredAutomationRules(state, { now:new Date('2026-08-11T12:35:00.000Z'), recoveryMode:'normal' });
+  assert.equal(result.changed, true);
+  assert.equal(result.state.transactions.find((tx)=>tx.id === 'tx-1').budgetCategoryId, '');
+  assert.equal(result.state.transactions.find((tx)=>tx.id === 'tx-new').budgetCategoryId, 'budget-fuel');
+});
+
+test('recovery-mode preview is read-only and reports the block', async () => {
+  let state = stateWithTransactions();
+  state = upsertAutomationRule(state, fuelRule(), new Date('2026-08-11T11:00:00.000Z'));
+  const before = structuredClone(state);
+  const preview = await previewStoredAutomationRules(state, { ruleId:'rule_fictional_fuel', recoveryMode:'recovery_required', now:new Date('2026-08-11T12:00:00.000Z') });
+  assert.equal(preview.blockedCount, 1);
+  assert.equal(preview.items[0].reasonCode, 'recovery_mode_active');
+  assert.deepEqual(state, before);
+});
+
+test('retrospective application remains unavailable and separate from preview', async () => {
+  let state = stateWithTransactions();
+  state = upsertAutomationRule(state, fuelRule(), new Date('2026-08-11T11:00:00.000Z'));
+  const preview = await previewStoredAutomationRules(state, { ruleId:'rule_fictional_fuel', now:new Date('2026-08-11T12:00:00.000Z') });
+  assert.equal(preview.retrospective.supported, false);
+  assert.equal(preview.retrospective.automatic, false);
+  assert.equal(preview.retrospective.requiresSeparateConfirmation, true);
+});

--- a/tests/automation-rules.test.js
+++ b/tests/automation-rules.test.js
@@ -170,9 +170,9 @@ test('compatible duplicate actions deduplicate and conflicting categories fail s
   assert.ok(result.results.some((row) => row.reasonCode === 'rule_conflict'));
 });
 
-test('preview includes a paused rule but never mutates state', () => {
+test('preview includes a paused rule but never mutates state', async () => {
   const state = upsertAutomationRule(baseState(), { ...merchantBudgetRule(), enabled: false }, new Date('2026-08-11T11:00:00.000Z'));
-  const preview = previewStoredAutomationRules(state, { ruleId: 'rule_tesco_fuel', now: new Date('2026-08-11T12:00:00.000Z') });
+  const preview = await previewStoredAutomationRules(state, { ruleId: 'rule_tesco_fuel', now: new Date('2026-08-11T12:00:00.000Z') });
   assert.equal(preview.matchCount, 1);
   assert.equal(state.transactions[0].budgetCategoryId, '');
 });
@@ -215,7 +215,7 @@ test('date-relative recurring rule creates one local reminder for a confirmed pa
 });
 
 test('rules implementation has no network, telemetry or analytics dependency', async () => {
-  for (const file of ['automation-rule-model.js', 'automation-rules.js']) {
+  for (const file of ['automation-rule-model.js', 'automation-rules.js', 'automation-rules-core.js']) {
     const source = await fs.readFile(new URL(`../${file}`, import.meta.url), 'utf8');
     assert.doesNotMatch(source, /from ['"]node:(?:http|https|net|tls|dns)['"]/);
     assert.doesNotMatch(source, /\bfetch\s*\(/);


### PR DESCRIPTION
## Purpose
Implement #80 with a private, local-only Automation **Test Rule / Dry Run** flow that uses the authoritative automation evaluation and safety path while guaranteeing preview does not mutate financial state.

## Work completed
- Added Test Rule for saved, disabled and unsaved draft rules.
- Reused real proposal evaluation and `executeAutomationProposal(..., previewOnly: true)` for dry-run safety semantics.
- Added clear preview counts for evaluated records, matches, would-apply outcomes, review-required outcomes, conflicts, duplicates, blocked outcomes and already-applied outcomes.
- Added bounded preview details with progressive disclosure for large histories.
- Added existing-record vs future-activity messaging and explicit confirmation before activation.
- New and materially edited rules are saved paused; activation records a future-only boundary so existing history is not silently rewritten.
- Preserved legacy behaviour for already-configured rules that predate activation metadata.
- Integrated with current automation history: real runs continue through the history runner, while dry-run preview never records history.
- Recovery-mode preview remains read-only and surfaces blocked outcomes rather than mutating state.
- Added the new automation rule core module to Electron Builder packaging after CI correctly identified the missing packaged dependency.

## Files changed
- `automation-rule-model.js`
- `automation-rules-core.js` (new)
- `automation-rules.js`
- `automation-rules-ui.js`
- `main-entry.js`
- `package.json`
- `tests/automation-rules.test.js`
- `tests/automation-preview.test.js` (new)
- `tests/automation-preview-ui.test.js` (new)

## User-facing changes
- Rule cards and the rule editor now expose **Test Rule**.
- Preview explicitly states **“Preview only — nothing has been changed.”**
- Preview distinguishes existing matches from what will happen to future matching activity.
- Conflicts, review-required and blocked outcomes are visible before activation.
- Large result sets are summarized first, with bounded detail disclosure.
- Enabling a paused rule requires a preview and a separate confirmation.
- Existing matching records are not automatically rewritten when a new/materially changed rule is enabled.

## Technical changes
- Added optional `activationMode` / `activatedAt` rule metadata with conservative future-only enforcement for newly activated rules.
- Split reusable rule evaluation/execution helpers into `automation-rules-core.js` so preview and execution share the same authoritative logic.
- Preview evaluates existing contexts deliberately, including active peer rules for conflict semantics, but invokes the real execution guard with `previewOnly`.
- Future-only transaction execution uses trustworthy local activity timestamps (`updatedAt`, `createdAt`, `importedAt`, or source-document `importedAt`) and skips conservatively when none exists.
- Real execution continues through `runStoredAutomationRulesWithHistory`; preview bypasses history recording entirely.
- Packaged Windows builds include `automation-rules-core.js` through `build.files`.
- No new network, telemetry, analytics or cloud path was added.

## Testing and verification
- **Passed:** focused pre-push Node tests — 23/23 (`automation-preview`, `automation-preview-ui`, `automation-rules`).
- **Passed:** focused pre-push syntax checks for all modified/new source and test files.
- **Passed:** focused pre-push privacy/static checks — no HTTP/HTTPS/net/tls/dns imports, `fetch`, telemetry or analytics path in the automation preview implementation/UI.
- **Passed — GitHub Actions Linux:** Git/PR conventions, `npm ci`, full `npm test`, `npm run check`, and `npm run lint`.
- **Passed — GitHub Actions Windows:** `npm ci`, full `npm test`, `npm run check`, `npm run lint`, built Pages runtime smoke test, Electron desktop startup smoke test, and Windows packaging smoke test.
- **Skipped by workflow as expected:** release publication job because this is a pull request, not a release-tag push.
- **Not represented as automated coverage:** manual hands-on Electron Test Rule/activation/cancel/theme/accessibility review was not performed in the headless workflow.

## Data and migration impact
- Adds optional automation-rule activation metadata only.
- Existing rules without that metadata normalize to legacy execution behaviour, avoiding a silent behavioural migration.
- Newly enabled or materially changed rules use future-only activation metadata.
- Preview itself does not increment revision, write financial values, create reminders, create Review Inbox items, create execution history or advance idempotency markers.
- No destructive stored-data migration is introduced.

## Known limitations
- Retrospective apply is intentionally **not supported** by this v2.2.0 change; it is reported separately in preview rather than being performed implicitly.
- A future-only transaction without a trustworthy local activity timestamp is skipped conservatively rather than risking historical mutation.
- Manual hands-on Electron/theme/accessibility review remains for user review; automated Electron startup and Windows packaging both pass.

## Excluded work
- AI-generated rule suggestions.
- Simulated external transactions.
- Cloud sandbox/testing.
- Generic financial What-If forecasting.
- Any automatic retrospective rewrite of historical data.

## Branch details
- **Branch:** `feature/automation-preview-test-rule`
- **Commit SHA:** `8760b6c1faac8d58806d6e83ca28607d061bc759`
- **Pull request:** #139
- **Target branch:** `main`

## Confirmations
- No changes were committed or pushed directly to `main`.
- This PR has **not** been merged by this workflow.
- No force-push or shared-history rewrite was performed.
- The original `feature/automation-preview` branch remains untouched after being superseded for commit-convention compliance.
- No personal financial data, imported documents, credentials, secrets or sensitive financial logs were committed.
- Only files relevant to #80 were changed.

#80 remains open during Review and should only move to Done after user review and merge.