### PR TITLE
[Superseded][Maintenance] Adaptive payday planning branch correction

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
       "next-move-priority.js",
       "payment-bulk-review.js",
       "payment-bulk-review-ui.js",
+      "payday-allocation.js",
+      "payday-allocation-ui.js",
       "payday-awareness.js",
       "payday-awareness-ui.js",
       "pdf-service.js",

--- a/payday-allocation-ui.js
+++ b/payday-allocation-ui.js
@@ -1,0 +1,216 @@
+import { formatCurrency, formatDate } from './finance-core.js';
+import {
+  buildPaydayAllocationPlan, PAYDAY_ALLOCATION_STATUS, PAYDAY_FUNDING_STATUS,
+  setPaydayPlanningChoiceAccepted, setPaydayPlanningPreferences
+} from './payday-allocation.js';
+
+const STATUS = Object.freeze({
+  [PAYDAY_ALLOCATION_STATUS.WAITING_FOR_INCOME]: ['Waiting for received income', ''],
+  [PAYDAY_ALLOCATION_STATUS.READY]: ['Payday plan ready', 'green'],
+  [PAYDAY_ALLOCATION_STATUS.BUDGET_SHORTFALL]: ['Budget gap is visible', 'amber'],
+  [PAYDAY_ALLOCATION_STATUS.PROTECTED_SHORTFALL]: ['Protected needs exceed payday money', 'amber'],
+  [PAYDAY_ALLOCATION_STATUS.NEEDS_REVIEW]: ['Review safety blockers', 'amber']
+});
+let queued = false;
+let running = false;
+let rerun = false;
+let saving = false;
+
+export function buildPaydayAllocationPresentationModel(plan) {
+  return {
+    status: plan?.status || PAYDAY_ALLOCATION_STATUS.NEEDS_REVIEW,
+    income: plan?.income || null,
+    horizonDate: plan?.horizonDate || null,
+    availableForPlanning: Number(plan?.availableForPlanning || 0),
+    protectedCommitments: plan?.protectedCommitments || emptyGroup(),
+    requiredDebt: plan?.requiredDebt || emptyGroup(),
+    buffer: plan?.buffer || { required: 0, funded: 0, shortfall: 0 },
+    budget: plan?.budget || { required: 0, funded: 0, shortfall: 0, categories: [] },
+    optionalDebt: plan?.optionalDebt || {}, optionalSavings: plan?.optionalSavings || {},
+    leftoverUnallocated: Number(plan?.leftoverUnallocated || 0), warnings: plan?.warnings || [],
+    preferences: plan?.preferences || {}, why: plan?.why || []
+  };
+}
+
+function boot() {
+  if (!window.financeAPI?.loadState) return;
+  ensureHost();
+  document.addEventListener('click', handleClick, true);
+  document.addEventListener('submit', handleSubmit, true);
+  document.addEventListener('change', (event) => {
+    if (!document.getElementById('paydayAllocationPanel')?.contains(event.target)) window.setTimeout(scheduleRefresh, 120);
+  }, true);
+  window.addEventListener('focus', scheduleRefresh);
+  observeRenders();
+  scheduleRefresh();
+}
+
+function ensureHost() {
+  if (document.getElementById('paydayAllocationPanel')) return;
+  const view = document.getElementById('view-today');
+  if (!view) return;
+  const panel = document.createElement('section');
+  panel.id = 'paydayAllocationPanel'; panel.className = 'panel'; panel.setAttribute('aria-labelledby', 'paydayAllocationTitle');
+  panel.innerHTML = [
+    '<div class="panel-heading"><div><p class="eyebrow">PAYDAY ALLOCATION</p><h2 id="paydayAllocationTitle">Protect the important money first</h2><p class="muted">A local plan for money already received. It never moves money or makes payments.</p></div><span id="paydayAllocationBadge" class="badge">Loading</span></div>',
+    '<div id="paydayAllocationMetrics" class="metric-grid three"></div>',
+    '<div id="paydayAllocationWarnings"></div><div id="paydayAllocationSteps" class="compact-card-list"></div>',
+    '<details class="plan-why"><summary>Why?</summary><ul id="paydayAllocationWhy"></ul></details>',
+    '<form id="paydayAllocationPreferences" class="form-grid" novalidate><h3>Planning preferences</h3>',
+    '<label>Flexible Budget allowance · optional override<input id="paydayFlexibleAllowance" type="number" min="0" step="0.01" inputmode="decimal" /></label>',
+    '<label>Safe optional priority debt<select id="paydayOptionalDebt"><option value="">Use current safe recommendation</option></select></label>',
+    '<label class="confirmation-check"><input id="paydayDeclineOptionalDebt" type="checkbox" />Do not include an optional debt overpayment</label>',
+    '<label>Optional savings target<input id="paydayOptionalSavings" type="number" min="0" step="0.01" inputmode="decimal" /></label>',
+    '<div class="button-row"><button class="primary-button" type="submit">Save planning preferences</button><button id="paydayOpenBufferSettings" class="secondary-button" type="button">Adjust buffer in Settings</button></div>',
+    '<p id="paydayAllocationPreferenceStatus" class="muted" role="status" aria-live="polite"></p></form>'
+  ].join('');
+  const existing = document.getElementById('paydayTodayPanel');
+  if (existing?.parentElement === view) existing.after(panel);
+  else { const metrics = view.querySelector('.metric-grid'); if (metrics) metrics.before(panel); else view.prepend(panel); }
+}
+
+function observeRenders() {
+  for (const id of ['view-today', 'todaySupportingList', 'cashFlowValue']) {
+    const target = document.getElementById(id); if (!target) continue;
+    new MutationObserver(scheduleRefresh).observe(target, { attributes: true, childList: true, characterData: true, subtree: id !== 'view-today' });
+  }
+}
+
+function handleClick(event) {
+  if (event.target.closest('#paydayOpenBufferSettings')) { document.querySelector('.nav-button[data-view="settings"]')?.click(); return; }
+  const choice = event.target.closest('[data-payday-choice]');
+  if (choice) { saveChoice(choice.dataset.paydayChoice, choice.getAttribute('aria-pressed') !== 'true'); return; }
+  if (event.target.closest('.nav-button, [data-view-target], [data-add], [data-edit], [data-review-route], #saveSettingsButton, #saveEditButton, #confirmImportButton')) window.setTimeout(scheduleRefresh, 120);
+}
+function handleSubmit(event) { if (event.target?.id === 'paydayAllocationPreferences') { event.preventDefault(); savePreferences(); } }
+function scheduleRefresh() { if (queued || saving) return; queued = true; window.setTimeout(() => { queued = false; refresh(); }, 50); }
+
+async function refresh() {
+  if (running) { rerun = true; return; }
+  running = true;
+  try {
+    ensureHost();
+    const loaded = await window.financeAPI.loadState();
+    if (loaded?.status !== 'normal' || !loaded.state) return renderUnavailable('Payday planning is unavailable while financial data is not in normal mode.');
+    render(buildPaydayAllocationPresentationModel(buildPaydayAllocationPlan(loaded.state)));
+  } catch { renderUnavailable('The payday allocation plan could not be calculated. No financial data, transfer or payment was changed.'); }
+  finally { running = false; if (rerun) { rerun = false; scheduleRefresh(); } }
+}
+
+function render(model) {
+  const [label, tone] = STATUS[model.status] || STATUS[PAYDAY_ALLOCATION_STATUS.NEEDS_REVIEW];
+  const badge = byId('paydayAllocationBadge'); badge.textContent = label; badge.className = `badge ${tone}`.trim();
+  replace(byId('paydayAllocationMetrics'),
+    metric('Received', model.income ? money(model.income.amountReceived) : 'Not received', model.income?.name || 'Future income is not current cash'),
+    metric('Available to plan', money(model.availableForPlanning), model.horizonDate ? `Through ${safeDate(model.horizonDate)}` : 'Planning horizon needs review'),
+    metric('Budget gap', money(model.budget.shortfall), model.budget.shortfall > 0 ? 'Visible; no assumed borrowing' : 'Active Budget currently covered'));
+
+  const warnings = byId('paydayAllocationWarnings'); replace(warnings);
+  for (const item of model.warnings) warnings.append(messageCard(item.code === 'budget_shortfall' ? 'Budget gap' : 'Needs review', item.explanation));
+
+  const steps = byId('paydayAllocationSteps'); replace(steps,
+    groupCard('1 · MUST PROTECT', 'Known commitments', model.protectedCommitments),
+    groupCard('2 · MUST PROTECT', 'Required debt payments', model.requiredDebt),
+    simpleCard('3 · MUST PROTECT', 'Starter / emergency buffer', model.buffer.required, model.buffer.funded, model.buffer.fundingStatus, model.buffer.reason),
+    budgetCard(model.budget), optionalDebtCard(model.optionalDebt), optionalSavingsCard(model.optionalSavings),
+    simpleCard('UNALLOCATED', 'Left unallocated', model.leftoverUnallocated, model.leftoverUnallocated, PAYDAY_FUNDING_STATUS.FUNDED, 'Unassigned money stays unassigned.'));
+
+  const why = byId('paydayAllocationWhy'); replace(why); for (const item of model.why) why.append(listItem(item));
+  populatePreferences(model); renderDashboard(model);
+}
+
+function groupCard(eyebrow, title, group) {
+  const card = shell(eyebrow, title, group.fundingStatus); const list = document.createElement('div'); list.className = 'dashboard-list';
+  if (!group.items.length) list.append(muted('Nothing separate is recorded for this step.'));
+  for (const item of group.items) list.append(row(item.name, item.required, item.funded, item.fundingStatus, item.date ? `Due ${safeDate(item.date)}` : 'Protected'));
+  card.append(list, totals(group.required, group.funded, group.shortfall)); return card;
+}
+function budgetCard(budget) {
+  const card = shell('4 · RECOMMENDED', 'Cover the active Budget', budget.shortfall > 0 ? PAYDAY_FUNDING_STATUS.PARTIALLY_FUNDED : PAYDAY_FUNDING_STATUS.FUNDED);
+  card.append(muted(budget.userOverride ? `Saved flexible allowance: ${money(budget.requestedFlexibleAllowance)}. The complete Budget remains visible.` : 'Every active Budget category remains visible; short funding is shared proportionally.'));
+  const list = document.createElement('div'); list.className = 'dashboard-list';
+  if (!budget.categories.length) list.append(muted('No active Budget categories are recorded.'));
+  for (const item of budget.categories) { const itemRow = row(item.name, item.required, item.funded, item.fundingStatus, item.section || 'Budget'); itemRow.append(choiceButton(item.choiceId, item.accepted)); list.append(itemRow); }
+  card.append(list, totals(budget.required, budget.funded, budget.shortfall));
+  if (budget.shortfall > 0) card.append(muted(`${money(budget.shortfall)} remains uncovered. A later income can be reconsidered only after it is received.`));
+  return card;
+}
+function optionalDebtCard(item) {
+  const card = shell('5 · OPTIONAL', 'Additional debt payment', item.funded > 0 ? PAYDAY_FUNDING_STATUS.FUNDED : PAYDAY_FUNDING_STATUS.UNFUNDED);
+  card.append(muted(item.reason || 'No optional debt allocation is recommended.'));
+  if (item.debtId) card.append(row(item.name, item.maximumSafeAmount || 0, item.funded || 0, item.fundingStatus, 'Safety ceiling, not a required payment'));
+  card.append(choiceButton(item.choiceId || 'optional-debt', item.accepted)); return card;
+}
+function optionalSavingsCard(item) {
+  const card = shell('6 · OPTIONAL', 'Savings / discretionary allocation', item.fundingStatus);
+  card.append(row(item.name || 'Optional savings', item.target || 0, item.funded || 0, item.fundingStatus, item.reason || 'No target set.'));
+  card.append(choiceButton(item.choiceId || 'optional-savings', item.accepted)); return card;
+}
+function simpleCard(eyebrow, title, required, funded, status, detail) { const card = shell(eyebrow, title, status); card.append(row(title, required, funded, status, detail || '')); return card; }
+
+function shell(eyebrow, title, status) {
+  const card = document.createElement('article'); card.className = 'review-card';
+  const heading = document.createElement('div'); heading.className = 'review-card-heading';
+  const copy = document.createElement('div'); const e = document.createElement('p'); e.className = 'eyebrow'; e.textContent = eyebrow;
+  const h = document.createElement('h3'); h.textContent = title; copy.append(e, h); heading.append(copy, statusBadge(status)); card.append(heading); return card;
+}
+function row(name, required, funded, status, detail) {
+  const out = document.createElement('div'); out.className = 'dashboard-list-row horizontal'; const copy = document.createElement('div');
+  const strong = document.createElement('strong'); strong.textContent = name; const small = document.createElement('span'); small.textContent = `${fundingLabel(status)}${detail ? ` · ${detail}` : ''}`;
+  const amount = document.createElement('strong'); amount.textContent = required > 0 ? `${money(funded)} / ${money(required)}` : money(funded); copy.append(strong, small); out.append(copy, amount); return out;
+}
+function totals(required, funded, shortfall) { return muted(`${money(funded)} covered of ${money(required)}${shortfall > 0 ? ` · ${money(shortfall)} short` : ''}`); }
+function statusBadge(status) { const node = document.createElement('span'); node.className = `badge ${status === PAYDAY_FUNDING_STATUS.FUNDED ? 'green' : status === PAYDAY_FUNDING_STATUS.PARTIALLY_FUNDED || status === PAYDAY_FUNDING_STATUS.NEEDS_REVIEW ? 'amber' : ''}`.trim(); node.textContent = fundingLabel(status); return node; }
+function choiceButton(id, accepted) { const button = document.createElement('button'); button.type = 'button'; button.className = 'text-button'; button.dataset.paydayChoice = id; button.setAttribute('aria-pressed', String(Boolean(accepted))); button.textContent = accepted ? 'Accepted in plan' : 'Accept in plan'; return button; }
+
+function populatePreferences(model) {
+  byId('paydayFlexibleAllowance').value = model.preferences.flexibleAllowance ?? '';
+  const debt = byId('paydayOptionalDebt'); replace(debt, option('', 'Use current safe recommendation'));
+  for (const item of model.optionalDebt.options || []) debt.append(option(item.id, `${item.name} · ${money(item.balance)}`));
+  debt.value = [...debt.options].some((item) => item.value === model.preferences.optionalDebtId) ? model.preferences.optionalDebtId : '';
+  byId('paydayDeclineOptionalDebt').checked = model.preferences.optionalDebtDeclined === true;
+  byId('paydayOptionalSavings').value = model.preferences.optionalSavingsTarget || '';
+}
+
+async function savePreferences() {
+  await savePlanningState((state) => setPaydayPlanningPreferences(state, {
+    flexibleAllowance: inputMoney('paydayFlexibleAllowance', null), optionalDebtId: byId('paydayOptionalDebt').value,
+    optionalDebtDeclined: byId('paydayDeclineOptionalDebt').checked, optionalSavingsTarget: inputMoney('paydayOptionalSavings', 0)
+  }), 'Planning preferences saved.');
+}
+async function saveChoice(id, accepted) { await savePlanningState((state) => setPaydayPlanningChoiceAccepted(state, id, accepted), accepted ? 'Planning choice accepted.' : 'Planning choice removed.'); }
+async function savePlanningState(update, success) {
+  if (saving) return; saving = true; const status = byId('paydayAllocationPreferenceStatus'); status.textContent = 'Saving…';
+  try {
+    const loaded = await window.financeAPI.loadState(); if (loaded?.status !== 'normal' || !loaded.state) throw new Error('Financial data is not available for editing.');
+    const saved = await window.financeAPI.saveState(update(loaded.state));
+    if (saved?.status === 'blocked') throw new Error(saved.message || 'Saving is paused while recovery is required.');
+    if (saved?.status === 'conflict') { status.textContent = 'Your data changed at the same time. Nothing was overwritten; try again.'; return; }
+    status.textContent = success; window.location.reload();
+  } catch (error) { status.textContent = error?.message || 'The planning preference could not be saved.'; }
+  finally { saving = false; }
+}
+
+function renderDashboard(model) {
+  const host = document.querySelector('[data-dashboard-module="upcoming"]'); if (!host) return;
+  let item = byId('dashboardPaydayAllocation'); if (!item) { item = document.createElement('div'); item.id = 'dashboardPaydayAllocation'; item.className = 'dashboard-list-row horizontal'; host.append(item); }
+  replace(item); const label = document.createElement('span'); label.textContent = model.income ? 'Payday plan' : 'Payday planning'; const value = document.createElement('strong');
+  value.textContent = model.status === PAYDAY_ALLOCATION_STATUS.READY ? `${money(model.leftoverUnallocated)} unallocated`
+    : model.status === PAYDAY_ALLOCATION_STATUS.WAITING_FOR_INCOME ? 'Waiting for income'
+      : model.budget.shortfall > 0 ? `${money(model.budget.shortfall)} Budget gap` : 'Needs review'; item.append(label, value);
+}
+function renderUnavailable(message) { ensureHost(); replace(byId('paydayAllocationWarnings'), messageCard('Payday plan unavailable', message)); }
+function messageCard(title, text) { const card = document.createElement('article'); card.className = 'check-card warning'; const strong = document.createElement('strong'); strong.textContent = title; const p = document.createElement('p'); p.textContent = text; card.append(strong, p); return card; }
+function metric(label, value, hint) { const card = document.createElement('article'); card.className = 'metric-card'; const a = document.createElement('span'); a.textContent = label; const b = document.createElement('strong'); b.textContent = value; const c = document.createElement('small'); c.textContent = hint; card.append(a, b, c); return card; }
+function fundingLabel(status) { return ({ funded: 'Funded', partially_funded: 'Partially funded', unfunded: 'Unfunded', needs_review: 'Needs review' })[status] || 'Needs review'; }
+function safeDate(value) { try { return formatDate(value); } catch { return String(value || 'Unknown date'); } }
+function money(value) { return Number.isFinite(Number(value)) ? formatCurrency(Number(value)) : 'Unavailable'; }
+function inputMoney(id, fallback) { const value = byId(id).value; return value === '' ? fallback : Math.max(0, Number(value) || 0); }
+function option(value, label) { const node = document.createElement('option'); node.value = value; node.textContent = label; return node; }
+function muted(text) { const p = document.createElement('p'); p.className = 'muted'; p.textContent = text; return p; }
+function listItem(text) { const li = document.createElement('li'); li.textContent = text; return li; }
+function emptyGroup() { return { required: 0, funded: 0, shortfall: 0, fundingStatus: PAYDAY_FUNDING_STATUS.FUNDED, items: [] }; }
+function byId(id) { return document.getElementById(id); }
+function replace(node, ...children) { if (node) node.replaceChildren(...children); }
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') boot();

--- a/payday-allocation.js
+++ b/payday-allocation.js
@@ -1,0 +1,268 @@
+import { buildCashFlowForecast } from './cash-flow-forecast.js';
+import { buildDebtRecommendation, DEBT_RECOMMENDATION_STATUS } from './debt-recommendation-engine.js';
+import { buildPaydayContext, PAYDAY_STATUS } from './payday-awareness.js';
+import { buildUnifiedFinancialProfile, UNIFIED_FACT_STATUS } from './unified-financial-profile.js';
+
+export const PAYDAY_ALLOCATION_VERSION = 1;
+export const PAYDAY_ALLOCATION_STATUS = Object.freeze({
+  WAITING_FOR_INCOME: 'waiting_for_income', READY: 'ready', BUDGET_SHORTFALL: 'budget_shortfall',
+  PROTECTED_SHORTFALL: 'protected_shortfall', NEEDS_REVIEW: 'needs_review'
+});
+export const PAYDAY_FUNDING_STATUS = Object.freeze({
+  FUNDED: 'funded', PARTIALLY_FUNDED: 'partially_funded', UNFUNDED: 'unfunded', NEEDS_REVIEW: 'needs_review'
+});
+export const PAYDAY_PLANNING_PREFERENCES_VERSION = 1;
+
+export function normalisePaydayPlanningPreferences(value) {
+  const source = plainObject(value) ? value : {};
+  return {
+    version: PAYDAY_PLANNING_PREFERENCES_VERSION,
+    flexibleAllowance: moneyOrNull(source.flexibleAllowance),
+    optionalDebtId: safeId(source.optionalDebtId),
+    optionalDebtDeclined: source.optionalDebtDeclined === true,
+    optionalSavingsTarget: moneyOrNull(source.optionalSavingsTarget) ?? 0,
+    acceptedChoiceIds: [...new Set((Array.isArray(source.acceptedChoiceIds) ? source.acceptedChoiceIds : []).map(safeId).filter(Boolean))].slice(0, 100)
+  };
+}
+
+export function setPaydayPlanningPreferences(state = {}, patch = {}) {
+  const next = structuredClone(state || {});
+  next.profile = plainObject(next.profile) ? next.profile : {};
+  const current = normalisePaydayPlanningPreferences(next.profile.paydayPlanningPreferences);
+  next.profile.paydayPlanningPreferences = normalisePaydayPlanningPreferences({ ...current, ...(patch || {}) });
+  delete next.paydayAllocationPlan;
+  delete next.paydayAllocationSnapshot;
+  return next;
+}
+
+export function setPaydayPlanningChoiceAccepted(state = {}, choiceId, accepted = true) {
+  const id = safeId(choiceId);
+  if (!id) return structuredClone(state || {});
+  const current = normalisePaydayPlanningPreferences(state?.profile?.paydayPlanningPreferences);
+  const acceptedChoiceIds = accepted ? [...new Set([...current.acceptedChoiceIds, id])] : current.acceptedChoiceIds.filter((item) => item !== id);
+  return setPaydayPlanningPreferences(state, { acceptedChoiceIds });
+}
+
+export function buildPaydayAllocationPlan(state = {}, options = {}) {
+  const now = validDate(options.now);
+  const today = validDateKey(options.today) ? options.today : localDateKey(now);
+  const profile = options.profile || buildUnifiedFinancialProfile(state, { now });
+  const payday = options.paydayContext || buildPaydayContext(state, { now });
+  const forecast = options.forecast || buildCashFlowForecast(state, { now, profile, paydayContext: payday });
+  const debt = options.debtRecommendation || buildDebtRecommendation(state, { now, profile, paydayContext: payday, forecast });
+  const preferences = normalisePaydayPlanningPreferences(state?.profile?.paydayPlanningPreferences);
+  const context = { today, profile, payday, forecast, debt, preferences };
+  const received = receivedStreams(payday);
+  const requested = safeId(options.streamId);
+  const stream = requested ? received.find((item) => String(item.id) === requested) : received[0];
+  return deepFreeze(stream ? activePlan(context, stream) : waitingPlan(context));
+}
+
+function waitingPlan(context) {
+  const horizonDate = nextHorizon(context.payday, context.today);
+  const budget = budgetCoverage(context.profile, 0, true, context.preferences);
+  return finish(context, {
+    id: `payday-allocation:${horizonDate || 'waiting'}`, status: PAYDAY_ALLOCATION_STATUS.WAITING_FOR_INCOME,
+    income: null, horizonDate, availableForPlanning: 0,
+    protectedCommitments: emptyGroup('protected_commitments'), requiredDebt: emptyGroup('required_debt'),
+    buffer: allocation('buffer', 'Protected starter / emergency buffer', bufferShortfall(context.profile), 0, true),
+    budget, optionalDebt: optionalDebt(context, 0, false), optionalSavings: optionalSavings(context, 0, true),
+    leftoverUnallocated: 0,
+    warnings: [{ code: 'income_not_received', explanation: 'Expected future income is not allocated until trusted received evidence exists.' }],
+    blockerCodes: ['income_not_received']
+  });
+}
+
+function activePlan(context, stream) {
+  const received = round(moneyOrNull(stream?.received?.amount) ?? 0);
+  const liquid = trustedLiquid(context.profile);
+  const availableForPlanning = liquid === null ? 0 : round(Math.min(received, Math.max(0, liquid)));
+  const horizonDate = nextHorizon(context.payday, context.today);
+  const safe = context.payday?.safeUntilPayday || {};
+  const blockers = [];
+  const warnings = [];
+
+  if (liquid === null) blockers.push('trusted_liquid_position_unavailable');
+  if (!horizonDate) blockers.push('dependable_payday_unknown');
+  if (safe.status !== 'available') blockers.push(...(safe.reasonCodes || ['safe_until_payday_unavailable']).map((code) => `payday_${safeId(code)}`));
+  else if (safe.horizonDate !== horizonDate) blockers.push('payday_horizon_mismatch');
+  if (context.forecast?.status === 'unavailable') blockers.push('forecast_unavailable');
+  for (const item of context.forecast?.blockers || []) warnings.push({ code: `forecast_${safeId(item.code) || 'review'}`, explanation: String(item.explanation || item.reason || 'The forecast contains an unresolved safety condition.') });
+
+  let remaining = availableForPlanning;
+  const protectedTarget = round(nonNegative(safe?.protected?.scheduled) + nonNegative(safe?.protected?.recurring));
+  const protectedCommitments = groupAllocation('protected_commitments', protectedItems(safe), protectedTarget, remaining);
+  remaining = round(Math.max(0, remaining - protectedCommitments.funded));
+  const debtTarget = round(nonNegative(safe?.protected?.debt));
+  const requiredDebt = groupAllocation('required_debt', debtItems(safe), debtTarget, remaining);
+  remaining = round(Math.max(0, remaining - requiredDebt.funded));
+  const buffer = allocation('buffer', 'Protected starter / emergency buffer', nonNegative(safe?.protected?.buffer), Math.min(nonNegative(safe?.protected?.buffer), remaining), false);
+  buffer.reason = 'The recorded starter / emergency buffer shortfall is protected before flexible or optional allocations.';
+  buffer.choiceId = 'buffer';
+  buffer.accepted = context.preferences.acceptedChoiceIds.includes('buffer');
+  remaining = round(Math.max(0, remaining - buffer.funded));
+
+  const protectedShortfall = round(protectedCommitments.shortfall + requiredDebt.shortfall + buffer.shortfall);
+  if (protectedShortfall > 0) warnings.push({ code: 'protected_shortfall', explanation: 'Received trusted money does not fully cover known protected needs before the next dependable income.' });
+
+  const hold = blockers.length > 0 || protectedShortfall > 0;
+  const budget = budgetCoverage(context.profile, hold ? 0 : remaining, hold, context.preferences);
+  if (!hold) remaining = round(Math.max(0, remaining - budget.funded));
+  if (budget.shortfall > 0) warnings.push({ code: 'budget_shortfall', explanation: 'Part of the active Budget remains uncovered. Every Budget category stays visible; the gap is not treated as cash or borrowing.' });
+
+  const canUseOptional = !hold && budget.shortfall === 0;
+  const optional = optionalDebt(context, remaining, canUseOptional);
+  remaining = round(Math.max(0, remaining - optional.funded));
+  const savings = optionalSavings(context, remaining, !canUseOptional);
+  remaining = round(Math.max(0, remaining - savings.funded));
+
+  if (received > availableForPlanning && liquid !== null) warnings.push({ code: 'received_income_exceeds_current_liquid_cash', explanation: 'The plan is capped at the lower current trusted liquid amount rather than reallocating payday money that may already have been spent.' });
+  for (const item of context.debt?.blockers || []) warnings.push({ code: `debt_${safeId(item.code) || 'review'}`, explanation: String(item.explanation || 'A debt safety condition blocks optional overpayment.') });
+
+  const status = blockers.length ? PAYDAY_ALLOCATION_STATUS.NEEDS_REVIEW
+    : protectedShortfall > 0 ? PAYDAY_ALLOCATION_STATUS.PROTECTED_SHORTFALL
+      : budget.shortfall > 0 ? PAYDAY_ALLOCATION_STATUS.BUDGET_SHORTFALL : PAYDAY_ALLOCATION_STATUS.READY;
+
+  return finish(context, {
+    id: `payday-allocation:${safeId(stream.id) || 'income'}:${stream.received?.date || context.today}`, status,
+    income: { streamId: String(stream.id || ''), name: String(stream.name || 'Received income'), receivedDate: stream.received?.date || context.today,
+      amountReceived: received, sourceTypes: [...new Set(stream.received?.sourceTypes || [])], expectedAmountRange: stream.expectedAmountRange || null,
+      expectedIncomeCountedAsCurrentCash: false },
+    horizonDate, availableForPlanning, protectedCommitments, requiredDebt, buffer, budget,
+    optionalDebt: optional, optionalSavings: savings, leftoverUnallocated: remaining,
+    warnings: uniqueWarnings(warnings), blockerCodes: [...new Set(blockers)]
+  });
+}
+
+function finish(context, values) {
+  return {
+    kind: 'payday-allocation-plan', version: PAYDAY_ALLOCATION_VERSION, derived: true, persist: false,
+    asOf: context.today, sourceRevision: context.profile?.sourceRevision ?? null, currency: context.profile?.currency || 'GBP',
+    preferences: { ...context.preferences, acceptedChoiceIds: [...context.preferences.acceptedChoiceIds] }, ...values,
+    totals: { received: values.income?.amountReceived ?? 0, availableForPlanning: values.availableForPlanning,
+      protectedCommitments: values.protectedCommitments.required, requiredDebt: values.requiredDebt.required,
+      protectedBuffer: values.buffer.required, budgetRemaining: values.budget.required, budgetFunded: values.budget.funded,
+      budgetShortfall: values.budget.shortfall, optionalDebt: values.optionalDebt.funded, optionalSavings: values.optionalSavings.funded,
+      leftoverUnallocated: values.leftoverUnallocated },
+    futureCoverage: { nextDependableIncomeDate: values.horizonDate || null, assumedFutureIncomeAmount: 0,
+      budgetShortfallAwaitingLaterReceipt: values.budget.shortfall,
+      treatment: values.budget.shortfall > 0 && values.horizonDate ? 'revisit_when_received' : 'none_required' },
+    safety: { externalTransferMade: false, externalPaymentMade: false, automaticBorrowingUsed: false,
+      futureExpectedIncomeAllocated: false, financialSafetyOverpaymentStatus: context.profile?.financialSafety?.overpaymentStatus || null,
+      forecastStatus: context.forecast?.status || 'unavailable' },
+    why: [
+      'Only trusted income already marked as received is eligible for this payday allocation plan.',
+      'Known commitments, required debt payments and the protected starter / emergency buffer come before flexible or optional money.',
+      'The complete active Budget remains visible even when available income cannot cover it all.',
+      'Expected future income can set the next horizon but is never counted as cash before receipt.',
+      'Derived guidance is recalculated from current facts; no transfer, payment, standing order or borrowing action is performed.'
+    ]
+  };
+}
+
+function budgetCoverage(profile, available, review, preferences) {
+  const categories = (profile?.budget?.categories || []).map((item) => ({
+    id: String(item.id || ''), name: String(item.name || 'Budget category'), section: String(item.section || ''),
+    required: round(Math.max(0, Number(item.remaining || 0))), monthlyPlanned: round(Math.max(0, Number(item.monthlyPlanned || 0))),
+    actual: round(Math.max(0, Number(item.actual || 0)))
+  }));
+  const required = round(categories.reduce((sum, item) => sum + item.required, 0));
+  const requested = preferences.flexibleAllowance === null ? required : round(Math.min(required, preferences.flexibleAllowance));
+  const pool = review ? 0 : round(Math.min(Math.max(0, available), requested));
+  const fundedCategories = proportionalCoverage(categories, pool, review, preferences);
+  const funded = round(fundedCategories.reduce((sum, item) => sum + item.funded, 0));
+  return { kind: 'budget_coverage', treatment: 'planning_coverage_not_recorded_spending', required, funded,
+    shortfall: round(Math.max(0, required - funded)), requestedFlexibleAllowance: requested, defaultFlexibleAllowance: required,
+    userOverride: preferences.flexibleAllowance !== null, categories: fundedCategories, allActiveCategoriesVisible: true,
+    expectedFutureIncomeAppliedToShortfall: false };
+}
+
+function proportionalCoverage(categories, pool, review, preferences) {
+  const total = categories.reduce((sum, item) => sum + item.required, 0);
+  let assigned = 0;
+  return categories.map((item, index) => {
+    let funded = review || total <= 0 ? 0 : round(pool * (item.required / total));
+    if (index === categories.length - 1) funded = round(Math.min(item.required, Math.max(0, pool - assigned)));
+    funded = Math.min(item.required, funded); assigned = round(assigned + funded);
+    const choiceId = `budget:${safeId(item.id) || index}`;
+    return { ...item, choiceId, funded, shortfall: round(Math.max(0, item.required - funded)),
+      fundingStatus: review ? PAYDAY_FUNDING_STATUS.NEEDS_REVIEW : fundingStatus(item.required, funded),
+      accepted: preferences.acceptedChoiceIds.includes(choiceId), source: 'authoritative_budget_remaining' };
+  });
+}
+
+function optionalDebt(context, available, allowed) {
+  const recommendation = context.debt || {};
+  const candidates = Array.isArray(recommendation.eligibleDebts) ? recommendation.eligibleDebts : [];
+  const selected = context.preferences.optionalDebtId ? candidates.find((item) => String(item.id) === context.preferences.optionalDebtId) : recommendation.priorityDebt;
+  const safeMaximum = round(moneyOrNull(recommendation.maximumSafeOptionalAmount) ?? 0);
+  const balance = round(moneyOrNull(selected?.balance) ?? safeMaximum);
+  const canFund = allowed && recommendation.status === DEBT_RECOMMENDATION_STATUS.AVAILABLE && selected && !context.preferences.optionalDebtDeclined;
+  const funded = canFund ? round(Math.min(Math.max(0, available), safeMaximum, balance)) : 0;
+  const choiceId = selected ? `optional-debt:${safeId(selected.id)}` : 'optional-debt';
+  return { kind: 'optional_debt', debtId: selected ? String(selected.id || '') : null, name: String(selected?.name || 'Optional debt payment'),
+    required: 0, maximumSafeAmount: safeMaximum, funded, shortfall: 0,
+    fundingStatus: funded > 0 ? PAYDAY_FUNDING_STATUS.FUNDED : PAYDAY_FUNDING_STATUS.UNFUNDED,
+    declined: context.preferences.optionalDebtDeclined, userSelectedDebt: Boolean(context.preferences.optionalDebtId),
+    options: candidates.map((item) => ({ id: String(item.id || ''), name: String(item.name || 'Eligible debt'), balance: round(moneyOrNull(item.balance) ?? 0) })),
+    choiceId, accepted: context.preferences.acceptedChoiceIds.includes(choiceId),
+    reason: context.preferences.optionalDebtDeclined ? 'The user has declined optional debt allocation.'
+      : !allowed ? 'Optional debt allocation is paused until protected needs and the active Budget are covered.'
+        : recommendation.status !== DEBT_RECOMMENDATION_STATUS.AVAILABLE ? String(recommendation.blockers?.[0]?.explanation || 'Financial Safety is not currently offering an optional debt overpayment.')
+          : 'Financial Safety permits this optional planning amount. It does not make a payment.', externalPaymentMade: false };
+}
+
+function optionalSavings(context, available, review) {
+  const target = round(context.preferences.optionalSavingsTarget);
+  const funded = review ? 0 : round(Math.min(Math.max(0, available), target));
+  return { kind: 'optional_savings', name: 'Optional savings allocation', target, required: 0, funded,
+    shortfall: round(Math.max(0, target - funded)), fundingStatus: review ? PAYDAY_FUNDING_STATUS.NEEDS_REVIEW : fundingStatus(target, funded),
+    choiceId: 'optional-savings', accepted: context.preferences.acceptedChoiceIds.includes('optional-savings'),
+    reason: target > 0 ? 'This saved planning target is considered only after protected needs and Budget coverage. No transfer is made.' : 'No optional savings target is set.',
+    externalTransferMade: false };
+}
+
+function protectedItems(safe) {
+  return [...(safe?.detail?.scheduled || []).map((item) => detail(item, 'scheduled_commitment')),
+    ...(safe?.detail?.recurring || []).map((item) => detail(item, 'recurring_commitment'))].filter(Boolean).sort(byDate);
+}
+function debtItems(safe) { return (safe?.detail?.debt || []).map((item) => detail(item, 'required_debt_payment')).filter(Boolean).sort(byDate); }
+function detail(item, kind) {
+  const amount = moneyOrNull(item?.amount); if (amount === null || amount <= 0) return null;
+  return { id: safeId(item.id) || safeId(item.name), name: String(item.name || 'Protected item'), date: validDateKey(item.date) ? item.date : null, amount: round(amount), kind };
+}
+function byDate(a, b) { return (a.date || '9999-12-31').localeCompare(b.date || '9999-12-31') || a.name.localeCompare(b.name); }
+
+function groupAllocation(kind, items, required, available) {
+  let remaining = available;
+  const fundedItems = items.map((item) => { const funded = round(Math.min(item.amount, Math.max(0, remaining))); remaining = round(Math.max(0, remaining - funded));
+    return { ...item, required: item.amount, funded, shortfall: round(item.amount - funded), fundingStatus: fundingStatus(item.amount, funded) }; });
+  let funded = round(fundedItems.reduce((sum, item) => sum + item.funded, 0));
+  if (funded < required && remaining > 0) funded = round(Math.min(required, funded + remaining));
+  return { kind, required, funded, shortfall: round(Math.max(0, required - funded)), fundingStatus: fundingStatus(required, funded), items: fundedItems };
+}
+function emptyGroup(kind) { return { kind, required: 0, funded: 0, shortfall: 0, fundingStatus: PAYDAY_FUNDING_STATUS.FUNDED, items: [] }; }
+function allocation(id, name, required, funded, review) {
+  const need = round(nonNegative(required)); const covered = round(Math.min(need, nonNegative(funded)));
+  return { id, name, required: need, funded: covered, shortfall: round(need - covered), fundingStatus: review ? PAYDAY_FUNDING_STATUS.NEEDS_REVIEW : fundingStatus(need, covered) };
+}
+function fundingStatus(required, funded) { return required <= 0 || funded >= required ? PAYDAY_FUNDING_STATUS.FUNDED : funded > 0 ? PAYDAY_FUNDING_STATUS.PARTIALLY_FUNDED : PAYDAY_FUNDING_STATUS.UNFUNDED; }
+
+function receivedStreams(payday) { return (payday?.streams || []).filter((item) => item?.status === PAYDAY_STATUS.RECEIVED && moneyOrNull(item?.received?.amount) !== null)
+  .sort((a, b) => String(b.received?.date || '').localeCompare(String(a.received?.date || '')) || String(a.id || '').localeCompare(String(b.id || ''))); }
+function nextHorizon(payday, today) {
+  if (validDateKey(payday?.nextPayday?.date) && payday.nextPayday.date > today) return payday.nextPayday.date;
+  return (payday?.streams || []).map((item) => item?.nextExpected?.date).filter((date) => validDateKey(date) && date > today).sort()[0] || null;
+}
+function trustedLiquid(profile) { const fact = profile?.liquidPosition?.total; if (fact?.status !== UNIFIED_FACT_STATUS.KNOWN) return null; const value = Number(fact.value); return Number.isFinite(value) ? round(value) : null; }
+function bufferShortfall(profile) { const value = Number(profile?.buffer?.shortfall); return Number.isFinite(value) && value > 0 ? round(value) : 0; }
+function uniqueWarnings(items) { const map = new Map(); for (const item of items) { const code = safeId(item.code) || 'review'; if (!map.has(code)) map.set(code, { code, explanation: String(item.explanation || 'Review this planning condition.') }); } return [...map.values()]; }
+function safeId(value) { return String(value || '').trim().replace(/[^a-z0-9:_-]+/gi, '-').replace(/^-+|-+$/g, '').slice(0, 160); }
+function moneyOrNull(value) { if (value === null || value === undefined || value === '') return null; const n = Number(value); return Number.isFinite(n) && n >= 0 ? n : null; }
+function nonNegative(value) { const n = Number(value); return Number.isFinite(n) && n > 0 ? n : 0; }
+function round(value) { return Math.round((Number(value) + Number.EPSILON) * 100) / 100; }
+function plainObject(value) { return Boolean(value) && typeof value === 'object' && !Array.isArray(value); }
+function validDate(value) { const date = value instanceof Date ? new Date(value.getTime()) : new Date(value || Date.now()); return Number.isNaN(date.getTime()) ? new Date() : date; }
+function validDateKey(value) { const text = String(value || ''); if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) return false; const date = new Date(`${text}T12:00:00Z`); return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === text; }
+function localDateKey(date) { return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`; }
+function deepFreeze(value) { if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value; Object.freeze(value); for (const child of Object.values(value)) deepFreeze(child); return value; }

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -44,7 +44,7 @@ contextBridge.exposeInMainWorld('financeAPI', Object.freeze({
 }));
 
 function loadFinancialPresentationModules() {
-  for (const source of ['financial-presentation-forecast.js', 'financial-presentation-debt.js']) {
+  for (const source of ['financial-presentation-forecast.js', 'financial-presentation-debt.js', 'payday-allocation-ui.js']) {
     if (document.querySelector(`script[data-financial-presentation="${source}"]`)) continue;
     const script = document.createElement('script');
     script.type = 'module';

--- a/tests/payday-allocation.test.js
+++ b/tests/payday-allocation.test.js
@@ -1,0 +1,253 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { FinanceDataStore } from '../data-store.js';
+import {
+  buildPaydayAllocationPlan,
+  PAYDAY_ALLOCATION_STATUS,
+  setPaydayPlanningPreferences
+} from '../payday-allocation.js';
+import {
+  PAYDAY_RULE,
+  PAYDAY_TIMING,
+  upsertIncomeSchedule,
+  WEEKEND_ADJUSTMENT
+} from '../payday-awareness.js';
+
+const NOW = new Date('2026-08-11T12:00:00.000Z');
+const seedPath = new URL('../seed-data.json', import.meta.url);
+const backupPassword = 'fictional-payday-password';
+
+function baseState(overrides = {}) {
+  return {
+    schemaVersion: 10,
+    meta: { createdAt: NOW.toISOString(), updatedAt: NOW.toISOString(), revision: 4 },
+    automation: { version: 1, enabled: true, executions: [], manualOverrides: [] },
+    profile: { name: '', locale: 'en-GB', currency: 'GBP', dependableIncome: 2000, paydayDay: null, incomeSchedules: [] },
+    settings: {
+      selectedMonth: '2026-08', extraDebtPayment: 0, emergencyBufferTarget: 200, emergencyBufferBalance: 50,
+      extraIncomeDebtPercent: 80, llmModel: 'qwen2.5:1.5b', reminders: { weekly: false, weeklyDay: 'monday', hour: 9 },
+      snoozedActions: {}, appearance: { theme: 'system' }, dashboard: {}
+    },
+    accounts: [{ id: 'current', name: 'Fictional Current', type: 'current', currentBalance: 2000, statementDate: '2026-08-10', active: true }],
+    transactions: [], payslips: [], taxDocuments: [], creditReports: [], debts: [], overdrafts: [], budgets: [], scheduledPayments: [],
+    documents: [], tasks: [], checkIns: [], importBatches: [], reviewItems: [],
+    ...overrides
+  };
+}
+
+function withIncomeSchedule(state, input = {}) {
+  return upsertIncomeSchedule(state, {
+    id: input.id || 'fictional-salary',
+    name: input.name || 'Fictional Employer',
+    matchText: input.matchText || input.name || 'Fictional Employer',
+    cadence: 'monthly',
+    rule: { type: PAYDAY_RULE.FIXED_DAY, day: input.day || 10, weekendAdjustment: WEEKEND_ADJUSTMENT.NONE },
+    timingRelationship: PAYDAY_TIMING.CURRENT,
+    expectedAmountRange: input.expectedAmountRange || { min: 1900, max: 2100 },
+    active: true,
+    effectiveFrom: '2026-08-01'
+  }, NOW);
+}
+
+function receivedIncome(amount = 2000, date = '2026-08-10', description = 'Fictional Employer') {
+  return {
+    id: `income-${date}-${amount}`, accountId: 'current', date, budgetMonth: date.slice(0, 7), description,
+    category: 'Income', incoming: amount, outgoing: 0, transferStatus: 'no', budgetTreatment: 'income',
+    duplicateStatus: 'none', reviewStatus: 'not_required', importReviewStatus: 'trusted', financiallyActive: true
+  };
+}
+
+function activeBudget(id, category, planned, section = 'Essentials') {
+  return { id, category, section, planned };
+}
+
+function currentDebt(overrides = {}) {
+  return {
+    id: 'fictional-loan', name: 'Fictional Loan', type: 'Personal loan', currentBalance: 500,
+    balanceEffectiveDate: '2026-08-10', apr: 0.12, contractualPayment: 50, paymentDueDate: '2026-08-22',
+    status: 'current', arrangementStatus: 'none', arrangementPayment: null, statusConflict: false, includeInPlan: true,
+    ...overrides
+  };
+}
+
+function paydayState(overrides = {}) {
+  const state = withIncomeSchedule(baseState(overrides));
+  if (!state.transactions.length) state.transactions = [receivedIncome()];
+  return state;
+}
+
+test('salary received with bills before the next payday protects those commitments first', () => {
+  const state = paydayState({
+    scheduledPayments: [{ id: 'essential-bill', name: 'Fictional Essential Bill', amount: 100, dueDate: '2026-08-20', status: 'due', includedInBudget: false }],
+    budgets: [activeBudget('food', 'Food', 300)]
+  });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.equal(plan.income.amountReceived, 2000);
+  assert.equal(plan.horizonDate, '2026-09-10');
+  assert.equal(plan.protectedCommitments.required, 100);
+  assert.equal(plan.protectedCommitments.funded, 100);
+  assert.equal(plan.safety.futureExpectedIncomeAllocated, false);
+  assert.equal(plan.safety.externalPaymentMade, false);
+});
+
+test('required debt minimums are protected before flexible or optional allocation', () => {
+  const state = paydayState({ debts: [currentDebt()], budgets: [activeBudget('food', 'Food', 300)] });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.equal(plan.requiredDebt.required, 50);
+  assert.equal(plan.requiredDebt.funded, 50);
+  assert.equal(plan.requiredDebt.items[0].kind, 'required_debt_payment');
+});
+
+test('default or unresolved arrangement safety state blocks unsafe optional overpayment', () => {
+  const state = paydayState({
+    debts: [currentDebt({ status: 'defaulted', arrangementStatus: 'unknown' })],
+    budgets: []
+  });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.notEqual(plan.status, PAYDAY_ALLOCATION_STATUS.READY);
+  assert.equal(plan.optionalDebt.funded, 0);
+  assert.equal(plan.safety.externalPaymentMade, false);
+});
+
+test('starter or emergency buffer shortfall is explicitly protected', () => {
+  const state = paydayState({ settings: { ...baseState().settings, emergencyBufferTarget: 400, emergencyBufferBalance: 100 } });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.equal(plan.buffer.required, 300);
+  assert.equal(plan.buffer.funded, 300);
+});
+
+test('reduced-than-expected income exposes Budget shortfall and compresses optional allocation first', () => {
+  const state = paydayState({
+    accounts: [{ id: 'current', name: 'Fictional Current', type: 'current', currentBalance: 650, statementDate: '2026-08-10', active: true }],
+    transactions: [receivedIncome(650)],
+    scheduledPayments: [{ id: 'bill', name: 'Fictional Bill', amount: 100, dueDate: '2026-08-20', status: 'due', includedInBudget: false }],
+    debts: [currentDebt()],
+    budgets: [activeBudget('food', 'Food', 300), activeBudget('travel', 'Travel', 200)]
+  });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.equal(plan.income.amountReceived, 650);
+  assert.notEqual(plan.status, PAYDAY_ALLOCATION_STATUS.READY);
+  assert.equal(plan.budget.categories.length, 2);
+  assert.ok(plan.budget.shortfall > 0);
+  assert.equal(plan.optionalDebt.funded, 0);
+  assert.ok(plan.leftoverUnallocated >= 0);
+});
+
+test('a second dependable income stream shortens the current payday planning horizon', () => {
+  let state = paydayState();
+  state = withIncomeSchedule(state, { id: 'fictional-side-income', name: 'Fictional Side Income', matchText: 'Fictional Side Income', day: 15, expectedAmountRange: { min: 300, max: 350 } });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.equal(plan.income.streamId, 'fictional-salary');
+  assert.equal(plan.horizonDate, '2026-08-15');
+});
+
+test('a changed bill amount or date recalculates the derived plan instead of retaining a stale snapshot', () => {
+  const first = paydayState({ scheduledPayments: [{ id: 'bill', name: 'Fictional Bill', amount: 100, dueDate: '2026-08-20', status: 'due', includedInBudget: false }] });
+  const second = structuredClone(first);
+  second.scheduledPayments[0].amount = 225;
+  second.scheduledPayments[0].dueDate = '2026-08-18';
+
+  const before = buildPaydayAllocationPlan(first, { now: NOW });
+  const after = buildPaydayAllocationPlan(second, { now: NOW });
+  assert.equal(before.protectedCommitments.required, 100);
+  assert.equal(after.protectedCommitments.required, 225);
+  assert.equal(after.protectedCommitments.items[0].date, '2026-08-18');
+});
+
+test('future expected income is not allocated before trusted receipt evidence exists', () => {
+  const state = withIncomeSchedule(baseState(), { day: 28, expectedAmountRange: { min: 5000, max: 5000 } });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.equal(plan.status, PAYDAY_ALLOCATION_STATUS.WAITING_FOR_INCOME);
+  assert.equal(plan.income, null);
+  assert.equal(plan.availableForPlanning, 0);
+  assert.equal(plan.safety.futureExpectedIncomeAllocated, false);
+});
+
+test('user-adjusted flexible allowance persists as an explicit override and never replaces the Budget', () => {
+  let state = paydayState({ budgets: [activeBudget('food', 'Food', 300), activeBudget('travel', 'Travel', 200)] });
+  state = setPaydayPlanningPreferences(state, { flexibleAllowance: 250 });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.equal(plan.preferences.flexibleAllowance, 250);
+  assert.equal(plan.budget.userOverride, true);
+  assert.equal(plan.budget.required, 500);
+  assert.equal(plan.budget.requestedFlexibleAllowance, 250);
+  assert.equal(plan.budget.categories.length, 2);
+});
+
+test('no negative or silently overcommitted plan is recommended when protected needs exceed payday cash', () => {
+  const state = paydayState({
+    accounts: [{ id: 'current', name: 'Fictional Current', type: 'current', currentBalance: 120, statementDate: '2026-08-10', active: true }],
+    transactions: [receivedIncome(120)],
+    scheduledPayments: [{ id: 'bill', name: 'Fictional Bill', amount: 150, dueDate: '2026-08-20', status: 'due', includedInBudget: false }],
+    budgets: [activeBudget('food', 'Food', 300)]
+  });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.equal(plan.status, PAYDAY_ALLOCATION_STATUS.PROTECTED_SHORTFALL);
+  assert.ok(plan.protectedCommitments.shortfall > 0);
+  assert.equal(plan.budget.funded, 0);
+  assert.equal(plan.optionalDebt.funded, 0);
+  assert.ok(plan.leftoverUnallocated >= 0);
+});
+
+test('the complete active Budget remains visible with funded, partial or unfunded coverage when money is short', () => {
+  const state = paydayState({
+    accounts: [{ id: 'current', name: 'Fictional Current', type: 'current', currentBalance: 500, statementDate: '2026-08-10', active: true }],
+    transactions: [receivedIncome(500)],
+    settings: { ...baseState().settings, emergencyBufferTarget: 0, emergencyBufferBalance: 0 },
+    budgets: [
+      activeBudget('food', 'Food', 300),
+      activeBudget('travel', 'Travel', 200),
+      activeBudget('health', 'Health', 100)
+    ]
+  });
+  const plan = buildPaydayAllocationPlan(state, { now: NOW });
+
+  assert.equal(plan.budget.allActiveCategoriesVisible, true);
+  assert.deepEqual(plan.budget.categories.map((item) => item.id), ['food', 'travel', 'health']);
+  assert.ok(plan.budget.shortfall > 0);
+  assert.ok(plan.budget.categories.every((item) => ['funded', 'partially_funded', 'unfunded', 'needs_review'].includes(item.fundingStatus)));
+  assert.equal(plan.budget.expectedFutureIncomeAppliedToShortfall, false);
+});
+
+test('portable backup and restore preserve explicit payday planning preferences without persisting a derived plan', async (t) => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'onestep-payday-allocation-'));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const store = new FinanceDataStore(directory, seedPath, null, { appVersion: '2.1.26' });
+  await store.initialise();
+  let state = (await store.loadState()).state;
+  state = setPaydayPlanningPreferences(state, {
+    flexibleAllowance: 275,
+    optionalDebtId: 'fictional-loan',
+    optionalDebtDeclined: true,
+    optionalSavingsTarget: 40,
+    acceptedChoiceIds: ['budget:food']
+  });
+  state = await store.saveState(state);
+  const backupPath = path.join(directory, 'payday-preferences.osmb');
+  await store.createPortableBackup(backupPath, backupPassword, state);
+
+  let changed = setPaydayPlanningPreferences(state, { flexibleAllowance: 50, optionalDebtDeclined: false });
+  changed = await store.saveState(changed);
+  assert.equal(changed.profile.paydayPlanningPreferences.flexibleAllowance, 50);
+
+  const restored = await store.restorePortableBackup(backupPath, backupPassword);
+  assert.equal(restored.status, 'restored');
+  assert.equal(restored.state.profile.paydayPlanningPreferences.flexibleAllowance, 275);
+  assert.equal(restored.state.profile.paydayPlanningPreferences.optionalDebtDeclined, true);
+  assert.equal(restored.state.profile.paydayPlanningPreferences.optionalSavingsTarget, 40);
+  assert.deepEqual(restored.state.profile.paydayPlanningPreferences.acceptedChoiceIds, ['budget:food']);
+  assert.equal('paydayAllocationPlan' in restored.state, false);
+  assert.equal('paydayAllocationSnapshot' in restored.state, false);
+});


### PR DESCRIPTION
## Purpose
Implements #85 — Adaptive payday planning and allocation for v2.2.0.

Turn trusted received payday income into a conservative, explainable allocation plan while continuing to rely on the existing unified financial profile, payday awareness / Safe Until Payday, cash-flow forecast, Budget rules, debt recommendation engine and Financial Safety.

## Work completed
- Added a derived payday allocation engine that only plans from trusted income already marked as received.
- Allocates in the safety-first order: known commitments → required debt → protected buffer → active Budget → optional debt → optional savings → unallocated cash.
- Keeps the entire active Budget visible when income is insufficient, with funded / partially funded / unfunded states and an explicit remaining Budget gap.
- Uses the next dependable income stream as the planning horizon without counting expected future income as current cash.
- Caps planning at the lower of the received-income amount and the current trusted liquid position.
- Reuses the existing debt recommendation maximum and blockers rather than independently deciding optional overpayment safety.
- Persists only explicit planning preferences / accepted choices under the existing profile object; derived plans remain non-persistent.
- Added a Today payday-plan UI with Must protect / Recommended / Optional / Needs review sections, Why? explanations and preference controls.
- Added package/preload integration and focused tests, including backup/restore preservation of explicit planning preferences.

## Files changed
- `payday-allocation.js`
- `payday-allocation-ui.js`
- `tests/payday-allocation.test.js`
- `preload-bridge.cjs`
- `package.json`

## User-facing changes
- Today now gains an ordered payday allocation panel when the desktop local presentation modules load.
- Received income, available money, Budget gap and the next dependable-income horizon are shown clearly.
- Every active Budget category remains visible even when current payday money cannot cover it all.
- Users can save an optional flexible-Budget allowance, choose a safe eligible priority debt, decline optional debt allocation, set an optional savings target and conceptually accept planning choices.
- No transfer, debt payment, savings transfer, standing order or borrowing action is performed.

## Technical changes
- Allocation plans are derived (`persist: false`) and rebuilt from current authoritative facts.
- Explicit preferences are stored as `profile.paydayPlanningPreferences`; the existing profile migration preserves additional profile fields, so no stored-data schema bump is required.
- Safe Until Payday remains authoritative for protected scheduled/recurring/debt/buffer amounts.
- Cash-flow forecast and debt recommendation are consumed directly.
- Optional debt funding is bounded by the existing recommendation status, maximum safe optional amount, selected eligible debt balance and remaining received cash.
- Future expected income is never applied to current allocations or Budget shortfall.

## Testing and verification
### Passed before push
- Targeted allocation logic harness: **11/11 passed**.
- `node --check payday-allocation.js`: **Passed**.
- `node --check payday-allocation-ui.js`: **Passed**.
- `node --check tests/payday-allocation.test.js`: **Passed**.
- `node --check preload-bridge.cjs`: **Passed**.
- Branch/main scope comparison: **Passed** — one focused commit, five relevant files only, branch is 1 ahead / 0 behind its commencement base.

### CI / environment-dependent verification
- Full repository tests: pending GitHub Actions execution on this draft PR.
- `npm run check` / privacy check: pending GitHub Actions execution on this draft PR.
- `npm run lint`: local environment unavailable because repository dependencies / ESLint executable are not installed here; GitHub Actions is authoritative.
- Electron/manual reduced-income and defaulted-debt scenarios: unavailable in this connector-only environment; automated scenarios are included but are not represented as manual testing.
- Theme/accessibility visual review: unavailable in this connector-only environment.
- Windows packaging / strongest Windows verification: pending GitHub Actions execution on this draft PR.

## Data and migration impact
- No schema-version change.
- Only explicit payday-planning preferences/accepted choices are persisted.
- Derived allocation plans are not stored as financial facts.
- Portable backup/restore coverage verifies explicit planning preferences survive while derived snapshots are absent.
- No financial data is transmitted or added to diagnostics.

## Known limitations
- This change does not move money or make payments; it is decision support only.
- A manual Electron visual/theme/accessibility pass still requires a Windows desktop review environment.
- A later income can only be reconsidered after authoritative received evidence exists; the plan intentionally does not pre-spend expected income.

## Excluded work
- Automatic bank transfers.
- Bill payment or standing-order creation.
- Investment allocation.
- Tax planning.
- AI Companion.

## Branch details
- Branch: `feature/adaptive-payday-planning`
- Commit SHA: `be261fb91580fc643cfd8b47693a5d2f80ccae9b`
- Pull request: this draft PR
- Target branch: `main`

## Confirmations
- No changes were committed or pushed directly to `main`.
- This workflow did not merge the PR.
- No personal financial data, imported documents, credentials, secrets or sensitive logs were committed.
- Only files relevant to #85 were changed.