### PR TITLE
[v2.2.0][Feature] Add automation management dashboard

### DIFF
--- a/automation-dashboard-render.js
+++ b/automation-dashboard-render.js
@@ -1,0 +1,94 @@
+const $ = (id) => document.getElementById(id);
+const e = (value) => String(value ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+export function automationViewMarkup() {
+  return `<p id="automationStatus" class="sr-only" role="status" aria-live="polite"></p>
+  <section class="automation-hero panel" aria-labelledby="automationHeroTitle">
+    <div class="automation-hero-copy"><p class="eyebrow">LOCAL FINANCIAL AUTOMATION</p><h2 id="automationHeroTitle">Automation is loading…</h2><p id="automationHeroText" class="muted"></p></div>
+    <label class="automation-master-switch"><input id="automationMasterToggle" type="checkbox" role="switch"><span><strong id="automationMasterLabel">Automation On</strong><small>Pause stops automatic changes. Rules, reminders, history and Review Inbox work stay intact.</small></span></label>
+  </section>
+  <div class="automation-summary-grid">
+    ${stat('Enabled rules','automationEnabledRuleCount','automationRuleCountDetail')}
+    <article class="automation-stat panel"><span>Needs review</span><strong id="automationReviewCount">0</strong><small>Uncertain automation stays review-first.</small><button class="text-button" type="button" data-automation-route="review">Open Review Inbox</button></article>
+    ${stat('Configured reminders','automationReminderCount','Definitions remain saved while paused.')}
+    ${stat('Recent activity','automationRecentCount','automationRecentDetail')}
+  </div>
+  <div class="automation-layout">
+    ${section('RULES','Your automation rules','See what is active, what each rule does, and its latest recorded outcome.','Manage rules','rules','automationRulesList',true)}
+    ${section('RECURRING ACTIVITY','Recognised patterns','','Review patterns','recurring','automationRecurringList')}
+    ${section('REMINDERS','Upcoming reminders','','Manage reminders','reminders','automationRemindersList')}
+    ${section('RECENT ACTIVITY','What OneStep did','A compact view only. Full Why? and Undo controls stay in local automation history.','Open full history','history','automationActivityList',true)}
+  </div>`;
+}
+
+export function renderAutomationModel(model, message = '') {
+  const toggle = $('automationMasterToggle');
+  if (toggle) { toggle.checked = model.enabled; toggle.disabled = false; toggle.setAttribute('aria-checked', String(model.enabled)); }
+  set('automationMasterLabel', model.enabled ? 'Automation On' : 'Automation Paused');
+  set('automationHeroTitle', model.enabled ? 'Automation is on' : 'Automation is paused');
+  set('automationHeroText', model.enabled
+    ? 'OneStep can apply enabled local rules when their safety and certainty checks pass. Anything uncertain stays review-first.'
+    : 'Automatic mutations are stopped. Your rules, reminders, history and review work are preserved until you resume.');
+  set('automationEnabledRuleCount', model.enabledRuleCount);
+  set('automationRuleCountDetail', model.totalRuleCount ? `${model.totalRuleCount} rule${model.totalRuleCount === 1 ? '' : 's'} configured` : 'No rules configured');
+  set('automationReviewCount', model.reviewCount);
+  set('automationReminderCount', model.configuredReminderCount);
+  const recent = Object.values(model.recentTotals).reduce((sum, value) => sum + value, 0);
+  set('automationRecentCount', recent);
+  set('automationRecentDetail', recent ? `${model.recentTotals.applied} applied · ${model.recentTotals.needsReview} need review · ${model.recentTotals.skipped + model.recentTotals.blocked} skipped or blocked` : 'Nothing recorded yet.');
+  renderList('automationRulesList', model.rules, ruleRow, empty('No automation rules yet.','Create a small rule when you have a repeatable task worth automating.','Create a rule','rules'));
+  renderList('automationRecurringList', model.recurring, recurringRow, '<p class="muted">No confirmed or likely recurring patterns are ready to show yet.</p>');
+  renderList('automationRemindersList', model.reminders, reminderRow, empty('No upcoming configured reminders.','Add a reminder for a due date you want OneStep to surface locally.','Add reminder','reminders'));
+  renderList('automationActivityList', model.recentActivity, activityRow, '<p class="muted">No automation activity yet. Applied, skipped, blocked and review-required outcomes will appear here.</p>');
+  set('automationStatus', message);
+  renderDashboardStatus(model);
+}
+
+export function renderAutomationRecovery() {
+  const toggle = $('automationMasterToggle');
+  if (toggle) toggle.disabled = true;
+  set('automationHeroTitle','Automation controls are unavailable during data recovery');
+  set('automationHeroText','Data recovery protections are separate from Automation pause. Resolve recovery first; Automation cannot override those protections.');
+  set('automationMasterLabel','Automation unavailable');
+  set('automationStatus','Data recovery protections are active. Automation controls are unavailable.');
+  set('dashboardAutomationTitle','Automation unavailable');
+  set('dashboardAutomationBadge','Recovery');
+  set('dashboardAutomationText','Data recovery protections are active. Automation cannot override them.');
+}
+
+export function renderDashboardStatus(model) {
+  set('dashboardAutomationTitle', model.enabled ? 'Automation on' : 'Automation paused');
+  set('dashboardAutomationBadge', model.enabled ? 'On' : 'Paused');
+  set('dashboardAutomationText', model.reviewCount
+    ? `${model.enabledRuleCount} enabled rule${model.enabledRuleCount === 1 ? '' : 's'} · ${model.reviewCount} item${model.reviewCount === 1 ? '' : 's'} need review.`
+    : `${model.enabledRuleCount} enabled rule${model.enabledRuleCount === 1 ? '' : 's'} · nothing from automation needs review.`);
+}
+
+function stat(label,id,detail) {
+  const detailMarkup = detail.startsWith?.('automation') ? `<small id="${detail}"></small>` : `<small>${e(detail)}</small>`;
+  return `<article class="automation-stat panel"><span>${e(label)}</span><strong id="${id}">0</strong>${detailMarkup}</article>`;
+}
+function section(eyebrow,title,copy,button,route,listId,wide=false) {
+  return `<article class="panel automation-section${wide ? ' automation-section-wide' : ''}"><div class="panel-heading"><div><p class="eyebrow">${eyebrow}</p><h2>${title}</h2>${copy ? `<p class="muted">${copy}</p>` : ''}</div><button class="${wide ? 'secondary-button' : 'text-button'}" type="button" data-automation-route="${route}">${button}</button></div><div id="${listId}" class="automation-list"></div></article>`;
+}
+function ruleRow(rule) {
+  return `<article class="automation-row"><div class="automation-row-heading"><strong>${e(rule.name)}</strong><span class="badge ${rule.enabled ? '' : 'muted-badge'}">${rule.enabled ? 'Enabled' : 'Paused'}</span></div><p class="muted automation-row-summary">${e(rule.summary)}</p><p class="automation-row-meta">${rule.lastRun ? `Last result: ${e(rule.lastRun.status)} · ${e(formatDateTime(rule.lastRun.timestamp))}` : 'No recorded run yet.'}</p><div class="button-row"><button class="secondary-button" type="button" data-automation-rule-open="${e(rule.id)}">Open</button><button class="secondary-button" type="button" data-automation-rule-toggle="${e(rule.id)}" data-automation-rule-enable="${String(!rule.enabled)}">${rule.enabled ? 'Pause rule' : 'Enable rule'}</button></div></article>`;
+}
+function recurringRow(item) {
+  return `<article class="automation-row compact"><div class="automation-row-heading"><strong>${e(item.label || 'Recurring activity')}</strong><span class="badge">${e(titleCase(item.confidence))}</span></div><p class="muted">${e([titleCase(item.direction), titleCase(item.cadence), item.purpose].filter(Boolean).join(' · '))}</p>${item.nextExpected ? `<p class="automation-row-meta">Next expected around ${e(formatLocalDate(item.nextExpected))}.</p>` : ''}</article>`;
+}
+function reminderRow(item) {
+  return `<article class="automation-row compact"><div class="automation-row-heading"><strong>${e(item.title || 'Financial reminder')}</strong><span class="badge">${e(reminderStatus(item.status))}</span></div><p class="muted">${e(formatLocalDate(item.dueDate))} · reminder ${e(timing(item.daysBefore))}.</p></article>`;
+}
+function activityRow(item) {
+  const attention = ['Needs review','Blocked'].includes(item.status) ? ' attention-badge' : '';
+  return `<article class="automation-row compact"><div class="automation-row-heading"><strong>${e(item.summary)}</strong><span class="badge${attention}">${e(item.status)}</span></div><p class="automation-row-meta">${e([formatDateTime(item.timestamp), item.ruleLabel].filter(Boolean).join(' · '))}</p></article>`;
+}
+function empty(title,detail,button,route) { return `<div class="automation-empty"><p class="automation-empty-title">${e(title)}</p><p class="muted">${e(detail)}</p><button class="secondary-button" type="button" data-automation-route="${route}">${e(button)}</button></div>`; }
+function renderList(id,items,mapper,emptyMarkup) { const node=$(id); if (node) node.innerHTML=items.length ? items.map(mapper).join('') : emptyMarkup; }
+function set(id,value) { const node=$(id); if (node) node.textContent=String(value ?? ''); }
+function formatDateTime(value) { const date=new Date(value); return Number.isNaN(date.getTime()) ? 'Date unavailable' : new Intl.DateTimeFormat('en-GB',{dateStyle:'medium',timeStyle:'short'}).format(date); }
+function formatLocalDate(value) { const [y,m,d]=String(value||'').split('-').map(Number); const date=new Date(y,m-1,d,12); return Number.isNaN(date.getTime()) ? 'date unavailable' : new Intl.DateTimeFormat('en-GB',{day:'numeric',month:'short',year:'numeric'}).format(date); }
+function titleCase(value) { return String(value||'').replace(/[-_]/g,' ').replace(/\b\w/g,(c)=>c.toUpperCase()); }
+function reminderStatus(value) { return value==='due_today' ? 'Due today' : value==='overdue' ? 'Overdue' : 'Upcoming'; }
+function timing(days) { return Number(days)===0 ? 'on the due date' : `${days} day${Number(days)===1?'':'s'} before`; }

--- a/automation-dashboard-ui.js
+++ b/automation-dashboard-ui.js
@@ -1,0 +1,268 @@
+import { buildAutomationDashboardModel, setAutomationEnabledState } from './automation-dashboard.js';
+import { setAutomationRuleEnabled } from './automation-rule-model.js';
+import { renderRecurringActivityPanel } from './recurring-finance-ui.js';
+import { automationViewMarkup, renderAutomationModel, renderAutomationRecovery } from './automation-dashboard-render.js';
+
+let state = null;
+let started = false;
+let refreshing = false;
+let queued = false;
+const RETURN_KEY = 'onestep.automation.return';
+
+function boot() {
+  const shell = document.getElementById('appShell');
+  if (!shell || !window.financeAPI?.loadState) return;
+  if (!shell.hidden) {
+    queueMicrotask(start);
+    return;
+  }
+  const observer = new MutationObserver(() => {
+    if (!shell.hidden) {
+      observer.disconnect();
+      queueMicrotask(start);
+    }
+  });
+  observer.observe(shell, { attributes: true, attributeFilter: ['hidden'] });
+}
+
+function start() {
+  if (started) return;
+  started = true;
+  ensureSurface();
+  document.addEventListener('click', onClick, true);
+  document.addEventListener('change', onChange, true);
+  const restore = window.sessionStorage.getItem(RETURN_KEY) === '1';
+  window.sessionStorage.removeItem(RETURN_KEY);
+  if (restore) activate(false);
+  refresh();
+}
+
+function ensureSurface() {
+  ensureNav();
+  ensureView();
+  ensureDashboardCard();
+}
+
+function ensureNav() {
+  if (document.querySelector('.nav-button[data-view="automation"]')) return;
+  const nav = document.querySelector('.sidebar nav');
+  if (!nav) return;
+  const button = document.createElement('button');
+  button.className = 'nav-button';
+  button.type = 'button';
+  button.dataset.view = 'automation';
+  button.setAttribute('aria-label', 'Automation');
+  button.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2 5 13h6l-1 9 9-12h-6z"/></svg><span class="nav-label">Automation <span id="automationNavCount" class="nav-count" aria-label="0 automation items need review" hidden>0</span></span>';
+  nav.insertBefore(button, nav.querySelector('[data-view="guide"]') || nav.querySelector('[data-view="settings"]') || null);
+}
+
+function ensureView() {
+  if (document.getElementById('view-automation')) return;
+  const section = document.createElement('section');
+  section.id = 'view-automation';
+  section.className = 'view automation-view';
+  section.hidden = true;
+  section.setAttribute('aria-labelledby', 'viewTitle');
+  section.innerHTML = automationViewMarkup();
+  const guide = document.getElementById('view-guide');
+  if (guide) guide.before(section);
+  else document.querySelector('.main-content')?.append(section);
+}
+
+function ensureDashboardCard() {
+  if (document.getElementById('dashboardAutomationStatus')) return;
+  const modules = document.getElementById('dashboardModules');
+  if (!modules) return;
+  const card = document.createElement('article');
+  card.id = 'dashboardAutomationStatus';
+  card.className = 'dashboard-module automation-dashboard-status';
+  card.innerHTML = '<div class="dashboard-module-heading"><div><p class="eyebrow">AUTOMATION</p><h2 id="dashboardAutomationTitle">Automation</h2></div><span id="dashboardAutomationBadge" class="badge">Loading</span></div><p id="dashboardAutomationText" class="muted">Checking local automation state…</p><button class="secondary-button" type="button" data-automation-open>Open Automation</button>';
+  modules.append(card);
+}
+
+async function refresh(message = '') {
+  if (refreshing) {
+    queued = true;
+    return;
+  }
+  refreshing = true;
+  try {
+    ensureSurface();
+    const loaded = await window.financeAPI.loadState();
+    if (loaded?.status !== 'normal' || !loaded.state) {
+      renderAutomationRecovery();
+      return;
+    }
+    state = loaded.state;
+    const model = buildAutomationDashboardModel(state, new Date());
+    renderAutomationModel(model, message);
+    renderAttention(model.reviewCount);
+  } catch {
+    setStatus('Automation could not be refreshed. No financial information was changed.');
+  } finally {
+    refreshing = false;
+    if (queued) {
+      queued = false;
+      refresh();
+    }
+  }
+}
+
+function renderAttention(value) {
+  const count = document.getElementById('automationNavCount');
+  if (!count) return;
+  count.textContent = String(value);
+  count.hidden = value === 0;
+  count.setAttribute('aria-label', `${value} automation item${value === 1 ? '' : 's'} need review`);
+}
+
+function activate(shouldRefresh = true) {
+  ensureSurface();
+  document.querySelectorAll('.nav-button').forEach((button) => {
+    button.classList.toggle('active', button.dataset.view === 'automation');
+  });
+  document.querySelectorAll('.view').forEach((view) => {
+    const active = view.id === 'view-automation';
+    view.classList.toggle('active', active);
+    view.hidden = !active;
+  });
+  setText('viewEyebrow', 'SEE IT · UNDERSTAND IT · CONTROL IT');
+  setText('viewTitle', 'Automation');
+  if (shouldRefresh) refresh();
+}
+
+async function onChange(event) {
+  if (event.target?.id === 'automationMasterToggle') {
+    await saveGlobal(event.target.checked, event.target);
+  }
+}
+
+async function onClick(event) {
+  const open = event.target.closest('[data-automation-open],.nav-button[data-view="automation"]');
+  if (open) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    activate();
+    return;
+  }
+  const route = event.target.closest('[data-automation-route]');
+  if (route) {
+    event.preventDefault();
+    await routeTo(route.dataset.automationRoute);
+    return;
+  }
+  const edit = event.target.closest('[data-automation-rule-open]');
+  if (edit) {
+    event.preventDefault();
+    await routeToRule(edit.dataset.automationRuleOpen, false);
+    return;
+  }
+  const toggle = event.target.closest('[data-automation-rule-toggle]');
+  if (!toggle) return;
+  event.preventDefault();
+  const enable = toggle.dataset.automationRuleEnable === 'true';
+  if (enable) await routeToRule(toggle.dataset.automationRuleToggle, true);
+  else await pauseRule(toggle.dataset.automationRuleToggle, toggle);
+}
+
+async function saveGlobal(enabled, control) {
+  control.disabled = true;
+  setStatus(enabled ? 'Resuming automation…' : 'Pausing automation…');
+  try {
+    const latest = await latestNormal();
+    const saved = await window.financeAPI.saveState(setAutomationEnabledState(latest, enabled));
+    if (['blocked', 'conflict'].includes(saved?.status)) {
+      throw new Error(saved.message || 'Automation state could not be saved safely.');
+    }
+    window.sessionStorage.setItem(RETURN_KEY, '1');
+    window.location.reload();
+  } catch (error) {
+    control.disabled = false;
+    await refresh(error?.message || 'Automation state could not be changed safely.');
+  }
+}
+
+async function pauseRule(id, button) {
+  button.disabled = true;
+  setStatus('Pausing rule…');
+  try {
+    const latest = await latestNormal();
+    const next = setAutomationRuleEnabled(latest, id, false, new Date());
+    const saved = await window.financeAPI.saveState(next);
+    if (['blocked', 'conflict'].includes(saved?.status)) {
+      throw new Error(saved.message || 'That rule could not be saved safely.');
+    }
+    window.sessionStorage.setItem(RETURN_KEY, '1');
+    window.location.reload();
+  } catch (error) {
+    button.disabled = false;
+    await refresh(error?.message || 'That rule could not be changed safely.');
+  }
+}
+
+async function latestNormal() {
+  const loaded = await window.financeAPI.loadState();
+  if (loaded?.status !== 'normal' || !loaded.state) {
+    throw new Error('Automation controls are unavailable while data recovery protections are active.');
+  }
+  return loaded.state;
+}
+
+async function routeTo(route) {
+  if (route === 'review') {
+    document.querySelector('.nav-button[data-view="review"]')?.click();
+    return;
+  }
+  if (route === 'recurring') {
+    document.querySelector('.nav-button[data-view="transactions"]')?.click();
+    if (state) renderRecurringActivityPanel(state);
+    queueMicrotask(() => focusElement(document.getElementById('recurringActivityPanel')));
+    return;
+  }
+  document.querySelector('.nav-button[data-view="settings"]')?.click();
+  if (state) renderRecurringActivityPanel(state);
+  const target = route === 'rules'
+    ? document.getElementById('automationRulesSettings')
+    : route === 'reminders'
+      ? document.getElementById('financialRemindersSettings')
+      : document.getElementById('automationHistorySettings');
+  queueMicrotask(() => focusElement(target));
+}
+
+async function routeToRule(id, activation) {
+  await routeTo('rules');
+  queueMicrotask(() => {
+    const selector = activation ? '[data-automation-toggle]' : '[data-automation-edit]';
+    const button = [...document.querySelectorAll(selector)].find((item) => (
+      String(activation ? item.dataset.automationToggle : item.dataset.automationEdit) === String(id)
+    ));
+    if (!button) return;
+    focusElement(button);
+    button.click();
+  });
+}
+
+function focusElement(target) {
+  target?.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
+  const focusTarget = target?.matches?.('button,input,select,textarea,[tabindex]')
+    ? target
+    : target?.querySelector?.('button,input,select,textarea,[tabindex]');
+  focusTarget?.focus?.({ preventScroll: true });
+}
+
+function setStatus(value) {
+  setText('automationStatus', value || '');
+}
+
+function setText(id, value) {
+  const node = document.getElementById(id);
+  if (node) node.textContent = value;
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+}

--- a/automation-dashboard.css
+++ b/automation-dashboard.css
@@ -1,0 +1,71 @@
+.automation-view { display: grid; gap: 1rem; }
+.automation-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 390px);
+  gap: 1.2rem;
+  align-items: center;
+  padding: clamp(1rem, 2.4vw, 1.5rem);
+}
+.automation-hero-copy p:last-child { max-width: 720px; margin-bottom: 0; line-height: 1.55; }
+.automation-master-switch {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.8rem;
+  align-items: start;
+  margin: 0;
+  padding: 0.95rem;
+  background: var(--surface-subtle);
+  border: 1px solid var(--line);
+  border-radius: 15px;
+}
+.automation-master-switch input { width: 1.25rem; height: 1.25rem; margin-top: 0.1rem; accent-color: var(--teal-dark); }
+.automation-master-switch span { display: grid; gap: 0.25rem; }
+.automation-master-switch small { color: var(--muted); line-height: 1.45; }
+.automation-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+.automation-stat { display: grid; gap: 0.25rem; min-width: 0; }
+.automation-stat > span { color: var(--muted); font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.045em; }
+.automation-stat > strong { font-size: clamp(1.65rem, 3vw, 2.25rem); letter-spacing: -0.045em; }
+.automation-stat > small { color: var(--muted); line-height: 1.4; }
+.automation-layout { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }
+.automation-section { min-width: 0; }
+.automation-section-wide { grid-column: 1 / -1; }
+.automation-list { display: grid; gap: 0.65rem; margin-top: 0.8rem; }
+.automation-row {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.85rem;
+  background: var(--surface-subtle);
+  border: 1px solid var(--line);
+  border-radius: 13px;
+}
+.automation-row.compact { gap: 0.35rem; }
+.automation-row p { margin: 0; }
+.automation-row-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.8rem; }
+.automation-row-heading strong { min-width: 0; overflow-wrap: anywhere; }
+.automation-row-summary { line-height: 1.5; }
+.automation-row-meta { color: var(--muted); font-size: 0.76rem; line-height: 1.45; }
+.automation-empty { display: grid; gap: 0.45rem; justify-items: start; padding: 0.8rem; background: var(--surface-subtle); border: 1px dashed var(--line-strong); border-radius: 13px; }
+.automation-empty p { margin: 0; }
+.automation-empty-title { font-weight: 800; }
+.muted-badge { opacity: 0.72; }
+.attention-badge { color: var(--warning-ink); background: var(--amber-soft); }
+.automation-dashboard-status .badge { white-space: nowrap; }
+
+@media (max-width: 1050px) {
+  .automation-summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 820px) {
+  .automation-hero, .automation-layout { grid-template-columns: 1fr; }
+  .automation-section-wide { grid-column: auto; }
+}
+
+@media (max-width: 560px) {
+  .automation-summary-grid { grid-template-columns: 1fr; }
+  .automation-row-heading { align-items: stretch; flex-direction: column; }
+  .automation-row-heading .badge { align-self: start; }
+}

--- a/automation-dashboard.js
+++ b/automation-dashboard.js
@@ -1,0 +1,137 @@
+import { normaliseAutomationState } from './automation-state.js';
+import {
+  AUTOMATION_HISTORY_FILTER,
+  automationHistoryEntries,
+  automationHistoryPresentation
+} from './automation-history.js';
+import { automationReviewSources } from './automation-review-integration.js';
+import { actionLabel, explainRule } from './automation-rule-model.js';
+import { FINANCIAL_REMINDER_STATUS, listFinancialReminderSources } from './financial-reminders.js';
+import { deriveRecurringPatterns, RECURRING_CONFIDENCE } from './recurring-finance.js';
+
+const RECENT_ACTIVITY_LIMIT = 5;
+const RECENT_SUMMARY_LIMIT = 20;
+const MANAGEMENT_LIST_LIMIT = 6;
+
+export function buildAutomationDashboardModel(state = {}, now = new Date()) {
+  const automation = normaliseAutomationState(state?.automation);
+  const sourceState = { ...state, automation };
+  const historyEntries = automationHistoryEntries(sourceState, AUTOMATION_HISTORY_FILTER.ALL);
+  const latestByRule = latestHistoryByRule(historyEntries);
+  const rules = automation.rules.map((rule) => ruleSummary(rule, latestByRule.get(rule.id)));
+  const configuredReminderIds = new Set(automation.reminders.map((reminder) => reminder.id));
+  const reminders = listFinancialReminderSources(sourceState, now)
+    .filter((reminder) => configuredReminderIds.has(reminder.configId)
+      && reminder.enabled
+      && reminder.status !== FINANCIAL_REMINDER_STATUS.RESOLVED)
+    .slice(0, MANAGEMENT_LIST_LIMIT)
+    .map(reminderSummary);
+  const recurring = deriveRecurringPatterns(sourceState, { includeRejected: false })
+    .filter((pattern) => [RECURRING_CONFIDENCE.CONFIRMED, RECURRING_CONFIDENCE.LIKELY].includes(pattern.confidence))
+    .slice(0, MANAGEMENT_LIST_LIMIT)
+    .map(recurringSummary);
+  const reviewSources = automationReviewSources(sourceState, now);
+  const recentActivity = historyEntries.slice(0, RECENT_ACTIVITY_LIMIT)
+    .map((entry) => ({ entry, presentation: automationHistoryPresentation(sourceState, entry) }))
+    .filter(({ presentation }) => Boolean(presentation))
+    .map(({ entry, presentation }) => ({
+      id: entry.id || presentation.id,
+      status: presentation.statusLabel,
+      summary: presentation.summary,
+      ruleLabel: presentation.ruleLabel,
+      timestamp: presentation.timestamp,
+      undoAvailable: Boolean(presentation.undo?.available)
+    }));
+
+  return {
+    enabled: automation.enabled,
+    enabledRuleCount: rules.filter((rule) => rule.enabled).length,
+    totalRuleCount: rules.length,
+    reviewCount: reviewSources.length,
+    configuredReminderCount: configuredReminderIds.size,
+    recurringCount: recurring.length,
+    rules,
+    reminders,
+    recurring,
+    recentActivity,
+    recentTotals: recentActivityTotals(historyEntries.slice(0, RECENT_SUMMARY_LIMIT))
+  };
+}
+
+export function setAutomationEnabledState(state = {}, enabled) {
+  const next = structuredClone(state || {});
+  next.automation = normaliseAutomationState(next.automation);
+  next.automation.enabled = Boolean(enabled);
+  return next;
+}
+
+function latestHistoryByRule(entries) {
+  const output = new Map();
+  for (const entry of entries) {
+    for (const ruleId of entry.ruleIds || []) {
+      if (!output.has(ruleId)) output.set(ruleId, entry);
+    }
+  }
+  return output;
+}
+
+function ruleSummary(rule, latest) {
+  return {
+    id: rule.id,
+    name: rule.name,
+    enabled: rule.enabled,
+    summary: explainRule(rule),
+    action: actionLabel(rule.action) || 'local action',
+    lastRun: latest ? {
+      status: historyStatusLabel(latest.result),
+      timestamp: latest.timestamp
+    } : null
+  };
+}
+
+function recurringSummary(pattern) {
+  return {
+    id: pattern.id,
+    label: pattern.label,
+    purpose: pattern.purpose,
+    direction: pattern.direction,
+    cadence: pattern.cadence,
+    confidence: pattern.confidence,
+    nextExpected: pattern.nextExpected?.date || null
+  };
+}
+
+function reminderSummary(reminder) {
+  return {
+    id: reminder.configId,
+    sourceType: reminder.sourceType,
+    sourceId: reminder.sourceId,
+    title: reminder.title,
+    dueDate: reminder.dueDate,
+    daysBefore: reminder.daysBefore,
+    status: reminder.status,
+    dismissedToday: reminder.dismissedToday
+  };
+}
+
+function recentActivityTotals(entries) {
+  const totals = { applied: 0, needsReview: 0, skipped: 0, blocked: 0, undone: 0 };
+  for (const entry of entries) {
+    if (entry.result === 'applied') totals.applied += 1;
+    else if (entry.result === 'needs_review') totals.needsReview += 1;
+    else if (entry.result === 'skipped') totals.skipped += 1;
+    else if (entry.result === 'blocked') totals.blocked += 1;
+    else if (entry.result === 'undone') totals.undone += 1;
+  }
+  return totals;
+}
+
+function historyStatusLabel(result) {
+  return ({
+    applied: 'Applied',
+    needs_review: 'Needs review',
+    skipped: 'Skipped',
+    blocked: 'Blocked',
+    undone: 'Undone'
+  })[result] || 'Recorded';
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
     "productName": "OneStep Money",
     "asar": true,
     "files": [
+      "automation-dashboard.css",
+      "automation-dashboard.js",
+      "automation-dashboard-ui.js",
+      "automation-dashboard-render.js",
       "automation-engine.js",
       "automation-history.js",
       "automation-history-runner.js",

--- a/preload-bridge.cjs
+++ b/preload-bridge.cjs
@@ -64,9 +64,29 @@ function loadAutomationHistoryModule() {
   document.head.append(script);
 }
 
+function loadAutomationDashboardModule() {
+  const stylesheet = 'automation-dashboard.css';
+  if (!document.querySelector(`link[data-automation-dashboard-style="${stylesheet}"]`)) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = stylesheet;
+    link.dataset.automationDashboardStyle = stylesheet;
+    document.head.append(link);
+  }
+
+  const source = 'automation-dashboard-ui.js';
+  if (document.querySelector(`script[data-automation-dashboard="${source}"]`)) return;
+  const script = document.createElement('script');
+  script.type = 'module';
+  script.src = source;
+  script.dataset.automationDashboard = source;
+  document.head.append(script);
+}
+
 function loadLocalPresentationModules() {
   loadFinancialPresentationModules();
   loadAutomationHistoryModule();
+  loadAutomationDashboardModule();
 }
 
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {

--- a/tests/automation-dashboard.test.js
+++ b/tests/automation-dashboard.test.js
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { buildAutomationDashboardModel, setAutomationEnabledState } from '../automation-dashboard.js';
+import { createUserFinancialReminder } from '../financial-reminders.js';
+
+const NOW = new Date('2026-08-11T12:00:00.000Z');
+
+function baseState() {
+  return {
+    meta: { revision: 7 },
+    accounts: [],
+    transactions: [],
+    tasks: [],
+    reviewItems: [],
+    automation: {
+      enabled: true,
+      rules: [{
+        id: 'fictional_groceries',
+        name: 'Tag fictional groceries',
+        enabled: true,
+        trigger: 'transaction_change',
+        conditions: [{ field: 'merchant', operator: 'contains', value: 'fictional market' }],
+        action: { type: 'add_tag', value: 'groceries' },
+        explanation: 'Tag fictional grocery payments for local review.',
+        activationMode: 'future_only',
+        activatedAt: '2026-08-10T12:00:00.000Z',
+        createdAt: '2026-08-10T12:00:00.000Z',
+        updatedAt: '2026-08-10T12:00:00.000Z'
+      }, {
+        id: 'fictional_paused',
+        name: 'Paused fictional rule',
+        enabled: false,
+        trigger: 'transaction_change',
+        conditions: [{ field: 'purpose', operator: 'equals', value: 'fictional' }],
+        action: { type: 'add_tag', value: 'paused' },
+        explanation: 'A paused fictional rule.',
+        activationMode: 'future_only',
+        activatedAt: null,
+        createdAt: '2026-08-10T12:00:00.000Z',
+        updatedAt: '2026-08-10T12:00:00.000Z'
+      }],
+      reminders: [],
+      executions: {},
+      manualOverrides: {},
+      reviewSignals: {
+        review_signal_fictional: {
+          id: 'review_signal_fictional',
+          kind: 'engine_review',
+          sourceType: 'state',
+          sourceId: 'global',
+          actionType: 'add_local_tag',
+          ruleIds: ['fictional_groceries'],
+          reasonCode: 'review_required',
+          priority: 'normal',
+          dueAt: null,
+          createdAt: '2026-08-11T10:00:00.000Z',
+          updatedAt: '2026-08-11T10:00:00.000Z'
+        }
+      },
+      history: {
+        history_fictional_applied: {
+          id: 'history_fictional_applied',
+          executionId: null,
+          ruleIds: ['fictional_groceries'],
+          sourceType: 'state',
+          sourceId: 'global',
+          actionType: 'add_local_tag',
+          result: 'applied',
+          timestamp: '2026-08-11T09:00:00.000Z',
+          reasonCode: 'applied',
+          undoStatus: 'unavailable',
+          undo: null,
+          undoneAt: null
+        }
+      }
+    }
+  };
+}
+
+test('dashboard derives authoritative state, enabled rules, review count and recent history', () => {
+  const model = buildAutomationDashboardModel(baseState(), NOW);
+  assert.equal(model.enabled, true);
+  assert.equal(model.totalRuleCount, 2);
+  assert.equal(model.enabledRuleCount, 1);
+  assert.equal(model.reviewCount, 1);
+  assert.equal(model.recentTotals.applied, 1);
+  assert.equal(model.rules.find((rule) => rule.id === 'fictional_groceries')?.lastRun?.status, 'Applied');
+});
+
+test('pause and resume preserve definitions and history without replaying anything', () => {
+  const original = baseState();
+  const paused = setAutomationEnabledState(original, false);
+  const resumed = setAutomationEnabledState(paused, true);
+
+  assert.equal(original.automation.enabled, true);
+  assert.equal(paused.automation.enabled, false);
+  assert.equal(resumed.automation.enabled, true);
+  assert.deepEqual(resumed.automation.rules, paused.automation.rules);
+  assert.deepEqual(resumed.automation.reminders, paused.automation.reminders);
+  assert.deepEqual(resumed.automation.history, paused.automation.history);
+  assert.deepEqual(resumed.automation.executions, paused.automation.executions);
+});
+
+test('configured reminders are derived from reminder source truth', () => {
+  const withReminder = createUserFinancialReminder(baseState(), {
+    title: 'Review fictional annual policy',
+    dueDate: '2026-08-20',
+    daysBefore: 7
+  }, NOW);
+  const model = buildAutomationDashboardModel(withReminder, NOW);
+  assert.equal(model.configuredReminderCount, 1);
+  assert.equal(model.reminders.length, 1);
+  assert.equal(model.reminders[0].title, 'Review fictional annual policy');
+});
+
+test('empty automation state produces a useful zero-state model', () => {
+  const model = buildAutomationDashboardModel({ transactions: [], tasks: [] }, NOW);
+  assert.equal(model.enabled, true);
+  assert.equal(model.totalRuleCount, 0);
+  assert.equal(model.reviewCount, 0);
+  assert.equal(model.recentActivity.length, 0);
+  assert.equal(model.reminders.length, 0);
+});
+
+
+test('UI contract keeps pause semantic, review routing and passive refresh mutation-free', () => {
+  const source = [
+    readFileSync(new URL('../automation-dashboard-ui.js', import.meta.url), 'utf8'),
+    readFileSync(new URL('../automation-dashboard-render.js', import.meta.url), 'utf8')
+  ].join('\n');
+  const css = readFileSync(new URL('../automation-dashboard.css', import.meta.url), 'utf8');
+
+  assert.match(source, /id="automationMasterToggle" type="checkbox" role="switch"/);
+  assert.match(source, /id="automationStatus"[^>]+aria-live="polite"/);
+  assert.match(source, /data-automation-route="review">Open Review Inbox/);
+  assert.doesNotMatch(source, /runAutomationRules\s*\(/);
+  assert.match(source, /Data recovery protections are separate from Automation pause/);
+  assert.match(css, /@media \(max-width: 820px\)/);
+  assert.match(css, /var\(--surface-subtle\)/);
+});


### PR DESCRIPTION
## Purpose
Implement #76 as one clear, local-first Automation management surface without turning the main Dashboard into a technical console or duplicating automation-engine business logic.

## Work completed
- Added a dedicated Automation navigation/view with authoritative Automation On/Paused state.
- Added derived enabled-rule, review, reminder and recent-activity summaries.
- Added compact rule status, recurring activity, reminders and recent automation history views.
- Added navigation into existing rule editing/Test Rule, recurring management, reminders, Review Inbox and full history workflows.
- Added a small main Dashboard Automation status/attention card.
- Kept passive dashboard refresh presentation-only; it never invokes the automation runner.
- Kept data-recovery protections distinct from Automation pause and non-overridable.
- Added focused model/UI contract tests and responsive theme-aware styling.

## Files changed
- `automation-dashboard.js`
- `automation-dashboard-ui.js`
- `automation-dashboard-render.js`
- `automation-dashboard.css`
- `tests/automation-dashboard.test.js`
- `preload-bridge.cjs`
- `package.json`

## User-facing changes
Users now have a dedicated Automation screen showing whether automation is on or paused, how many rules are enabled, what needs review, configured reminders, recurring patterns and recent activity. They can pause automation globally, pause individual rules, and navigate into the existing safe management surfaces. Re-enabling a rule routes through the existing Test Rule/future-only activation workflow rather than bypassing it.

## Technical changes
The screen derives its model from the existing v2.2.0 automation state/history/review/recurrence/reminder modules. Global pause changes only the authoritative `automation.enabled` state. No duplicate persisted counters or secondary pause state were introduced. Passive rendering does not execute rules.

## Testing and verification
- **Passed — local syntax/static:** `node --check` for the new dashboard modules, focused test and preload bridge; `package.json` parse validation.
- **Passed — local privacy/static scan:** no telemetry, analytics, new network calls or financial-value logging introduced by the dashboard source.
- **Passed — Linux CI:** Git/PR conventions, `npm test`, `npm run check` (including project/privacy checks), `npm run lint`.
- **Passed — Windows CI:** `npm test`, `npm run check` (including project/privacy checks), `npm run lint`.
- **Passed — Windows CI:** built Pages artifact runtime smoke test.
- **Passed — Windows CI:** Electron desktop startup smoke test.
- **Passed — Windows CI:** Windows packaging smoke test.
- **Skipped — release-windows:** expected for this draft/non-release PR; no production release or completed installer is claimed.
- **Unavailable / not performed:** manual human Windows UI walkthrough. Automated Electron startup and Windows packaging smoke coverage passed, but this is not presented as manual testing.

## Data and migration impact
No stored-data migration and no new persisted financial fields. Dashboard counters and summaries are derived from existing authoritative local state. Global pause preserves rules, reminders, history, executions and Review Inbox work.

## Known limitations
- Full Why?/Undo detail remains in the existing local Automation History surface by design rather than being duplicated in the dashboard.
- Automated Electron/Windows smoke coverage does not replace a manual visual interaction review.

## Excluded work
- Automation engine changes
- New rule/recurrence/history business logic
- AI Companion work
- Remote/cloud automation
- Unrelated Dashboard redesign

## Branch details
- Branch: `feature/automation-dashboard-management`
- Commit SHA: `19836ebe348510c428caa6385aa8b272fe34c909`
- Pull request: https://github.com/cntintheslk-OneStepMoney/onestep-money/pull/143
- Target branch: `main`

## Confirmations
- No changes were committed or pushed directly to `main`.
- This workflow has not merged this PR.
- No personal financial data, imported documents, credentials, secrets or sensitive logs were committed.
- Only files relevant to #76 were changed.

Closes #76