### PR TITLE
[v2.3.1][Bug] Correct Money In income reconciliation

### DIFF
--- a/finance-core.js
+++ b/finance-core.js
@@ -6,6 +6,7 @@ import { resolveTransactionBudgetAssignment } from './transaction-categorisation
 export const SCHEMA_VERSION = 9;
 export const ALL_TIME_PERIOD = 'all';
 export const INCOME_PAYMENT_CATEGORY = 'Income';
+const PAYSLIP_RECONCILIATION_WINDOW_DAYS = 3;
 
 export function formatCurrency(value, options = {}) {
   return new Intl.NumberFormat('en-GB', {
@@ -47,13 +48,76 @@ export function periodTransactions(transactions, month) {
     && isTransactionFinanciallyActive(transaction));
 }
 
+export function calculatePeriodIncome(state, month = state.settings?.selectedMonth) {
+  const transactionEvidence = periodTransactions(state.transactions, month)
+    .filter(isExternalCashflowTransaction)
+    .map((transaction, index) => ({
+      transaction,
+      key: `${String(transaction.id || 'transaction')}@${index}`,
+      sourceId: String(transaction.id || `transaction-${index + 1}`),
+      date: financialDateKey(transaction.date),
+      period: reportingMonth(transaction.budgetMonth) || reportingMonth(transaction.date),
+      amountPennies: Math.max(0, moneyToPennies(transaction.incoming))
+    }))
+    .filter((entry) => entry.amountPennies > 0);
+  const entries = transactionEvidence.map((entry) => ({
+    sourceType: 'transaction', sourceId: entry.sourceId, date: entry.date,
+    amount: penniesToMoney(entry.amountPennies)
+  }));
+  const availableTransactionKeys = new Set(transactionEvidence
+    .filter((entry) => isPayslipReconciliationTransaction(entry.transaction))
+    .map((entry) => entry.key));
+  let payslipFallbackPennies = 0;
+  const payslipEvidence = periodPayslips(state.payslips, month)
+    .map((payslip, index) => ({
+      payslip,
+      sourceId: String(payslip.id || `payslip-${index + 1}`),
+      payDate: financialDateKey(payslip.payDate),
+      period: reportingMonth(payslip.period) || reportingMonth(payslip.payDate),
+      amountPennies: Math.max(0, moneyToPennies(payslip.netPay))
+    }))
+    .filter((entry) => entry.payDate && entry.amountPennies > 0)
+    .sort((left, right) => left.payDate.localeCompare(right.payDate) || left.sourceId.localeCompare(right.sourceId));
+
+  for (const payslip of payslipEvidence) {
+    const match = transactionEvidence
+      .filter((entry) => availableTransactionKeys.has(entry.key) && entry.amountPennies === payslip.amountPennies)
+      .filter((entry) => entry.date
+        ? Math.abs(dateDistance(entry.date, payslip.payDate)) <= PAYSLIP_RECONCILIATION_WINDOW_DAYS
+        : Boolean(entry.period && payslip.period && entry.period === payslip.period))
+      .sort((left, right) => {
+        const leftDistance = left.date ? Math.abs(dateDistance(left.date, payslip.payDate)) : Number.POSITIVE_INFINITY;
+        const rightDistance = right.date ? Math.abs(dateDistance(right.date, payslip.payDate)) : Number.POSITIVE_INFINITY;
+        return leftDistance - rightDistance || left.sourceId.localeCompare(right.sourceId);
+      })[0];
+    if (match) {
+      availableTransactionKeys.delete(match.key);
+      continue;
+    }
+    payslipFallbackPennies += payslip.amountPennies;
+    entries.push({
+      sourceType: 'payslip', sourceId: payslip.sourceId, date: payslip.payDate,
+      amount: penniesToMoney(payslip.amountPennies)
+    });
+  }
+
+  const transactionPennies = transactionEvidence.reduce((total, entry) => total + entry.amountPennies, 0);
+  return {
+    total: penniesToMoney(transactionPennies + payslipFallbackPennies),
+    transactionTotal: penniesToMoney(transactionPennies),
+    payslipFallbackTotal: penniesToMoney(payslipFallbackPennies),
+    entries: entries.sort((left, right) => left.date.localeCompare(right.date)
+      || left.sourceType.localeCompare(right.sourceType) || left.sourceId.localeCompare(right.sourceId))
+  };
+}
+
 export function calculatePeriodSummary(state, month = state.settings?.selectedMonth) {
   const monthCount = reportingPeriodMonthCount(state, month);
   const rows = periodTransactions(state.transactions, month);
   const external = rows.filter(isExternalCashflowTransaction);
-  const income = sum(external, 'incoming');
+  const income = calculatePeriodIncome(state, month).total;
   const spending = sum(external, 'outgoing');
-  const payslips = (state.payslips || []).filter((payslip) => month === ALL_TIME_PERIOD || payslip.period === month);
+  const payslips = periodPayslips(state.payslips, month);
   const grossPay = sum(payslips, 'grossPay');
   const payrollDeductions = sum(payslips, 'totalDeductions');
   const netPay = sum(payslips, 'netPay');
@@ -821,6 +885,24 @@ function currentMonth() {
 function reportingMonth(value) {
   const month = String(value || '').slice(0, 7);
   return /^\d{4}-(0[1-9]|1[0-2])$/.test(month) ? month : '';
+}
+
+function periodPayslips(payslips, month) {
+  return (payslips || []).filter((payslip) => month === ALL_TIME_PERIOD
+    || (reportingMonth(payslip.period) || reportingMonth(payslip.payDate)) === month);
+}
+
+function financialDateKey(value) {
+  const text = String(value || '').slice(0, 10);
+  if (!/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(text)) return '';
+  const date = new Date(`${text}T12:00:00Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === text ? text : '';
+}
+
+function isPayslipReconciliationTransaction(transaction) {
+  const treatment = normaliseBudgetTreatment(transaction.budgetTreatment);
+  return !['refund', 'reversal'].includes(treatment)
+    && !transaction.refundOfTransactionId && !transaction.reversalOfTransactionId;
 }
 
 function exactTransactionKey(item) {

--- a/financial-reporting.js
+++ b/financial-reporting.js
@@ -1,6 +1,6 @@
 import {
-  ALL_TIME_PERIOD, availableReportingMonths, calculateBudgetAnalysis, calculatePeriodSummary,
-  formatCurrency, isExternalCashflowTransaction, periodTransactions
+  ALL_TIME_PERIOD, availableReportingMonths, calculateBudgetAnalysis, calculatePeriodIncome, calculatePeriodSummary,
+  formatCurrency, periodTransactions
 } from './finance-core.js';
 import { confirmedRecurringTransactionIds, deriveRecurringPatterns } from './recurring-finance.js';
 import { renderRecurringActivityPanel } from './recurring-finance-ui.js';
@@ -71,10 +71,9 @@ function spendingTimeline(state, period, budget, monthlyTimeline) {
 function incomeTimeline(state, period, monthlyTimeline) {
   if (period === ALL_TIME_PERIOD) return monthlyTimeline.map((row) => ({ label: row.month, amount: row.income, incomplete: row.incomplete }));
   const amounts = new Map();
-  for (const transaction of periodTransactions(state.transactions, period).filter(isExternalCashflowTransaction)) {
-    const date = String(transaction.date || '').slice(0, 10);
-    if (!date || Number(transaction.incoming || 0) <= 0) continue;
-    amounts.set(date, roundMoney((amounts.get(date) || 0) + Number(transaction.incoming || 0)));
+  for (const entry of calculatePeriodIncome(state, period).entries) {
+    if (!entry.date || Number(entry.amount || 0) <= 0) continue;
+    amounts.set(entry.date, roundMoney((amounts.get(entry.date) || 0) + Number(entry.amount || 0)));
   }
   return [...amounts.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([label, amount]) => ({ label, amount, incomplete: false }));
 }

--- a/tests/money-in-aggregation.test.js
+++ b/tests/money-in-aggregation.test.js
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ALL_TIME_PERIOD, calculatePeriodIncome, calculatePeriodSummary } from '../finance-core.js';
+import { buildFinancialReport } from '../financial-reporting.js';
+
+test('Money In counts normal trusted external income for one month', () => {
+  const state = baseState();
+  state.transactions = [transaction({ id: 'salary-credit', date: '2026-08-28', incoming: 2100 })];
+
+  const evidence = calculatePeriodIncome(state, '2026-08');
+  const summary = calculatePeriodSummary(state, '2026-08');
+  assert.equal(evidence.total, 2100);
+  assert.equal(evidence.transactionTotal, 2100);
+  assert.equal(evidence.payslipFallbackTotal, 0);
+  assert.equal(summary.income, 2100);
+});
+
+test('Money In uses a dated payslip as fallback when no corresponding trusted credit exists', () => {
+  const state = baseState();
+  state.payslips = [payslip({ id: 'august-payslip', period: '2026-08', payDate: '2026-08-28', netPay: 2050 })];
+
+  const evidence = calculatePeriodIncome(state, '2026-08');
+  assert.equal(evidence.total, 2050);
+  assert.equal(evidence.transactionTotal, 0);
+  assert.equal(evidence.payslipFallbackTotal, 2050);
+  assert.deepEqual(evidence.entries.map(({ sourceType, date, amount }) => [sourceType, date, amount]), [
+    ['payslip', '2026-08-28', 2050]
+  ]);
+});
+
+test('matching payslip and bank salary evidence are reconciled once, while distinct income remains counted', () => {
+  const state = baseState();
+  state.transactions = [
+    transaction({ id: 'salary-credit', date: '2026-08-29', incoming: 2050 }),
+    transaction({ id: 'fictional-side-income', date: '2026-08-14', incoming: 125.5 })
+  ];
+  state.payslips = [payslip({ id: 'august-payslip', period: '2026-08', payDate: '2026-08-28', netPay: 2050 })];
+
+  const evidence = calculatePeriodIncome(state, '2026-08');
+  assert.equal(evidence.total, 2175.5);
+  assert.equal(evidence.transactionTotal, 2175.5);
+  assert.equal(evidence.payslipFallbackTotal, 0);
+  assert.equal(evidence.entries.filter((entry) => entry.sourceType === 'payslip').length, 0);
+});
+
+test('multiple payslips reconcile one-to-one and preserve a genuinely unmatched second payment', () => {
+  const state = baseState();
+  state.transactions = [transaction({ id: 'salary-one', date: '2026-08-15', incoming: 1000 })];
+  state.payslips = [
+    payslip({ id: 'payslip-one', period: '2026-08', payDate: '2026-08-15', netPay: 1000 }),
+    payslip({ id: 'payslip-two', period: '2026-08', payDate: '2026-08-29', netPay: 1000 })
+  ];
+
+  const evidence = calculatePeriodIncome(state, '2026-08');
+  assert.equal(evidence.total, 2000);
+  assert.equal(evidence.transactionTotal, 1000);
+  assert.equal(evidence.payslipFallbackTotal, 1000);
+  assert.equal(evidence.entries.filter((entry) => entry.sourceType === 'payslip').length, 1);
+});
+
+test('refund cashflow stays Money In but is not mistaken for matching salary evidence', () => {
+  const state = baseState();
+  state.transactions = [transaction({
+    id: 'refund', date: '2026-08-28', incoming: 2050, budgetTreatment: 'refund', refundOfTransactionId: 'fictional-purchase'
+  })];
+  state.payslips = [payslip({ id: 'august-payslip', period: '2026-08', payDate: '2026-08-28', netPay: 2050 })];
+
+  const evidence = calculatePeriodIncome(state, '2026-08');
+  assert.equal(evidence.transactionTotal, 2050);
+  assert.equal(evidence.payslipFallbackTotal, 2050);
+  assert.equal(evidence.total, 4100);
+});
+
+test('Money In preserves transfer and duplicate financial-activity rules', () => {
+  const state = baseState();
+  state.transactions = [
+    transaction({ id: 'normal', date: '2026-08-01', incoming: 500 }),
+    transaction({ id: 'internal', date: '2026-08-02', incoming: 900, transferStatus: 'confirmed' }),
+    transaction({ id: 'exact', date: '2026-08-03', incoming: 700, duplicateStatus: 'exact' }),
+    transaction({ id: 'possible-pending', date: '2026-08-04', incoming: 600, duplicateStatus: 'possible', reviewStatus: 'pending' }),
+    transaction({ id: 'possible-accepted', date: '2026-08-05', incoming: 650, duplicateStatus: 'possible', reviewStatus: 'accepted' })
+  ];
+
+  const evidence = calculatePeriodIncome(state, '2026-08');
+  assert.equal(evidence.total, 1150);
+  assert.deepEqual(evidence.entries.map((entry) => entry.sourceId).sort(), ['normal', 'possible-accepted']);
+});
+
+test('eight-month reporting aggregates the same authoritative Money In rule without multiplying payslips', () => {
+  const state = baseState();
+  const months = Array.from({ length: 8 }, (_, index) => `2026-${String(index + 1).padStart(2, '0')}`);
+  state.payslips = months.map((period, index) => payslip({
+    id: `payslip-${index + 1}`,
+    period,
+    payDate: `${period}-28`,
+    netPay: 2000 + index
+  }));
+  state.transactions = months.slice(0, 4).map((period, index) => transaction({
+    id: `salary-${index + 1}`,
+    date: `${period}-28`,
+    budgetMonth: period,
+    incoming: 2000 + index
+  }));
+
+  const expected = months.reduce((total, _period, index) => total + 2000 + index, 0);
+  const evidence = calculatePeriodIncome(state, ALL_TIME_PERIOD);
+  const summary = calculatePeriodSummary(state, ALL_TIME_PERIOD);
+  assert.equal(evidence.total, expected);
+  assert.equal(summary.income, expected);
+  assert.equal(evidence.entries.length, 8);
+});
+
+test('spending and net cash flow remain reconciled when payslip fallback supplies Money In', () => {
+  const state = baseState();
+  state.transactions = [transaction({ id: 'spend', date: '2026-08-12', outgoing: 125 })];
+  state.payslips = [payslip({ id: 'august-payslip', period: '2026-08', payDate: '2026-08-28', netPay: 2050 })];
+
+  const summary = calculatePeriodSummary(state, '2026-08');
+  assert.equal(summary.income, 2050);
+  assert.equal(summary.spending, 125);
+  assert.equal(summary.netCashFlow, 1925);
+});
+
+test('financial report summary and Money In timeline consume the same authoritative income evidence', () => {
+  const state = baseState();
+  state.transactions = [transaction({ id: 'side-income', date: '2026-08-10', incoming: 100 })];
+  state.payslips = [payslip({ id: 'august-payslip', period: '2026-08', payDate: '2026-08-28', netPay: 2050 })];
+
+  const evidence = calculatePeriodIncome(state, '2026-08');
+  const report = buildFinancialReport(state, '2026-08', new Date('2026-09-10T12:00:00.000Z'));
+  assert.equal(report.summary.income, evidence.total);
+  assert.deepEqual(report.incomeTimeline, [
+    { label: '2026-08-10', amount: 100, incomplete: false },
+    { label: '2026-08-28', amount: 2050, incomplete: false }
+  ]);
+});
+
+test('invalid or undated payslips do not get matched across months or invented into Money In', () => {
+  const state = baseState();
+  state.payslips = [
+    payslip({ id: 'missing-date', period: '2026-08', payDate: '', netPay: 2050 }),
+    payslip({ id: 'invalid-date', period: '2026-08', payDate: '2026-08-99', netPay: 2100 })
+  ];
+  state.transactions = [transaction({ id: 'september-credit', date: '2026-09-01', budgetMonth: '2026-09', incoming: 2050 })];
+
+  assert.equal(calculatePeriodIncome(state, '2026-08').total, 0);
+  assert.equal(calculatePeriodIncome(state, '2026-09').total, 2050);
+});
+
+function baseState() {
+  return {
+    profile: { dependableIncome: 2000 },
+    settings: { selectedMonth: '2026-08', emergencyBufferTarget: 0, emergencyBufferBalance: 0 },
+    accounts: [{ id: 'fictional-current', type: 'current', currentBalance: 1000, active: true }],
+    transactions: [], payslips: [], debts: [], overdrafts: [], budgets: [], tasks: [], reviewItems: [], scheduledPayments: []
+  };
+}
+
+function transaction(overrides = {}) {
+  return {
+    id: 'transaction',
+    accountId: 'fictional-current',
+    date: '2026-08-01',
+    budgetMonth: '2026-08',
+    incoming: 0,
+    outgoing: 0,
+    category: '',
+    budgetTreatment: 'auto',
+    transferStatus: 'no',
+    duplicateStatus: 'none',
+    reviewStatus: 'not_required',
+    importReviewStatus: 'trusted',
+    financiallyActive: true,
+    ...overrides
+  };
+}
+
+function payslip(overrides = {}) {
+  return {
+    id: 'payslip',
+    period: '2026-08',
+    payDate: '2026-08-28',
+    grossPay: 2500,
+    totalDeductions: 450,
+    netPay: 2050,
+    ...overrides
+  };
+}


### PR DESCRIPTION
## Purpose
Correct Money In reporting so trusted external cash remains the primary evidence while a valid unmatched payslip can supply missing salary income without double counting a corresponding bank credit.

## Work completed
- Added one authoritative `calculatePeriodIncome()` path for selected-month and all-time Money In.
- Trusted financially-active external incoming transactions remain primary.
- Payslip net pay is used only as dated unmatched fallback evidence.
- Penny-exact, one-to-one reconciliation prevents a payslip and matching bank credit from being counted twice.
- Reconciliation uses real pay dates with a tight three-day window rather than merchant-description guessing.
- Internal transfers and duplicate/review-state exclusions remain authoritative.
- Refund/reversal cashflow retains its existing Money In treatment but cannot masquerade as salary-match evidence.
- Financial-reporting Money In timelines consume the same authoritative evidence entries as the summary.
- Added fictional regression coverage for single-period, multi-period, duplicate, transfer, refund, reconciliation and consumer-consistency cases.

## Files changed
- `finance-core.js`
- `financial-reporting.js`
- `tests/money-in-aggregation.test.js`

## User-facing changes
Dashboard, Payments, financial reporting and local fallback guidance now use a consistent Money In total. A valid payslip can prevent salary income disappearing when no trusted bank credit is present, while a matching payslip and bank payment are counted only once.

## Technical changes
`calculatePeriodIncome()` returns the authoritative period total plus transaction/payslip-fallback subtotals and dated evidence entries. `calculatePeriodSummary()` consumes that total, and `financial-reporting.js` uses the same entries for the single-period Money In timeline. No renderer-specific income arithmetic was introduced.

Payslip reconciliation is deliberately conservative: positive dated net pay only; penny-exact amount; one-to-one matching; real transaction/pay dates within three days where available; no refund/reversal matching. Invalid or undated payslips are not invented into Money In.

## Testing and verification
- Branch diff audit: **Passed — 3 focused files, 1 convention-compliant commit, 0 behind `development`**.
- Dedicated Money In regression suite: **Passed — 10/10**.
- Full automated suite: **Passed — 580/580**.
- Git/PR conventions: **Passed**.
- PR diff whitespace: **Passed**.
- Project check: **Passed**.
- Privacy check: **Passed — 194 files checked**.
- Lint: **Passed**.
- Quality benchmark: **Passed**.
- Policy CI: **Passed**.
- Security Gate: **Passed**.
- Dependency audit: **Passed — 0 vulnerabilities**.
- Windows tests/check/lint: **Passed — 580/580 tests plus project checks and lint**.
- Pages artifact runtime smoke: **Passed**.
- Electron desktop startup smoke: **Passed**.
- Windows NSIS packaging smoke: **Passed**.
- Packaged Windows native pointer/fullscreen smoke: **Passed**.
- Windows release publication: **Skipped as expected** for an untagged PR.
- Manual packaged Dashboard/Payments one-month + all-time verification: **Unavailable through connected tooling**; automated core/report-consumer coverage passed.

## Data and migration impact
No data migration and no historical financial-record rewrite. Existing transactions and payslips remain unchanged. The corrected Money In value is derived at read/report time through existing financially-active and external-cashflow rules.

## Known limitations
A payslip without a valid pay date is not used as fallback Money In because cross-month inference would be unsafe. Where bank and payslip evidence do not meet the penny/date reconciliation rule, OneStep does not silently merge them.

## Excluded work
- Dashboard redesign
- new income forecasting
- broad payslip parser changes
- categorisation redesign
- unrelated Budget or Financial Safety changes
- production promotion

## 8. Security review
No identified genuine security finding.

## Branch details
- Branch: `fix/money-in-aggregation`
- Commit SHA: `03fd962e36462ff12ce6edb96998c8108cb09683`
- Pull request: #180
- Target branch: `development`

## Confirmations
- No changes were committed or pushed directly to `development` or `production`.
- This PR has not been merged by this workflow.
- Production was not touched.
- No personal financial data, imported documents, databases/vaults, credentials, secrets or sensitive logs were committed.
- Only files relevant to #30 were changed.

#30 is ready for user review and remains in Review until user-approved merge and completion housekeeping.