### PR TITLE
[v2.3.1][Bug] Paginate full Project Sync reconciliation

### DIFF
--- a/scripts/project-sync.mjs
+++ b/scripts/project-sync.mjs
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { pathToFileURL } from 'node:url';
+import { pathToFileURL, URLSearchParams } from 'node:url';
 
 const canonicalFields = ['Project', 'Priority', 'Complexity', 'Title', 'Status', 'Type', 'Target Release', 'Area', 'Branch', 'Start Date', 'Target Date'];
 const lifecycle = ['Idea', 'Backlog', 'Planned', 'In Progress', 'Review', 'Done'];

--- a/scripts/project-sync.mjs
+++ b/scripts/project-sync.mjs
@@ -90,6 +90,40 @@ export function planUpdates(metadata, fields, current = {}) {
   return updates;
 }
 
+function paginatedPath(path, page, perPage) {
+  const [pathname, query = ''] = path.split('?');
+  const params = new URLSearchParams(query);
+  params.set('per_page', String(perPage));
+  params.set('page', String(page));
+  return `${pathname}?${params.toString()}`;
+}
+
+export async function paginateRest(client, path, options = {}) {
+  const perPage = options.perPage ?? 100;
+  const maxPages = options.maxPages ?? 1000;
+  if (!Number.isInteger(perPage) || perPage < 1 || perPage > 100) throw new Error('pagination perPage must be an integer from 1 to 100');
+  if (!Number.isInteger(maxPages) || maxPages < 1) throw new Error('pagination maxPages must be a positive integer');
+
+  const items = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    const batch = await client.rest(paginatedPath(path, page, perPage));
+    if (!Array.isArray(batch)) throw new Error(`GitHub pagination expected an array for ${path}`);
+    items.push(...batch);
+    if (batch.length < perPage) return items;
+  }
+  throw new Error(`GitHub pagination exceeded ${maxPages} pages for ${path}`);
+}
+
+export async function listRepositoryIssues(client, issueNumber = 0) {
+  if (issueNumber) return [await client.rest(`/issues/${issueNumber}`)];
+  const items = await paginateRest(client, '/issues?state=all');
+  return items.filter(item => !item.pull_request);
+}
+
+export function listRepositoryBranches(client) {
+  return paginateRest(client, '/branches');
+}
+
 class GitHub {
   constructor(token, repository) { this.token = token; [this.owner, this.repo] = repository.split('/'); }
   async request(url, options = {}) {
@@ -125,12 +159,13 @@ async function applyUpdate(client, projectId, itemId, update) {
   await client.graphql(mutation, { project: projectId, item: itemId, field: update.fieldId, value });
 }
 
-async function syncIssue(client, context, adapter, issue, dryRun) {
-  const branches = await client.rest('/branches?per_page=100');
+async function syncIssue(client, context, adapter, issue, dryRun, getBranches) {
   const planned = extract(issue.body, 'Planned branch');
   const pulls = planned ? await client.rest(`/pulls?state=all&per_page=100&head=${encodeURIComponent(`${client.owner}:${planned}`)}`) : [];
   const pr = pulls[0];
-  const branch = planned && (pr || branches.some(entry => entry.name === planned)) ? planned : undefined;
+  let branch;
+  if (planned && pr) branch = planned;
+  else if (planned && (await getBranches()).some(entry => entry.name === planned)) branch = planned;
   const startDate = pr?.created_at?.slice(0, 10) ?? (branch ? issue.created_at?.slice(0, 10) : undefined);
   const metadata = validateIssueMetadata(deriveIssueMetadata(issue, { project: adapter.project.displayName, branch, startDate, reviewReady: Boolean(pr?.draft === false && !pr?.merged_at), merged: Boolean(pr?.merged_at) }), adapter.areas);
   const updates = planUpdates(metadata, context.fields);
@@ -138,6 +173,12 @@ async function syncIssue(client, context, adapter, issue, dryRun) {
   const itemId = await ensureItem(client, context.id, issue.node_id);
   for (const update of updates) await applyUpdate(client, context.id, itemId, update);
   return { issue: issue.number, metadata, updates: updates.map(update => update.name) };
+}
+
+export async function syncIssues(client, context, adapter, issues, getBranches, dryRun = false) {
+  const results = [];
+  for (const issue of issues) results.push(await syncIssue(client, context, adapter, issue, dryRun, getBranches));
+  return results;
 }
 
 async function main() {
@@ -150,9 +191,10 @@ async function main() {
   const errors = validateProjectSchema(context.fields, adapter.areas);
   if (errors.length) throw new Error(errors.join('; '));
   const issueNumber = Number(process.env.DEVOPS_ISSUE_NUMBER || 0);
-  const issues = issueNumber ? [await client.rest(`/issues/${issueNumber}`)] : (await client.rest('/issues?state=all&per_page=100')).filter(item => !item.pull_request);
-  const results = [];
-  for (const issue of issues) results.push(await syncIssue(client, context, adapter, issue, process.argv.includes('--dry-run')));
+  const issues = await listRepositoryIssues(client, issueNumber);
+  let branchesPromise;
+  const getBranches = () => branchesPromise ??= listRepositoryBranches(client);
+  const results = await syncIssues(client, context, adapter, issues, getBranches, process.argv.includes('--dry-run'));
   console.log(JSON.stringify(results, null, 2));
 }
 

--- a/tests/project-sync-pagination.test.js
+++ b/tests/project-sync-pagination.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { listRepositoryBranches, listRepositoryIssues, paginateRest, syncIssues } from '../scripts/project-sync.mjs';
+
+function pagedClient(itemsByPath, calls = []) {
+  return {
+    owner: 'Blackline-Development-DevOps',
+    async rest(path) {
+      calls.push(path);
+      const url = new URL(`https://example.invalid${path}`);
+      const key = url.pathname + (url.searchParams.has('state') ? `?state=${url.searchParams.get('state')}` : '');
+      const all = itemsByPath[key];
+      if (!all) throw new Error(`unexpected REST path: ${path}`);
+      const page = Number(url.searchParams.get('page') || 1);
+      const perPage = Number(url.searchParams.get('per_page') || 100);
+      return all.slice((page - 1) * perPage, page * perPage);
+    }
+  };
+}
+
+function issue(number, extra = {}) {
+  return { number, node_id: `ISSUE_${number}`, title: `[Work][Bug][v2.3.1] Issue ${number}`, body: '', state: 'open', created_at: '2026-08-20T00:00:00Z', ...extra };
+}
+
+test('full issue reconciliation paginates beyond 100 and filters pull requests only after retrieval', async () => {
+  const raw = Array.from({ length: 205 }, (_, index) => issue(index + 1));
+  raw[25] = { ...raw[25], pull_request: { url: 'https://example.invalid/pr/26' } };
+  raw[150] = { ...raw[150], pull_request: { url: 'https://example.invalid/pr/151' } };
+  const calls = [];
+  const issues = await listRepositoryIssues(pagedClient({ '/issues?state=all': raw }, calls));
+
+  assert.equal(issues.length, 203);
+  assert.equal(issues.at(-1).number, 205);
+  assert.deepEqual(calls, [
+    '/issues?state=all&per_page=100&page=1',
+    '/issues?state=all&per_page=100&page=2',
+    '/issues?state=all&per_page=100&page=3'
+  ]);
+  assert.equal(issues.some(item => item.number === 26 || item.number === 151), false);
+});
+
+test('focused single-Issue reconciliation does not fetch the full Issue collection', async () => {
+  const calls = [];
+  const client = {
+    async rest(path) {
+      calls.push(path);
+      if (path === '/issues/174') return issue(174);
+      throw new Error(`unexpected REST path: ${path}`);
+    }
+  };
+
+  const issues = await listRepositoryIssues(client, 174);
+  assert.deepEqual(issues.map(item => item.number), [174]);
+  assert.deepEqual(calls, ['/issues/174']);
+});
+
+test('branch evidence paginates beyond 100 entries', async () => {
+  const branches = Array.from({ length: 145 }, (_, index) => ({ name: `branch-${index + 1}` }));
+  const calls = [];
+  const result = await listRepositoryBranches(pagedClient({ '/branches': branches }, calls));
+
+  assert.equal(result.length, 145);
+  assert.equal(result.at(-1).name, 'branch-145');
+  assert.deepEqual(calls, ['/branches?per_page=100&page=1', '/branches?per_page=100&page=2']);
+});
+
+test('later-page API failure rejects pagination instead of returning partial data', async () => {
+  const client = {
+    async rest(path) {
+      const page = Number(new URL(`https://example.invalid${path}`).searchParams.get('page'));
+      if (page === 1) return Array.from({ length: 100 }, (_, index) => ({ number: index + 1 }));
+      throw new Error('GitHub 502: upstream failure');
+    }
+  };
+
+  await assert.rejects(() => paginateRest(client, '/issues?state=all'), /GitHub 502: upstream failure/);
+});
+
+test('pagination is bounded and fails visibly rather than assuming completeness', async () => {
+  const client = { async rest() { return [{ id: 1 }]; } };
+  await assert.rejects(() => paginateRest(client, '/branches', { perPage: 1, maxPages: 2 }), /exceeded 2 pages/);
+});
+
+test('dry-run reconciliation returns every collected Issue number without forcing branch enumeration', async () => {
+  const issues = Array.from({ length: 105 }, (_, index) => issue(index + 1));
+  const client = { owner: 'Blackline-Development-DevOps', async rest(path) { throw new Error(`unexpected REST path: ${path}`); } };
+  const getBranches = async () => { throw new Error('branch enumeration should remain lazy for branchless Issues'); };
+  const context = { id: 'PROJECT', fields: {} };
+  const adapter = { project: { displayName: 'OneStep Money Development' }, areas: [] };
+
+  const results = await syncIssues(client, context, adapter, issues, getBranches, true);
+  assert.equal(results.length, 105);
+  assert.deepEqual(results.map(result => result.issue), issues.map(item => item.number));
+});


### PR DESCRIPTION
## Purpose
Ensure scheduled/manual Project Sync reconciles the complete repository Issue and branch sets instead of silently stopping at the first GitHub REST page.

## Work completed
- Added bounded REST pagination with `per_page=100` and explicit page traversal.
- Full reconciliation retrieves all Issue pages before filtering pull requests out.
- Focused `DEVOPS_ISSUE_NUMBER` sync remains a single-Issue fetch.
- Branch evidence is paginated beyond 100 entries and loaded lazily only when a planned branch needs branch-list evidence.
- Later-page API failures propagate and fail the sync instead of returning partial data.
- Added dedicated >100-item, mixed-PR, focused-sync, branch, failure, bounded-pagination and dry-run regression coverage.
- Corrected the repository lint environment by explicitly importing `URLSearchParams` from `node:url`; pagination behavior was unchanged.

## Files changed
- `scripts/project-sync.mjs`
- `tests/project-sync-pagination.test.js`

## User-facing changes
No application UI or financial behavior changes. Development Operations full Project reconciliation can now inspect the complete repository instead of only the first REST page.

## Technical changes
`paginateRest` applies deterministic page/per-page query parameters, validates bounds, requires array responses, stops only on a short page, and throws if the configured page bound is exhausted. Issue and branch listing reuse that helper. Branch enumeration is memoized/lazy during reconciliation so branchless and PR-backed Issues do not force an unnecessary full branch fetch.

## Testing and verification
- Focused Project Sync pagination/safety tests: **Passed — 6/6**.
- Full automated suite: **Passed — 570/570**.
- Git/PR conventions: **Passed**.
- PR diff whitespace: **Passed**.
- Project check: **Passed**.
- Privacy check: **Passed — 193 files checked**.
- Lint: **Passed** on the fresh authoritative run after the explicit Node URL helper import.
- Quality benchmark: **Passed**.
- Policy CI: **Passed**.
- Security Gate: **Passed**.
- Dependency audit: **Passed — 0 vulnerabilities**.
- Windows test/check/lint: **Passed**.
- Pages artifact runtime smoke: **Passed**.
- Electron desktop startup smoke: **Passed**.
- Windows NSIS packaging smoke: **Passed**.
- Packaged Windows native pointer/fullscreen smoke: **Passed**.
- Windows release publication: **Skipped as expected** for an untagged PR.
- Live credentialed full Project reconciliation: **Unavailable before integration through the connected tooling**; no workflow-dispatch action is exposed here. The pagination/dry-run path itself is covered by the focused regression suite.

The first CI attempt passed all 570 tests and project/privacy checks but failed lint because `URLSearchParams` was treated as an undefined global. That was fixed in the dedicated second commit; the fresh final CI run is fully green.

## Data and migration impact
No application financial-data migration. A successful full Project Sync may reconcile previously missed Issue/Project metadata; that is intended governance repair.

## Known limitations
No Project field schema or Area allowlist redesign is included. Pull lookup remains a focused head-branch query because #174 concerns full Issue/branch reconciliation pagination.

## Excluded work
- Project field schema changes
- historical Issue rewrites
- branch-model changes
- unrelated GitHub Actions modernization
- production promotion

## 8. Security review
No identified genuine security finding.

## Branch details
- Branch: `fix/project-sync-pagination`
- Commit SHA: `7a3d62105cf2f175e509fb2a66a0bc808b80265f`
- Implementation commit: `3fedf9317497b44827acda56411d720a02206725`
- Corrective lint commit: `7a3d62105cf2f175e509fb2a66a0bc808b80265f`
- Pull request: #176
- Target branch: `development`

## Confirmations
- No changes were committed or pushed directly to `development` or `production`.
- This PR has not been merged by this workflow.
- Production was not touched.
- No personal financial data, imported documents, databases/vaults, credentials, secrets or sensitive logs were committed.
- Only files relevant to #174 were changed.

#174 remains in Review until user-approved merge and completion housekeeping.