### PR TITLE
[v2.3.1][Bug] Restore subscription CSV export controls

### DIFF
--- a/subscription-workflow-ui.js
+++ b/subscription-workflow-ui.js
@@ -39,12 +39,7 @@ async function augmentWorkflowControls() {
   if (loaded?.status !== 'normal') return;
   latestState = loaded.state;
 
-  const heading = view.querySelector('.view-heading');
-  if (heading && !view.querySelector('[data-subscription-export]')) {
-    const exportButton = button('Export subscription data', 'secondary-button');
-    exportButton.dataset.subscriptionExport = 'true';
-    heading.append(exportButton);
-  }
+  ensureSubscriptionExportControl(view);
 
   const records = new Map(listSubscriptionRecords(latestState).map((record) => [record.id, record]));
   for (const card of view.querySelectorAll('[data-subscription-id]')) {
@@ -54,6 +49,23 @@ async function augmentWorkflowControls() {
     if (!record || !details) continue;
     details.append(workflowPanel(record));
   }
+}
+
+export function ensureSubscriptionExportControl(view, createControl = createExportControl) {
+  if (!view?.querySelector) return null;
+  const existing = view.querySelector('[data-subscription-export]');
+  if (existing) return existing;
+  const heading = view.querySelector('.subscriptions-heading');
+  if (!heading) return null;
+  const exportButton = createControl();
+  if (!exportButton) return null;
+  exportButton.dataset.subscriptionExport = 'true';
+  heading.append(exportButton);
+  return exportButton;
+}
+
+function createExportControl() {
+  return button('Export subscription data', 'secondary-button');
 }
 
 function workflowPanel(record) {
@@ -141,9 +153,18 @@ async function handleSubmit(event) {
 async function handleClick(event) {
   const exportButton = event.target.closest('[data-subscription-export]');
   if (!exportButton || !window.financeAPI?.exportCsv || !latestState) return;
+  try {
+    await runSubscriptionExport(exportButton, latestState, window.financeAPI.exportCsv);
+  } catch {
+    // Export cancellation/failure is non-destructive; the control is re-enabled by the runner.
+  }
+}
+
+export async function runSubscriptionExport(exportButton, state, exportCsv) {
+  if (!exportButton || !state || typeof exportCsv !== 'function') return null;
   exportButton.disabled = true;
   try {
-    await window.financeAPI.exportCsv(exportSubscriptionsCsv(latestState));
+    return await exportCsv(exportSubscriptionsCsv(state));
   } finally {
     exportButton.disabled = false;
   }

--- a/tests/subscription-export-surface.test.js
+++ b/tests/subscription-export-surface.test.js
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import test from 'node:test';
+import {
+  ensureSubscriptionExportControl,
+  runSubscriptionExport
+} from '../subscription-workflow-ui.js';
+
+function fakeSubscriptionsView() {
+  const heading = {
+    children: [],
+    append(node) { this.children.push(node); }
+  };
+  return {
+    heading,
+    querySelector(selector) {
+      if (selector === '.subscriptions-heading') return heading;
+      if (selector === '[data-subscription-export]') {
+        return heading.children.find((child) => child?.dataset?.subscriptionExport === 'true') || null;
+      }
+      return null;
+    }
+  };
+}
+
+function fakeExportButton() {
+  return { dataset: {}, disabled: false };
+}
+
+test('actual Subscriptions header receives exactly one export control and rerenders restore it', async () => {
+  const subscriptionsUi = await fs.readFile(new URL('../subscriptions-ui.js', import.meta.url), 'utf8');
+  assert.match(subscriptionsUi, /el\('div', 'subscriptions-heading'\)/);
+
+  const firstView = fakeSubscriptionsView();
+  const first = ensureSubscriptionExportControl(firstView, fakeExportButton);
+  const repeated = ensureSubscriptionExportControl(firstView, fakeExportButton);
+  assert.equal(first, repeated);
+  assert.equal(firstView.heading.children.length, 1);
+  assert.equal(first.dataset.subscriptionExport, 'true');
+
+  const rerenderedView = fakeSubscriptionsView();
+  const restored = ensureSubscriptionExportControl(rerenderedView, fakeExportButton);
+  assert.ok(restored);
+  assert.equal(rerenderedView.heading.children.length, 1);
+});
+
+test('subscription export uses the existing CSV path and always re-enables its control', async () => {
+  const state = { scheduledPayments: [], transactions: [], accounts: [] };
+  const snapshot = structuredClone(state);
+  const button = fakeExportButton();
+  let receivedCsv = '';
+
+  const result = await runSubscriptionExport(button, state, async (csv) => {
+    assert.equal(button.disabled, true);
+    receivedCsv = csv;
+    return { cancelled: true };
+  });
+
+  assert.deepEqual(result, { cancelled: true });
+  assert.match(receivedCsv, /"Subscription ID"/);
+  assert.equal(button.disabled, false);
+  assert.deepEqual(state, snapshot);
+
+  await assert.rejects(() => runSubscriptionExport(button, state, async () => {
+    throw new Error('fictional save failure');
+  }), /fictional save failure/);
+  assert.equal(button.disabled, false);
+  assert.deepEqual(state, snapshot);
+});
+
+test('export surface stays local-only and observer-driven across ordinary Subscriptions rerenders', async () => {
+  const ui = await fs.readFile(new URL('../subscription-workflow-ui.js', import.meta.url), 'utf8');
+  assert.match(ui, /querySelector\('\.subscriptions-heading'\)/);
+  assert.match(ui, /MutationObserver\(scheduleAugment\)/);
+  assert.match(ui, /ensureSubscriptionExportControl\(view\)/);
+  assert.match(ui, /window\.financeAPI\.exportCsv/);
+  assert.doesNotMatch(ui, /fetch\(|XMLHttpRequest|WebSocket|sendBeacon|telemetry|analytics/);
+});


### PR DESCRIPTION
## Purpose
Restore reliable access to the existing subscription CSV export from the real v2.3 Subscriptions screen without changing stored financial data or introducing any network/export service.

## Work completed
- Attached the export control to the authoritative `.subscriptions-heading` rendered by `subscriptions-ui.js`.
- Added an idempotent `ensureSubscriptionExportControl()` helper so repeated MutationObserver/rerender cycles do not create duplicate controls.
- Preserved automatic restoration of the control after the Subscriptions view replaces its contents during filtering/editing/rerendering.
- Added `runSubscriptionExport()` to own explicit disable/reenable behaviour around the existing local CSV export bridge.
- Export cancellation/failure is non-destructive and cannot leave the action permanently disabled.
- Preserved the existing `exportSubscriptionsCsv()` path and its CSV formula-neutralisation behavior.
- Added focused regression coverage for real header alignment, duplicate prevention, rerender recovery, existing CSV invocation, cancellation/failure recovery and local-only boundaries.

## Files changed
- `subscription-workflow-ui.js`
- `tests/subscription-export-surface.test.js`

## User-facing changes
`Export subscription data` is reachable from the actual Subscriptions header and is restored after ordinary Subscriptions rerenders. Export remains explicitly user initiated and local-only.

## Technical changes
The workflow augmentor now targets the same `.subscriptions-heading` class used by the primary Subscriptions renderer. Attachment is idempotent through a single helper. Export execution is isolated behind a small runner that always re-enables the triggering control in `finally`, while the click handler deliberately treats save-dialog cancellation/failure as non-destructive.

## Testing and verification
- Branch diff audit: **Passed — 2 focused files, 2 commits, 0 behind `development`**.
- Focused subscription export-surface regressions: **Added; pending CI**.
- Existing CSV formula-injection neutralisation regression: **Retained; pending full CI**.
- Full automated suite: **Pending CI**.
- Git/PR conventions: **Pending CI**.
- PR diff whitespace: **Pending CI**.
- Project check: **Pending CI**.
- Privacy check: **Pending CI**.
- Lint: **Pending CI**.
- Quality benchmark: **Pending CI**.
- Policy CI: **Pending CI**.
- Security Gate: **Pending CI**.
- Dependency audit: **Pending CI**.
- Windows tests/check/lint: **Pending CI**.
- Pages artifact runtime smoke: **Pending CI**.
- Electron desktop startup smoke: **Pending CI**.
- Windows NSIS packaging smoke: **Pending CI**.
- Packaged Windows native pointer/fullscreen smoke: **Pending CI**.
- Manual packaged Subscriptions export walkthrough: **Unavailable through connected tooling**; automated surface/rerender/export coverage is included.

## Data and migration impact
None. No state schema change, data migration, financial-record rewrite or export-format expansion. Existing subscription/export data remains user-owned and is derived through the established CSV implementation.

## Known limitations
Manual packaged click-through of the save dialog is unavailable through connected tooling. The automated coverage verifies surface attachment, rerender resilience, bridge invocation and cancellation/failure recovery.

## Excluded work
- full Subscriptions header redesign
- new export formats
- cloud upload/share/backup
- unrelated data-management settings
- production promotion

## 8. Security review
No identified genuine security finding.

## Branch details
- Branch: `fix/subscription-export-surface`
- Commit SHA: `0c5190d9fc8612a2ee875a26f6dad1a82dd89f8d`
- Pull request: this PR
- Target branch: `development`

## Confirmations
- No changes were committed or pushed directly to `development` or `production`.
- This PR has not been merged by this workflow.
- Production was not touched.
- No personal financial data, imported documents, databases/vaults, credentials, secrets or sensitive logs were committed.
- Only files relevant to #169 were changed.

#169 remains In Progress until verification is fully green, then moves to Review. It is not Done until user-approved merge and completion housekeeping.